### PR TITLE
modify the range of bbox in BboxTransform

### DIFF
--- a/mmdet/datasets/transforms.py
+++ b/mmdet/datasets/transforms.py
@@ -76,8 +76,8 @@ class BboxTransform(object):
         gt_bboxes = bboxes * scale_factor
         if flip:
             gt_bboxes = bbox_flip(gt_bboxes, img_shape)
-        gt_bboxes[:, 0::2] = np.clip(gt_bboxes[:, 0::2], 0, img_shape[1])
-        gt_bboxes[:, 1::2] = np.clip(gt_bboxes[:, 1::2], 0, img_shape[0])
+        gt_bboxes[:, 0::2] = np.clip(gt_bboxes[:, 0::2], 0, img_shape[1] - 1)
+        gt_bboxes[:, 1::2] = np.clip(gt_bboxes[:, 1::2], 0, img_shape[0] - 1)
         if self.max_num_gts is None:
             return gt_bboxes
         else:


### PR DESCRIPTION
In the original [BboxTransform](https://github.com/open-mmlab/mmdetection/blob/70383d4633fc8b30c5286f6833a267bcaf71808c/mmdet/datasets/transforms.py#L79), the bbox is clipped to `[0, w]` and `[0, h]` instead of `[0, w-1]` and `[0, h-1]`. if the ground truth bbox is annotated incorrectly with `w` and `h` in the coordinates which I occur in a text detection dataset, there is the case that the generated proposal is on the border of image with `x=w` or `y=h`, this can cause error when get target mask in [this line](https://github.com/open-mmlab/mmdetection/blob/70383d4633fc8b30c5286f6833a267bcaf71808c/mmdet/core/mask/mask_target.py#L29) for Mask RCNN。 