### PR TITLE
Fix for gt_ignore

### DIFF
--- a/tools/voc_eval.py
+++ b/tools/voc_eval.py
@@ -27,7 +27,7 @@ def voc_eval(result_file, dataset, iou_thr=0.5):
         gt_bboxes.append(bboxes)
         gt_labels.append(labels)
     if not gt_ignore:
-        gt_ignore = gt_ignore
+        gt_ignore = None
     if hasattr(dataset, 'year') and dataset.year == 2007:
         dataset_name = 'voc07'
     else:


### PR DESCRIPTION
Fix for issue #1236. If list `gt_ignore` was empty, it should become `None` after the following if statement:
```
if not gt_ignore:
        gt_ignore = gt_ignore
```
otherwise, the `eval_map` function throws an `AssertionError`.
Changed it to `gt_ignore = None`.