### PR TITLE
Added mask visualization part to inference part and add out_file interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ cfg.model.pretrained = None
 model = build_detector(cfg.model, test_cfg=cfg.test_cfg)
 _ = load_checkpoint(model, 'https://s3.ap-northeast-2.amazonaws.com/open-mmlab/mmdetection/models/faster_rcnn_r50_fpn_1x_20181010-3d1b3351.pth')
 
+# if your model contains mask branch.
+# then results[0] is bboxex, result[1] is mask segms
+# you should use result[0] instead of result to visualize bbox
+# mask visualization is in process.
+
 # test a single image
 img = mmcv.imread('test.jpg')
 result = inference_detector(model, img, cfg)
@@ -162,9 +167,7 @@ show_result(img, result)
 imgs = ['test1.jpg', 'test2.jpg']
 for i, result in enumerate(inference_detector(model, imgs, cfg, device='cuda:0')):
     print(i, imgs[i])
-    # bbox:result[0]
-    # segms:result[1]
-    show_result(imgs[i], result[0])
+    show_result(imgs[i], result)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,6 @@ cfg.model.pretrained = None
 model = build_detector(cfg.model, test_cfg=cfg.test_cfg)
 _ = load_checkpoint(model, 'https://s3.ap-northeast-2.amazonaws.com/open-mmlab/mmdetection/models/faster_rcnn_r50_fpn_1x_20181010-3d1b3351.pth')
 
-# if your model contains mask branch.
-# then results[0] is bboxex, result[1] is mask segms
-# you should use result[0] instead of result to visualize bbox
-# mask visualization is in process.
-
 # test a single image
 img = mmcv.imread('test.jpg')
 result = inference_detector(model, img, cfg)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -51,7 +51,7 @@ def inference_detector(model, imgs, cfg, device='cuda:0'):
         return _inference_generator(model, imgs, img_transform, cfg, device)
 
 
-def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
+def show_result(img, result, dataset='coco', score_thr=0.3, out_file=None):
     img = mmcv.imread(img)
     class_names = get_classes(dataset)
     if isinstance(result, tuple):
@@ -80,5 +80,4 @@ def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
         labels,
         class_names=class_names,
         score_thr=score_thr,
-        show=False,
-        out_file=outfile)
+        show=out_file is None)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -1,10 +1,11 @@
 import mmcv
 import numpy as np
+import pycocotools.mask as maskUtils
 import torch
 
+from mmdet.core import get_classes
 from mmdet.datasets import to_tensor
 from mmdet.datasets.transforms import ImageTransform
-from mmdet.core import get_classes
 
 
 def _prepare_data(img, img_transform, cfg, device):
@@ -50,18 +51,34 @@ def inference_detector(model, imgs, cfg, device='cuda:0'):
         return _inference_generator(model, imgs, img_transform, cfg, device)
 
 
-def show_result(img, result, dataset='coco', score_thr=0.3):
-    class_names = get_classes(dataset)
-    labels = [
-        np.full(len(bbox), i, dtype=np.int32)
-        for i, bbox in enumerate(result)
-    ]
-    labels = np.concatenate(labels)
-    bboxes = np.vstack(result)
-    img = mmcv.imread(img)
-    mmcv.imshow_det_bboxes(
-        img.copy(),
-        bboxes,
-        labels,
-        class_names=class_names,
-        score_thr=score_thr)
+def show_result(img, result, dataset = 'coco', score_thr = 0.3, outfile = None):
+	im = mmcv.imread(img)
+	class_names = get_classes(dataset)
+	if isinstance(result, tuple):
+		bbox_result, segm_result = result
+	else:
+		bbox_result, segm_result = result, None
+	bboxes = np.vstack(bbox_result)
+	# draw segmentation masks
+	if segm_result is not None:
+		segms = mmcv.concat_list(segm_result)
+		inds = np.where(bboxes[:, -1] > score_thr)[0]
+		for i in inds:
+			color_mask = np.random.randint(
+				0, 256, (1, 3), dtype = np.uint8)
+			mask = maskUtils.decode(segms[i]).astype(np.bool)
+			im[mask] = im[mask] * 0.5 + color_mask * 0.5
+	# draw bounding boxes
+	labels = [
+		np.full(bbox.shape[0], i, dtype = np.int32)
+		for i, bbox in enumerate(bbox_result)
+	]
+	labels = np.concatenate(labels)
+	mmcv.imshow_det_bboxes(
+		im,
+		bboxes,
+		labels,
+		class_names = class_names,
+		score_thr = score_thr,
+		show = False,
+		out_file = outfile)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -58,6 +58,7 @@ def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
         bbox_result, segm_result = result
     else:
         bbox_result, segm_result = result, None
