### PR TITLE
Optimize Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,12 @@ ARG CUDNN="7.5"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
-RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6
+RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install mmdetection
-RUN conda install cython -y
+RUN conda install cython -y && conda clean --all
 RUN git clone https://github.com/open-mmlab/mmdetection.git /mmdetection
 WORKDIR /mmdetection
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
Hi! Here is my suggestion about optimizing Dockerfile. Some tarballs and other cache files may not be re-used so that we could choose to clean them up during image building process. I hope that these suggestion could assist in reducing the image size as you may add more commands here in the future.

*Reference:*
* https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
* https://docs.conda.io/projects/conda/en/latest/commands/clean.html
* https://pip.pypa.io/en/stable/reference/pip_install/
* https://stackoverflow.com/questions/45594707/what-is-pips-no-cache-dir-good-for/45594808