### PR TITLE
Support different type of dataset for training

### DIFF
--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -28,7 +28,9 @@ def _concat_dataset(cfg, default_args=None):
 
 
 def build_dataset(cfg, default_args=None):
-    if cfg['type'] == 'RepeatDataset':
+    if isinstance(cfg, (list, tuple)):
+        dataset = ConcatDataset([build_dataset(c, default_args) for c in cfg])
+    elif cfg['type'] == 'RepeatDataset':
         dataset = RepeatDataset(
             build_dataset(cfg['dataset'], default_args), cfg['times'])
     elif isinstance(cfg['ann_file'], (list, tuple)):


### PR DESCRIPTION
Solve above situations:
1. using different type of dataset for training
```
data = dict(
    train=(
        dict(
            type='XxDataset',
            params=...,
            ),
        dict(
            type='YyDataset',
            params=...,
            )))
```
2、same type of dataset, but different parameters
```
data = dict(
    train=(
        dict(
            type='XxDataset',
            params=P1,
            ),
        dict(
            type='XxDataset',
            params=P2,
            )))
```