### PR TITLE
Add support for string ids for COCO dataset

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -16,14 +16,14 @@ class CocoDataset(CustomDataset):
         self.img_ids = self.coco.getImgIds()
         img_infos = []
         for i in self.img_ids:
-            info = self.coco.loadImgs(i)[0]
+            info = self.coco.loadImgs([i])[0]
             info['filename'] = info['file_name']
             img_infos.append(info)
         return img_infos
 
     def get_ann_info(self, idx):
         img_id = self.img_infos[idx]['id']
-        ann_ids = self.coco.getAnnIds(imgIds=img_id)
+        ann_ids = self.coco.getAnnIds(imgIds=[img_id])
         ann_info = self.coco.loadAnns(ann_ids)
         return self._parse_ann_info(ann_info)
 


### PR DESCRIPTION
The `loadImgs` and `getAnnIds` in `pycocotools` expect a list of ids or single int id. They will treat single string id as list of ids. Always passing a list will work.