### PR TITLE
allow specifying multi-scale random mode

### DIFF
--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -40,6 +40,7 @@ class CustomDataset(Dataset):
                  img_prefix,
                  img_scale,
                  img_norm_cfg,
+                 multiscale_mode='value',
                  size_divisor=None,
                  proposal_file=None,
                  num_max_proposals=1000,
@@ -72,6 +73,10 @@ class CustomDataset(Dataset):
         assert mmcv.is_list_of(self.img_scales, tuple)
         # normalization configs
         self.img_norm_cfg = img_norm_cfg
+
+        # multi-scale mode (only applicable for multi-scale training)
+        self.multiscale_mode = multiscale_mode
+        assert multiscale_mode in ['value', 'range']
 
         # max proposals per image
         self.num_max_proposals = num_max_proposals
@@ -196,7 +201,8 @@ class CustomDataset(Dataset):
 
         # apply transforms
         flip = True if np.random.rand() < self.flip_ratio else False
-        img_scale = random_scale(self.img_scales)  # sample a scale
+        # randomly sample a scale
+        img_scale = random_scale(self.img_scales, self.multiscale_mode)
         img, img_shape, pad_shape, scale_factor = self.img_transform(
             img, img_scale, flip, keep_ratio=self.resize_keep_ratio)
         img = img.copy()


### PR DESCRIPTION
- `value`: randomly select a scale from [a, b, ...]
- `range`: randomly generate a scale between [a, b]