### PR TITLE
Add MobileNetV2 SSD-Lite

### DIFF
--- a/configs/ssd300_mobilenetv2_coco.py
+++ b/configs/ssd300_mobilenetv2_coco.py
@@ -5,7 +5,8 @@ model = dict(
     pretrained='./snapshots/mobilenet_v2.pth.tar',
     backbone=dict(
         type='SSDMobilenetV2',
-        input_size=input_size
+        input_size=input_size,
+        activation_type='relu6'
         ),
     neck=None,
     bbox_head=dict(
@@ -14,7 +15,7 @@ model = dict(
         in_channels=(576, 1280, 512, 256, 256, 128),
         num_classes=81,
         anchor_strides=(16, 30, 60, 100, 150, 300),
-        basesize_ratio_range=(0.15, 0.9),
+        basesize_ratio_range=(0.2, 0.95),
         anchor_ratios=([2], [2, 3], [2, 3], [2, 3], [2], [2]),
         target_means=(.0, .0, .0, .0),
         target_stds=(0.1, 0.1, 0.2, 0.2),
@@ -122,7 +123,7 @@ log_config = dict(
 total_epochs = 24
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
-work_dir = './work_dirs/ssd300_coco'
+work_dir = './work_dirs/ssd300_mobilenet_v2_coco'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]

--- a/configs/ssd300_mobilenetv2_coco.py
+++ b/configs/ssd300_mobilenetv2_coco.py
@@ -1,0 +1,128 @@
+# model settings
+input_size = 300
+model = dict(
+    type='SingleStageDetector',
+    pretrained='./snapshots/mobilenet_v2.pth.tar',
+    backbone=dict(
+        type='SSDMobilenetV2',
+        input_size=input_size
+        ),
+    neck=None,
+    bbox_head=dict(
+        type='SSDHead',
+        input_size=input_size,
+        in_channels=(576, 1280, 512, 256, 256, 128),
+        num_classes=81,
+        anchor_strides=(16, 30, 60, 100, 150, 300),
+        basesize_ratio_range=(0.15, 0.9),
+        anchor_ratios=([2], [2, 3], [2, 3], [2, 3], [2], [2]),
+        target_means=(.0, .0, .0, .0),
+        target_stds=(0.1, 0.1, 0.2, 0.2),
+        depthwise_heads=True)
+        )
+cudnn_benchmark = True
+train_cfg = dict(
+    assigner=dict(
+        type='MaxIoUAssigner',
+        pos_iou_thr=0.5,
+        neg_iou_thr=0.5,
+        min_pos_iou=0.,
+        ignore_iof_thr=-1,
+        gt_max_assign_all=False),
+    smoothl1_beta=1.,
+    allowed_border=-1,
+    pos_weight=-1,
+    neg_pos_ratio=3,
+    debug=False)
+test_cfg = dict(
+    nms=dict(type='nms', iou_thr=0.45),
+    min_bbox_size=0,
+    score_thr=0.02,
+    max_per_img=200)
+# model training and testing settings
+# dataset settings
+dataset_type = 'CocoDataset'
+data_root = 'data/MS_COCO/'
+img_norm_cfg = dict(mean=[0, 0, 0], std=[255, 255, 255], to_rgb=True)
+data = dict(
+    imgs_per_gpu=50,
+    workers_per_gpu=3,
+    train=dict(
+        type='RepeatDataset',
+        times=5,
+        dataset=dict(
+            type=dataset_type,
+            ann_file=data_root + 'annotations/instances_train2017.json',
+            img_prefix=data_root + 'train2017/',
+            img_scale=(300, 300),
+            img_norm_cfg=img_norm_cfg,
+            size_divisor=None,
+            flip_ratio=0.5,
+            with_mask=False,
+            with_crowd=False,
+            with_label=True,
+            test_mode=False,
+            extra_aug=dict(
+                photo_metric_distortion=dict(
+                    brightness_delta=32,
+                    contrast_range=(0.5, 1.5),
+                    saturation_range=(0.5, 1.5),
+                    hue_delta=18),
+                expand=dict(
+                    mean=img_norm_cfg['mean'],
+                    to_rgb=img_norm_cfg['to_rgb'],
+                    ratio_range=(1, 4)),
+                random_crop=dict(
+                    min_ious=(0.1, 0.3, 0.5, 0.7, 0.9), min_crop_size=0.3)),
+            resize_keep_ratio=False)),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        img_prefix=data_root + 'val2017/',
+        img_scale=(300, 300),
+        img_norm_cfg=img_norm_cfg,
+        size_divisor=None,
+        flip_ratio=0,
+        with_mask=False,
+        with_label=False,
+        test_mode=True,
+        resize_keep_ratio=False),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/image_info_test-dev2017.json',
+        img_prefix=data_root + 'test2017/',
+        img_scale=(300, 300),
+        img_norm_cfg=img_norm_cfg,
+        size_divisor=None,
+        flip_ratio=0,
+        with_mask=False,
+        with_label=False,
+        test_mode=True,
+        resize_keep_ratio=False))
+# optimizer
+optimizer = dict(type='SGD', lr=2e-2, momentum=0.9, weight_decay=5e-4)
+optimizer_config = dict()
+# learning policy
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=1.0 / 3,
+    step=[16, 22])
+checkpoint_config = dict(interval=1)
+# yapf:disable
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        dict(type='TensorboardLoggerHook')
+    ])
+# yapf:enable
+# runtime settings
+total_epochs = 24
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+work_dir = './work_dirs/ssd300_coco'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]

