### PR TITLE
Add option to use linear scaling rule

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -35,6 +35,8 @@ def parse_args():
         default='none',
         help='job launcher')
     parser.add_argument('--local_rank', type=int, default=0)
+    parser.add_argument('--autoscale-lr', action='store_true',
+        help='automatically scale lr with the number of gpus')
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)
@@ -55,6 +57,10 @@ def main():
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
     cfg.gpus = args.gpus
+    
+    if args.autoscale_lr:
+        # apply the linear scaling rule (https://arxiv.org/abs/1706.02677)
+        cfg.optimizer['lr'] = cfg.optimizer['lr'] * cfg.gpus / 8   
 
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':

--- a/tools/train.py
+++ b/tools/train.py
@@ -35,7 +35,9 @@ def parse_args():
         default='none',
         help='job launcher')
     parser.add_argument('--local_rank', type=int, default=0)
-    parser.add_argument('--autoscale-lr', action='store_true',
+    parser.add_argument(
+        '--autoscale-lr',
+        action='store_true',
         help='automatically scale lr with the number of gpus')
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
@@ -57,10 +59,10 @@ def main():
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
     cfg.gpus = args.gpus
-    
+
     if args.autoscale_lr:
         # apply the linear scaling rule (https://arxiv.org/abs/1706.02677)
-        cfg.optimizer['lr'] = cfg.optimizer['lr'] * cfg.gpus / 8   
+        cfg.optimizer['lr'] = cfg.optimizer['lr'] * cfg.gpus / 8
 
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':


### PR DESCRIPTION
Add an option to use the linear scaling rule to automatically scale the learning rate when more or less than 8 gpus are used.

Results [box AP] on coco val2017:
1 GPU: 36.3
2 GPUs: 36.5
4 GPUs: 36.5
8 GPUs: 36.4