### PR TITLE
manually add type promotion

### DIFF
--- a/mmdet/core/anchor/anchor_target.py
+++ b/mmdet/core/anchor/anchor_target.py
@@ -164,10 +164,10 @@ def anchor_inside_flags(flat_anchors, valid_flags, img_shape,
     img_h, img_w = img_shape[:2]
     if allowed_border >= 0:
         inside_flags = valid_flags & \
-            (flat_anchors[:, 0] >= -allowed_border) & \
-            (flat_anchors[:, 1] >= -allowed_border) & \
-            (flat_anchors[:, 2] < img_w + allowed_border) & \
-            (flat_anchors[:, 3] < img_h + allowed_border)
+            (flat_anchors[:, 0] >= -allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 1] >= -allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.uint8)
     else:
         inside_flags = valid_flags
     return inside_flags


### PR DESCRIPTION
``Bool`` type has been separated from ``Byte`` in pytorch. ``valid_flags`` is in ``Byte`` type but arithmetic comparisons return ``Bool``, which causes error under current pytorch version.
To keep compatible across pytorch versions, we have to manually add the type promotion.
(pytorch has always been conservative in automatic type conversion, even if there is an issue [there](https://github.com/pytorch/pytorch/issues/23758), I believe they will not add the type promotion)