### PR TITLE
Require an operation(Save or Show the results) when testing

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -128,6 +128,10 @@ def parse_args():
 def main():
     args = parse_args()
 
+    assert args.out or args.show,\
+        'Please choice an operation(Save or Show the results)\
+         by argument --out or --show'
+
     if args.out is not None and not args.out.endswith(('.pkl', '.pickle')):
         raise ValueError('The output file must be a pkl file.')
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -128,9 +128,9 @@ def parse_args():
 def main():
     args = parse_args()
 
-    assert args.out or args.show,\
-        'Please choice an operation(Save or Show the results)\
-         by argument --out or --show'
+    assert args.out or args.show, \
+        ('Please specify at least one operation (save or show the results) '
+         'with the argument "--out" or "--show"')
 
     if args.out is not None and not args.out.endswith(('.pkl', '.pickle')):
         raise ValueError('The output file must be a pkl file.')


### PR DESCRIPTION
It will waste a lot time to inference but do nothing if we didn't assign an operation
I did several times :joy: 