+    bboxes = np.vstack(bbox_result)
     # draw segmentation masks
     if segm_result is not None:
         segms = mmcv.concat_list(segm_result)
@@ -68,10 +69,9 @@ def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
             mask = maskUtils.decode(segms[i]).astype(np.bool)
             img[mask] = img[mask] * 0.5 + color_mask * 0.5
     # draw bounding boxes
-    bboxes = np.vstack(bbox_result)
     labels = [
         np.full(bbox.shape[0], i, dtype=np.int32)
-        for i, bbox in enumerate(result)
+        for i, bbox in enumerate(bbox_result)
     ]
     labels = np.concatenate(labels)
     mmcv.imshow_det_bboxes(
@@ -79,4 +79,6 @@ def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
         bboxes,
         labels,
         class_names=class_names,
-        score_thr=score_thr)
+        score_thr=score_thr,
+        show=False,
+        out_file=outfile)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -53,7 +53,7 @@ def inference_detector(model, imgs, cfg, device='cuda:0'):
 def show_result(img, result, dataset='coco', score_thr=0.3):
     class_names = get_classes(dataset)
     labels = [
-        np.full(bbox.shape[0], i, dtype=np.int32)
+        np.full(len(bbox), i, dtype=np.int32)
         for i, bbox in enumerate(result)
     ]
     labels = np.concatenate(labels)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -51,34 +51,32 @@ def inference_detector(model, imgs, cfg, device='cuda:0'):
         return _inference_generator(model, imgs, img_transform, cfg, device)
 
 
-def show_result(img, result, dataset = 'coco', score_thr = 0.3, outfile = None):
-	im = mmcv.imread(img)
-	class_names = get_classes(dataset)
-	if isinstance(result, tuple):
-		bbox_result, segm_result = result
-	else:
-		bbox_result, segm_result = result, None
-	bboxes = np.vstack(bbox_result)
-	# draw segmentation masks
-	if segm_result is not None:
-		segms = mmcv.concat_list(segm_result)
-		inds = np.where(bboxes[:, -1] > score_thr)[0]
-		for i in inds:
-			color_mask = np.random.randint(
-				0, 256, (1, 3), dtype = np.uint8)
-			mask = maskUtils.decode(segms[i]).astype(np.bool)
-			im[mask] = im[mask] * 0.5 + color_mask * 0.5
-	# draw bounding boxes
-	labels = [
-		np.full(bbox.shape[0], i, dtype = np.int32)
-		for i, bbox in enumerate(bbox_result)
-	]
-	labels = np.concatenate(labels)
-	mmcv.imshow_det_bboxes(
-		im,
-		bboxes,
-		labels,
-		class_names = class_names,
-		score_thr = score_thr,
-		show = False,
-		out_file = outfile)
+def show_result(img, result, dataset='coco', score_thr=0.3, outfile=None):
+    img = mmcv.imread(img)
+    class_names = get_classes(dataset)
+    if isinstance(result, tuple):
+        bbox_result, segm_result = result
+    else:
+        bbox_result, segm_result = result, None
+    # draw segmentation masks
+    if segm_result is not None:
+        segms = mmcv.concat_list(segm_result)
+        inds = np.where(bboxes[:, -1] > score_thr)[0]
+        for i in inds:
+            color_mask = np.random.randint(
+                0, 256, (1, 3), dtype=np.uint8)
+            mask = maskUtils.decode(segms[i]).astype(np.bool)
+            img[mask] = img[mask] * 0.5 + color_mask * 0.5
+    # draw bounding boxes
+    bboxes = np.vstack(bbox_result)
+    labels = [
+        np.full(bbox.shape[0], i, dtype=np.int32)
+        for i, bbox in enumerate(result)
+    ]
+    labels = np.concatenate(labels)
+    mmcv.imshow_det_bboxes(
+        img.copy(),
+        bboxes,
+        labels,
+        class_names=class_names,
+        score_thr=score_thr)


### PR DESCRIPTION
I find it's the best way to modify `mmdet/apis/inference.py`, to add the existing mask visualization part into it. Also, since I am using remote servers to run my model, I think most of us do in this way, so I set the `show = False` and add an interface `out_file`.
I'm not sure if it's appropriate to directly pull a request, and sorry to post two boring issues to talk about these. Or maybe you can adopt these changes by next time commit.