--- a/configs/ssd300_mobilenetv2_coco.py
+++ b/configs/ssd300_mobilenetv2_coco.py
@@ -43,14 +43,14 @@ test_cfg = dict(
 # model training and testing settings
 # dataset settings
 dataset_type = 'CocoDataset'
-data_root = 'data/MS_COCO/'
+data_root = 'data/coco/'
 img_norm_cfg = dict(mean=[0, 0, 0], std=[255, 255, 255], to_rgb=True)
 data = dict(
-    imgs_per_gpu=50,
+    imgs_per_gpu=70,
     workers_per_gpu=3,
     train=dict(
         type='RepeatDataset',
-        times=5,
+        times=1,
         dataset=dict(
             type=dataset_type,
             ann_file=data_root + 'annotations/instances_train2017.json',
@@ -101,14 +101,14 @@ data = dict(
         test_mode=True,
         resize_keep_ratio=False))
 # optimizer
-optimizer = dict(type='SGD', lr=2e-2, momentum=0.9, weight_decay=5e-4)
-optimizer_config = dict()
+optimizer = dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=5e-4)
+optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
 # learning policy
 lr_config = dict(
     policy='step',
     warmup='linear',
     warmup_iters=500,
-    warmup_ratio=1.0 / 3,
+    warmup_ratio=1.0 / 10,
     step=[16, 22])
 checkpoint_config = dict(interval=1)
 # yapf:disable
@@ -120,7 +120,7 @@ log_config = dict(
     ])
 # yapf:enable
 # runtime settings
-total_epochs = 24
+total_epochs = 25
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/ssd300_mobilenet_v2_coco'

--- a/configs/wider_face/README.md
+++ b/configs/wider_face/README.md
@@ -28,5 +28,15 @@ mmdetection
 
 ```
 
-After that you can train the SSD300 on WIDER by launching training with the `ssd300_wider_face.py` config or
-create your own config based on the presented one.
+After that you can train the SSD300 on WIDER Face by launching training with the `ssd300_wider_face.py` or `mobilenetv2_tiny_ssd300_wider_face.py` configs or create your own config based on the presented one.
+
+## Baseline Models
+
+To download pre-trained MobileNetV2 backbone visit this [page](https://github.com/tonylins/pytorch-mobilenet-v2).
+
+| Model  | Width factor  | Complexity (GMACS) | Parameters (M) | AP* (all faces) | AP* (faces > 30 pix)| AP* (faces > 60 pix) | AP* (faces > 100 pix)| Download |
+|:---------:|:-------:|:-------:|:--------:|:-------------------:|:--------------:|
+| MobileNetV2-SSD-Lite-SingleHead  | 0.75 |   0.51    | 1.03      | 0.305 | 0.768 | 0.867 | 0.927 | [model](https://drive.google.com/file/d/1jRi0hxxzIlfgEEoKHS_SkOD529y3kKNb/view?usp=sharing) |
+| MobileNetV2-SSD-Lite-SingleHead  | 1.0  |   0.87    | 1.79      | 0.319 | 0.790 | 0.885 | 0.935 | [model](https://drive.google.com/file/d/1jjQBkLsNxfNR29UsJ2aeq1Ir4oZTuKEl/view?usp=sharing) |
+| VGG16-SSD  | 1.0  |   30.49    | 23.75      | 0.337 | 0.841 | 0.920 | 0.941 | [model](https://drive.google.com/file/d/1tBSPmUQwJZTAVfuxRlvDNkJVm2ww1gMk/view?usp=sharing) |
+*VOC AP on WIDER val with filtered faces by size threshold

--- a/configs/wider_face/mobilenetv2_tiny_ssd300_wider_face.py
+++ b/configs/wider_face/mobilenetv2_tiny_ssd300_wider_face.py
@@ -1,0 +1,142 @@
+# model settings
+input_size = 300
+width_mult = 0.75
+model = dict(
+    type='SingleStageDetector',
+    # The initial imagenet snapshot can be found in
+    # https://github.com/tonylins/pytorch-mobilenet-v2
+    pretrained='snapshots/mobilenet_v2.pth.tar',
+    backbone=dict(
+        type='SSDMobilenetV2',
+        input_size=input_size,
+        width_mult=width_mult,
+        activation_type='relu',
+        single_scale=True
+        ),
+    neck=None,
+    bbox_head=dict(
+        type='SSDHead',
+        input_size=input_size,
+        in_channels=(int(width_mult*480),),
+        num_classes=2,
+        anchor_strides=(16,),
+        anchor_widths=([9.4, 25.1, 14.7, 34.7, 143.0,
+                        77.4, 128.8, 51.1, 75.6],),
+        anchor_heights=([15.0, 39.6, 25.5, 63.2, 227.5,
+                         162.9, 124.5, 105.1, 72.6],),
+        target_means=(.0, .0, .0, .0),
+        target_stds=(0.1, 0.1, 0.2, 0.2),
+        loss_balancing=True,
+        depthwise_heads=True))
+cudnn_benchmark = True
+train_cfg = dict(
+    assigner=dict(
+        type='MaxIoUAssigner',
+        pos_iou_thr=0.4,
+        neg_iou_thr=0.4,
+        min_pos_iou=0.,
+        ignore_iof_thr=-1,
+        gt_max_assign_all=False),
+    smoothl1_beta=1.,
+    use_giou=False,
+    use_focal=False,
+    allowed_border=-1,
+    pos_weight=-1,
+    neg_pos_ratio=3,
+    debug=False)
+test_cfg = dict(
+    nms=dict(type='nms', iou_thr=0.45),
+    min_bbox_size=0,
+    score_thr=0.02,
+    max_per_img=200)
+# model training and testing settings
+# dataset settings
+dataset_type = 'WIDERFaceDataset'
+data_root = 'data/WIDERFace/'
+img_norm_cfg = dict(mean=[0, 0, 0], std=[255, 255, 255], to_rgb=True)
+data = dict(
+    imgs_per_gpu=65,
+    workers_per_gpu=2,
+    train=dict(
+        type='RepeatDataset',
+        times=2,
+        dataset=dict(
+            type=dataset_type,
+            ann_file=[
+                data_root + 'train.txt',
+            ],
+            min_size=17,
+            img_prefix=[data_root + 'WIDER_train/'],
+            img_scale=(input_size, input_size),
+            img_norm_cfg=img_norm_cfg,
+            size_divisor=None,
+            flip_ratio=0.5,
+            with_mask=False,
+            with_crowd=False,
+            with_label=True,
+            test_mode=False,
+            extra_aug=dict(
+                photo_metric_distortion=dict(
+                    brightness_delta=32,
+                    contrast_range=(0.5, 1.5),
+                    saturation_range=(0.5, 1.5),
+                    hue_delta=18),
+                expand=dict(
+                    mean=img_norm_cfg['mean'],
+                    to_rgb=img_norm_cfg['to_rgb'],
+                    ratio_range=(1, 2),
+                    prob=0.0),
+                random_crop=dict(
+                    min_ious=(0.1, 0.3, 0.5, 0.7, 0.9), min_crop_size=0.1)),
+            resize_keep_ratio=False)),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + '/val.txt',
+        img_prefix=data_root + 'WIDER_val/',
+        img_scale=(input_size, input_size),
+        img_norm_cfg=img_norm_cfg,
+        size_divisor=None,
+        flip_ratio=0,
+        with_mask=False,
+        with_label=False,
+        test_mode=True,
+        resize_keep_ratio=False),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + '/val.txt',
+        img_prefix=data_root + 'WIDER_val/',
+        img_scale=(input_size, input_size),
+        img_norm_cfg=img_norm_cfg,
+        size_divisor=None,
+        flip_ratio=0,
+        with_mask=False,
+        with_label=False,
+        test_mode=True,
+        resize_keep_ratio=False))
+# optimizer
+optimizer = dict(type='SGD', lr=0.5*1e-1, momentum=0.9, weight_decay=5e-4)
+optimizer_config = dict()
+# learning policy
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=1200,
+    warmup_ratio=1.0 / 3,
+    step=[40, 55, 65])
+checkpoint_config = dict(interval=1)
+# yapf:disable
+log_config = dict(
+    interval=1,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        dict(type='TensorboardLoggerHook')
+    ])
+# yapf:enable
+# runtime settings
+total_epochs = 70
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+work_dir = './work_dirs/ssd300_mobilenet_'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -3,11 +3,20 @@ import torch
 
 class AnchorGenerator(object):
 
-    def __init__(self, base_size, scales, ratios, scale_major=True, ctr=None):
+    def __init__(self, base_size, scales, ratios, scale_major=True, ctr=None,
+                 widths=None, heights=None):
         self.base_size = base_size
-        self.scales = torch.Tensor(scales)
-        self.ratios = torch.Tensor(ratios)
-        self.scale_major = scale_major
+        if widths is not None and heights is not None:
+            self.manual_anchors = True
+            assert len(heights) == len(widths)
+            self.heights = torch.Tensor(heights)
+            self.widths = torch.Tensor(widths)
+        else:
+            self.manual_anchors = False
+            self.scales = torch.Tensor(scales)
+            self.ratios = torch.Tensor(ratios)
+            self.scale_major = scale_major
+
         self.ctr = ctr
         self.base_anchors = self.gen_base_anchors()
 
@@ -24,14 +33,18 @@ class AnchorGenerator(object):
         else:
             x_ctr, y_ctr = self.ctr
 
-        h_ratios = torch.sqrt(self.ratios)
-        w_ratios = 1 / h_ratios
-        if self.scale_major:
-            ws = (w * w_ratios[:, None] * self.scales[None, :]).view(-1)
-            hs = (h * h_ratios[:, None] * self.scales[None, :]).view(-1)
+        if self.manual_anchors:
+            ws = self.widths
+            hs = self.heights
         else:
-            ws = (w * self.scales[:, None] * w_ratios[None, :]).view(-1)
-            hs = (h * self.scales[:, None] * h_ratios[None, :]).view(-1)
+            h_ratios = torch.sqrt(self.ratios)
+            w_ratios = 1 / h_ratios
+            if self.scale_major:
+                ws = (w * w_ratios[:, None] * self.scales[None, :]).view(-1)
+                hs = (h * h_ratios[:, None] * self.scales[None, :]).view(-1)
+            else:
+                ws = (w * self.scales[:, None] * w_ratios[None, :]).view(-1)
+                hs = (h * self.scales[:, None] * h_ratios[None, :]).view(-1)
 
         base_anchors = torch.stack(
             [

--- a/mmdet/datasets/extra_aug.py
+++ b/mmdet/datasets/extra_aug.py
@@ -66,15 +66,17 @@ class PhotoMetricDistortion(object):
 
 class Expand(object):
 
-    def __init__(self, mean=(0, 0, 0), to_rgb=True, ratio_range=(1, 4)):
+    def __init__(self, mean=(0, 0, 0), to_rgb=True,
+                 ratio_range=(1, 4), prob=0.5):
         if to_rgb:
             self.mean = mean[::-1]
         else:
             self.mean = mean
         self.min_ratio, self.max_ratio = ratio_range
+        self.prob = prob
 
     def __call__(self, img, boxes, labels):
-        if random.randint(2):
+        if random.uniform(0, 1) > self.prob:
             return img, boxes, labels
 
         h, w, c = img.shape

--- a/mmdet/models/anchor_heads/ssd_head.py
+++ b/mmdet/models/anchor_heads/ssd_head.py
@@ -243,4 +243,4 @@ class SSDHead(AnchorHead):
         loss_reg = torch.exp(-self.loss_weights[1])*loss_reg + \
             0.5*self.loss_weights[1]
 
-        return (losses_cls, losses_reg)
+        return (loss_cls, loss_reg)

--- a/mmdet/models/anchor_heads/ssd_head.py
+++ b/mmdet/models/anchor_heads/ssd_head.py
@@ -21,78 +21,115 @@ class SSDHead(AnchorHead):
                  anchor_strides=(8, 16, 32, 64, 100, 300),
                  basesize_ratio_range=(0.1, 0.9),
                  anchor_ratios=([2], [2, 3], [2, 3], [2, 3], [2], [2]),
+                 anchor_heights=[],
+                 anchor_widths=[],
                  target_means=(.0, .0, .0, .0),
-                 target_stds=(1.0, 1.0, 1.0, 1.0)):
+                 target_stds=(1.0, 1.0, 1.0, 1.0),
+                 loss_balancing=False,
+                 depthwise_heads=False):
         super(AnchorHead, self).__init__()
         self.input_size = input_size
         self.num_classes = num_classes
         self.in_channels = in_channels
         self.cls_out_channels = num_classes
-        num_anchors = [len(ratios) * 2 + 2 for ratios in anchor_ratios]
+        if len(anchor_heights):
+            assert len(anchor_heights) == len(anchor_widths)
+            num_anchors = [len(anc_conf) for anc_conf in anchor_heights]
+        else:
+            num_anchors = [len(ratios) * 2 + 2 for ratios in anchor_ratios]
         reg_convs = []
         cls_convs = []
         for i in range(len(in_channels)):
-            reg_convs.append(
-                nn.Conv2d(
+            if depthwise_heads:
+                reg_conv = nn.Sequential(
+                    nn.Conv2d(in_channels[i], in_channels[i],
+                              kernel_size=3, padding=1, groups=in_channels[i]),
+                    nn.BatchNorm2d(in_channels[i]),
+                    nn.ReLU(inplace=True),
+                    nn.Conv2d(in_channels[i], num_anchors[i] * 4,
+                              kernel_size=1, padding=0))
+                cls_conv = nn.Sequential(
+                    nn.Conv2d(in_channels[i], in_channels[i],
+                              kernel_size=3, padding=1, groups=in_channels[i]),
+                    nn.BatchNorm2d(in_channels[i]),
+                    nn.ReLU(inplace=True),
+                    nn.Conv2d(in_channels[i], num_anchors[i] * num_classes,
+                              kernel_size=1, padding=0))
+            else:
+                reg_conv = nn.Conv2d(
                     in_channels[i],
                     num_anchors[i] * 4,
                     kernel_size=3,
-                    padding=1))
-            cls_convs.append(
-                nn.Conv2d(
+                    padding=1)
+                cls_conv = nn.Conv2d(
                     in_channels[i],
                     num_anchors[i] * num_classes,
                     kernel_size=3,
-                    padding=1))
+                    padding=1)
+            reg_convs.append(reg_conv)
+            cls_convs.append(cls_conv)
         self.reg_convs = nn.ModuleList(reg_convs)
         self.cls_convs = nn.ModuleList(cls_convs)
 
-        min_ratio, max_ratio = basesize_ratio_range
-        min_ratio = int(min_ratio * 100)
-        max_ratio = int(max_ratio * 100)
-        step = int(np.floor(max_ratio - min_ratio) / (len(in_channels) - 2))
-        min_sizes = []
-        max_sizes = []
-        for r in range(int(min_ratio), int(max_ratio) + 1, step):
-            min_sizes.append(int(input_size * r / 100))
-            max_sizes.append(int(input_size * (r + step) / 100))
-        if input_size == 300:
-            if basesize_ratio_range[0] == 0.15:  # SSD300 COCO
-                min_sizes.insert(0, int(input_size * 7 / 100))
-                max_sizes.insert(0, int(input_size * 15 / 100))
-            elif basesize_ratio_range[0] == 0.2:  # SSD300 VOC
-                min_sizes.insert(0, int(input_size * 10 / 100))
-                max_sizes.insert(0, int(input_size * 20 / 100))
-        elif input_size == 512:
-            if basesize_ratio_range[0] == 0.1:  # SSD512 COCO
-                min_sizes.insert(0, int(input_size * 4 / 100))
-                max_sizes.insert(0, int(input_size * 10 / 100))
-            elif basesize_ratio_range[0] == 0.15:  # SSD512 VOC
-                min_sizes.insert(0, int(input_size * 7 / 100))
-                max_sizes.insert(0, int(input_size * 15 / 100))
         self.anchor_generators = []
         self.anchor_strides = anchor_strides
-        for k in range(len(anchor_strides)):
-            base_size = min_sizes[k]
-            stride = anchor_strides[k]
-            ctr = ((stride - 1) / 2., (stride - 1) / 2.)
-            scales = [1., np.sqrt(max_sizes[k] / min_sizes[k])]
-            ratios = [1.]
-            for r in anchor_ratios[k]:
-                ratios += [1 / r, r]  # 4 or 6 ratio
-            anchor_generator = AnchorGenerator(
-                base_size, scales, ratios, scale_major=False, ctr=ctr)
-            indices = list(range(len(ratios)))
-            indices.insert(1, len(indices))
-            anchor_generator.base_anchors = torch.index_select(
-                anchor_generator.base_anchors, 0, torch.LongTensor(indices))
-            self.anchor_generators.append(anchor_generator)
+        if len(anchor_heights):
+            assert len(anchor_heights) == len(anchor_widths)
+            for k in range(len(anchor_strides)):
+                assert len(anchor_widths[i]) == len(anchor_heights[i])
+                stride = anchor_strides[k]
+                if isinstance(stride, tuple):
+                    ctr = ((stride[0] - 1) / 2., (stride[1] - 1) / 2.)
+                else:
+                    ctr = ((stride - 1) / 2., (stride - 1) / 2.)
+                anchor_generator = AnchorGenerator(
+                    0, [], [], widths=anchor_widths[k],
+                    heights=anchor_heights[k],
+                    scale_major=False, ctr=ctr)
+                self.anchor_generators.append(anchor_generator)
+        else:
+            min_ratio, max_ratio = basesize_ratio_range
+            min_ratio = int(min_ratio * 100)
+            max_ratio = int(max_ratio * 100)
+            step = int(np.floor(max_ratio - min_ratio) /
+                       (len(in_channels) - 2))
+            min_sizes = []
+            max_sizes = []
+            for r in range(int(min_ratio), int(max_ratio) + 1, step):
+                min_sizes.append(int(input_size * r / 100))
+                max_sizes.append(int(input_size * (r + step) / 100))
+            min_sizes.insert(0, int(input_size * basesize_ratio_range[0] / 2))
+            max_sizes.insert(0, int(input_size * basesize_ratio_range[0]))
+            for k in range(len(anchor_strides)):
+                base_size = min_sizes[k]
+                stride = anchor_strides[k]
+                if isinstance(stride, tuple):
+                    ctr = ((stride[0] - 1) / 2., (stride[1] - 1) / 2.)
+                else:
+                    ctr = ((stride - 1) / 2., (stride - 1) / 2.)
+                scales = [1., np.sqrt(max_sizes[k] / min_sizes[k])]
+                ratios = [1.]
+                for r in anchor_ratios[k]:
+                    ratios += [1 / r, r]  # 4 or 6 ratio
+                anchor_generator = AnchorGenerator(
+                    base_size, scales, ratios, scale_major=False, ctr=ctr)
+                indices = list(range(len(ratios)))
+                indices.insert(1, len(indices))
+                anchor_generator.base_anchors = torch.index_select(
+                    anchor_generator.base_anchors, 0,
+                    torch.LongTensor(indices))
+                self.anchor_generators.append(anchor_generator)
 
         self.target_means = target_means
         self.target_stds = target_stds
         self.use_sigmoid_cls = False
         self.cls_focal_loss = False
         self.fp16_enabled = False
+        self.loss_balancing = loss_balancing
+        if self.loss_balancing:
+            self.loss_weights = torch.nn.Parameter(torch.FloatTensor(2))
+            for i in range(2):
+                self.loss_weights.data[i] = 0.
 
     def init_weights(self):
         for m in self.modules():
@@ -190,4 +227,20 @@ class SSDHead(AnchorHead):
             all_bbox_weights,
             num_total_samples=num_total_pos,
             cfg=cfg)
+
+        if self.loss_balancing:
+            losses_cls, losses_reg = self._balance_losses(losses_cls,
+                                                          losses_bbox)
+
         return dict(loss_cls=losses_cls, loss_bbox=losses_bbox)
+
+    def _balance_losses(self, losses_cls, losses_reg):
+        loss_cls = sum(_loss.mean() for _loss in losses_cls)
+        loss_cls = torch.exp(-self.loss_weights[0])*loss_cls + \
+            0.5*self.loss_weights[0]
+
+        loss_reg = sum(_loss.mean() for _loss in losses_reg)
+        loss_reg = torch.exp(-self.loss_weights[1])*loss_reg + \
+            0.5*self.loss_weights[1]
+
+        return (losses_cls, losses_reg)

--- a/mmdet/models/anchor_heads/ssd_head.py
+++ b/mmdet/models/anchor_heads/ssd_head.py
@@ -45,14 +45,14 @@ class SSDHead(AnchorHead):
                     nn.Conv2d(in_channels[i], in_channels[i],
                               kernel_size=3, padding=1, groups=in_channels[i]),
                     nn.BatchNorm2d(in_channels[i]),
-                    nn.ReLU(inplace=True),
+                    nn.ReLU6(inplace=True),
                     nn.Conv2d(in_channels[i], num_anchors[i] * 4,
                               kernel_size=1, padding=0))
                 cls_conv = nn.Sequential(
                     nn.Conv2d(in_channels[i], in_channels[i],
                               kernel_size=3, padding=1, groups=in_channels[i]),
                     nn.BatchNorm2d(in_channels[i]),
-                    nn.ReLU(inplace=True),
+                    nn.ReLU6(inplace=True),
                     nn.Conv2d(in_channels[i], num_anchors[i] * num_classes,
                               kernel_size=1, padding=0))
             else:

--- a/mmdet/models/backbones/__init__.py
+++ b/mmdet/models/backbones/__init__.py
@@ -2,5 +2,7 @@ from .resnet import ResNet, make_res_layer
 from .resnext import ResNeXt
 from .ssd_vgg import SSDVGG
 from .hrnet import HRNet
+from .mobilenetv2 import SSDMobilenetV2
 
-__all__ = ['ResNet', 'make_res_layer', 'ResNeXt', 'SSDVGG', 'HRNet']
+__all__ = ['ResNet', 'make_res_layer', 'ResNeXt', 'SSDVGG', 'HRNet',
+           'SSDMobilenetV2']

--- a/mmdet/models/backbones/mobilenetv2.py
+++ b/mmdet/models/backbones/mobilenetv2.py
@@ -146,19 +146,32 @@ class SSDMobilenetV2(nn.Module):
         # building last several layers
         self.extra_convs = []
         if not self.single_scale:
-            self.extra_convs.append(conv_1x1_bn(last_channel, 1280))
-            self.extra_convs.append(conv_1x1_bn(1280, 256))
-            self.extra_convs.append(conv_bn(256, 256, 2, groups=256))
-            self.extra_convs.append(conv_1x1_bn(256, 512, groups=1))
-            self.extra_convs.append(conv_1x1_bn(512, 128))
-            self.extra_convs.append(conv_bn(128, 128, 2, groups=128))
-            self.extra_convs.append(conv_1x1_bn(128, 256))
-            self.extra_convs.append(conv_1x1_bn(256, 128))
-            self.extra_convs.append(conv_bn(128, 128, 2, groups=128))
-            self.extra_convs.append(conv_1x1_bn(128, 256))
-            self.extra_convs.append(conv_1x1_bn(256, 64))
-            self.extra_convs.append(conv_bn(64, 64, 2, groups=64))
-            self.extra_convs.append(conv_1x1_bn(64, 128))
+            self.extra_convs.append(conv_1x1_bn(last_channel, 1280,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(1280, 256,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_bn(256, 256, 2, groups=256,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(256, 512, groups=1,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(512, 128,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_bn(128, 128, 2, groups=128,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(128, 256,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(256, 128,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_bn(128, 128, 2, groups=128,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(128, 256,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(256, 64,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_bn(64, 64, 2, groups=64,
+                                        activation=self.activation_class))
+            self.extra_convs.append(conv_1x1_bn(64, 128,
+                                        activation=self.activation_class))
             self.extra_convs = nn.Sequential(*self.extra_convs)
 
     @property

--- a/mmdet/models/backbones/mobilenetv2.py
+++ b/mmdet/models/backbones/mobilenetv2.py
@@ -1,0 +1,240 @@
+import torch
+import torch.nn as nn
+from mmcv.cnn import (constant_init, kaiming_init, normal_init)
+from ..registry import BACKBONES
+
+
+def conv_bn(inp, oup, stride, groups=1, activation=nn.ReLU):
+    return nn.Sequential(
+        nn.Conv2d(inp, oup, 3, stride, 1, bias=False, groups=groups),
+        nn.BatchNorm2d(oup),
+        activation(inplace=True)
+    )
+
+
+def conv_1x1_bn(inp, oup, groups=1, activation=nn.ReLU):
+    return nn.Sequential(
+        nn.Conv2d(inp, oup, 1, 1, 0, bias=False, groups=groups),
+        nn.BatchNorm2d(oup),
+        activation(inplace=True)
+    )
+
+
+class InvertedResidual(nn.Module):
+    def __init__(self, inp, oup, stride, expand_ratio, ssd_output=False,
+                 activation=nn.ReLU):
+        super(InvertedResidual, self).__init__()
+        self.stride = stride
+        assert stride in [1, 2]
+
+        hidden_dim = int(inp * expand_ratio)
+        inp = int(inp)
+        oup = int(oup)
+        self.use_res_connect = self.stride == 1 and inp == oup
+
+        if expand_ratio == 1:
+            self.conv = nn.Sequential(
+                # dw
+                nn.Conv2d(hidden_dim, hidden_dim, 3, stride, 1,
+                          groups=hidden_dim, bias=False),
+                nn.BatchNorm2d(hidden_dim),
+                activation(inplace=True),
+                # pw-linear
+                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+            )
+        else:
+            self.conv = [
+                # pw
+                nn.Conv2d(inp, hidden_dim, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(hidden_dim),
+                activation(inplace=True),
+                # dw
+                nn.Conv2d(hidden_dim, hidden_dim, 3, stride, 1,
+                          groups=hidden_dim, bias=False),
+                nn.BatchNorm2d(hidden_dim),
+                activation(inplace=True),
+                # pw-linear
+                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+            ]
+        self.ssd_output = ssd_output
+        if self.ssd_output:
+            self.output_conv = conv_1x1_bn(hidden_dim, hidden_dim, 1,
+                                           activation)
+            self.conv1 = nn.Sequential(*self.conv[0:3])
+            self.conv2 = nn.Sequential(*self.conv[3:])
+        else:
+            self.conv = nn.Sequential(*self.conv)
+
+    def compute_conv(self, x):
+        if not self.ssd_output:
+            return self.conv(x)
+
+        expanded_x = self.output_conv(self.conv1(x))
+        return (expanded_x, self.conv2(expanded_x))
+
+    def forward(self, x):
+        if self.use_res_connect:
+            if self.ssd_output:
+                expanded, conv = self.compute_conv(x)
+                return (expanded, x + conv)
+            return x + self.compute_conv(x)
+        else:
+            return self.compute_conv(x)
+
+
+@BACKBONES.register_module
+class SSDMobilenetV2(nn.Module):
+    def __init__(self, input_size, width_mult=1.0,
+                 activation_type='relu',
+                 single_scale=False):
+        super(SSDMobilenetV2, self).__init__()
+        self.input_size = input_size
+        self.single_scale = single_scale
+        self.width_mult = width_mult
+        block = InvertedResidual
+        input_channel = 32
+        last_channel = 320
+        interverted_residual_setting = [
+            # t, c, n, s
+            [1, 16, 1, 1],
+            [6, 24, 2, 2],
+            [6, 32, 3, 2],
+            [6, 64, 4, 2],
+            [6, 96, 3, 1],
+            [6, 160, 3, 2],
+            [6, 320, 1, 1],
+        ]
+        if self.single_scale:
+            interverted_residual_setting[-2] = [6, 160, 3, 1]
+            interverted_residual_setting[-1] = [4, 480, 1, 1]
+
+        assert activation_type in ['relu', 'relu6']
+        if activation_type in 'relu':
+            self.activation_class = nn.ReLU
+        else:
+            self.activation_class = nn.ReLU6
+
+        # building the first layer
+        input_channel = int(input_channel * self.width_mult)
+        if self.width_mult > 1.0:
+            self.last_channel = int(last_channel * self.width_mult)
+        else:
+            self.last_channel = last_channel
+        self.bn_first = nn.BatchNorm2d(3)
+        self.features = [conv_bn(3, input_channel, 2)]
+        # building inverted residual blocks
+        for t, c, n, s in interverted_residual_setting:
+            output_channel = c * self.width_mult
+            for i in range(n):
+                ssd_output = False
+                if i == 0 and c == 160 and s == 2 and not self.single_scale:
+                    ssd_output = True
+                if i == 0:
+                    self.features.append(block(input_channel, output_channel,
+                                               s, t, ssd_output,
+                                               self.activation_class))
+                else:
+                    self.features.append(block(input_channel, output_channel,
+                                               1, t, ssd_output,
+                                               self.activation_class))
+                input_channel = output_channel
+        # make it nn.Sequential
+        self.features = nn.Sequential(*self.features)
+
+        # building last several layers
+        self.extra_convs = []
+        if not self.single_scale:
+            self.extra_convs.append(conv_1x1_bn(last_channel, 1280))
+            self.extra_convs.append(conv_1x1_bn(1280, 256))
+            self.extra_convs.append(conv_bn(256, 256, 2, groups=256))
+            self.extra_convs.append(conv_1x1_bn(256, 512, groups=1))
+            self.extra_convs.append(conv_1x1_bn(512, 128))
+            self.extra_convs.append(conv_bn(128, 128, 2, groups=128))
+            self.extra_convs.append(conv_1x1_bn(128, 256))
+            self.extra_convs.append(conv_1x1_bn(256, 128))
+            self.extra_convs.append(conv_bn(128, 128, 2, groups=128))
+            self.extra_convs.append(conv_1x1_bn(128, 256))
+            self.extra_convs.append(conv_1x1_bn(256, 64))
+            self.extra_convs.append(conv_bn(64, 64, 2, groups=64))
+            self.extra_convs.append(conv_1x1_bn(64, 128))
+            self.extra_convs = nn.Sequential(*self.extra_convs)
+
+    @property
+    def activation_fun(self):
+        return self.activation_class
+
+    def init_weights(self, pretrained=None):
+        if isinstance(pretrained, str):
+            state_dict = torch.load(pretrained)
+            if 'state_dict' in state_dict:
+                state_dict = state_dict['state_dict']
+
+            if self.width_mult < 1.0:
+                patched_dict = {}
+                for k, v in state_dict.items():
+                    if 'backbone.' in k:
+                        k = k[len('backbone.'):]
+                    if 'features.17.conv' in k and self.single_scale:
+                        continue
+                    if 'conv' in k:  # process convs in inverted residuals
+                        if len(v.shape) == 1:
+                            v = v[:int(v.shape[0]*self.width_mult)]
+                        elif len(v.shape) == 4 and v.shape[1] == 1:
+                            assert v.shape[2] == v.shape[3] and v.shape[2] == 3
+                            v = v[:int(v.shape[0]*self.width_mult), ]
+                        elif len(v.shape) == 4 and v.shape[2] == 1:
+                            assert v.shape[2] == v.shape[3] and v.shape[2] == 1
+                            v = v[:int(v.shape[0]*self.width_mult),
+                                  :int(v.shape[1]*self.width_mult), ]
+                    elif 'features.0.' in k:  # process the first conv
+                        if len(v.shape):
+                            v = v[:int(v.shape[0]*self.width_mult), ]
+
+                    patched_dict[k] = v
+
+                self.load_state_dict(patched_dict, strict=False)
+            elif self.width_mult == 1.0:
+                patched_dict = {}
+                if self.single_scale:
+                    for k, v in state_dict.items():
+                        if 'features.17.conv' in k:
+                            continue
+                        patched_dict[k] = v
+                else:
+                    patched_dict = state_dict
+
+                self.load_state_dict(patched_dict, strict=False)
+            else:
+                print('Warning: loading of pre-trained weights is not \
+                       supported for MobileNetV2 with width_mult > 1')
+        elif pretrained is None:
+            for m in self.modules():
+                if isinstance(m, nn.Conv2d):
+                    kaiming_init(m)
+                elif isinstance(m, nn.BatchNorm2d):
+                    constant_init(m, 1)
+                elif isinstance(m, nn.Linear):
+                    normal_init(m, std=0.01)
+        else:
+            raise TypeError('pretrained must be a str or None')
+
+    def forward(self, x):
+        outs = []
+        x = self.bn_first(x)
+        for i, block in enumerate(self.features):
+            x = block(x)
+            if isinstance(x, tuple):
+                outs.append(x[0])
+                x = x[1]
+
+        for i, conv in enumerate(self.extra_convs):
+            x = conv(x)
+            if i % 3 == 0:
+                outs.append(x)
+
+        if self.single_scale:
+            outs.append(x)
+
+        return tuple(outs)

--- a/mmdet/models/backbones/mobilenetv2.py
+++ b/mmdet/models/backbones/mobilenetv2.py
@@ -4,19 +4,19 @@ from mmcv.cnn import (constant_init, kaiming_init, normal_init)
 from ..registry import BACKBONES
 
 
-def conv_bn(inp, oup, stride, groups=1, activation=nn.ReLU):
+def conv_bn(inp, oup, stride, groups=1, act_fn=nn.ReLU):
     return nn.Sequential(
         nn.Conv2d(inp, oup, 3, stride, 1, bias=False, groups=groups),
         nn.BatchNorm2d(oup),
-        activation(inplace=True)
+        act_fn(inplace=True)
     )
 
 
-def conv_1x1_bn(inp, oup, groups=1, activation=nn.ReLU):
+def conv_1x1_bn(inp, oup, groups=1, act_fn=nn.ReLU):
     return nn.Sequential(
         nn.Conv2d(inp, oup, 1, 1, 0, bias=False, groups=groups),
         nn.BatchNorm2d(oup),
-        activation(inplace=True)
+        act_fn(inplace=True)
     )
 
 
@@ -147,31 +147,31 @@ class SSDMobilenetV2(nn.Module):
         self.extra_convs = []
         if not self.single_scale:
             self.extra_convs.append(conv_1x1_bn(last_channel, 1280,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(1280, 256,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_bn(256, 256, 2, groups=256,
-                                        activation=self.activation_class))
+                                            act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(256, 512, groups=1,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(512, 128,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_bn(128, 128, 2, groups=128,
-                                        activation=self.activation_class))
+                                            act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(128, 256,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(256, 128,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_bn(128, 128, 2, groups=128,
-                                        activation=self.activation_class))
+                                            act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(128, 256,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(256, 64,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs.append(conv_bn(64, 64, 2, groups=64,
-                                        activation=self.activation_class))
+                                            act_fn=self.activation_class))
             self.extra_convs.append(conv_1x1_bn(64, 128,
-                                        activation=self.activation_class))
+                                                act_fn=self.activation_class))
             self.extra_convs = nn.Sequential(*self.extra_convs)
 
     @property


### PR DESCRIPTION
This PR adds:
- MobileNetV2 backbone for SSD
- Lite heads for SSD
- Automatic regression/classification losses balancing for SSD (based on [paper](http://openaccess.thecvf.com/content_cvpr_2018/papers/Kendall_Multi-Task_Learning_Using_CVPR_2018_paper.pdf))
- Ability to specify anchors in SSD manually
- Sample configs to demonstrate the above features