### PR TITLE
Bug fix for backward compatibility of parameter order

### DIFF
--- a/mmdet/models/backbones/resnet.py
+++ b/mmdet/models/backbones/resnet.py
@@ -108,7 +108,6 @@ class Bottleneck(nn.Module):
         self.planes = planes
         self.stride = stride
         self.dilation = dilation
-        self.downsample = downsample
         self.style = style
         self.with_cp = with_cp
         self.conv_cfg = conv_cfg
@@ -185,6 +184,7 @@ class Bottleneck(nn.Module):
         self.add_module(self.norm3_name, norm3)
 
         self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
 
     @property
     def norm1(self):


### PR DESCRIPTION
With the latest code, resuming from a checkpoint trained before #637 (yesterday) will leads to a shape mismatch because the order of parameters are changed. I just change it back for backward compatibility.