### PR TITLE
Fix "loss_bbox" assert

### DIFF
--- a/mmdet/models/bbox_heads/bbox_head.py
+++ b/mmdet/models/bbox_heads/bbox_head.py
@@ -116,17 +116,19 @@ class BBoxHead(nn.Module):
             losses['acc'] = accuracy(cls_score, labels)
         if bbox_pred is not None:
             pos_inds = labels > 0
-            if self.reg_class_agnostic:
-                pos_bbox_pred = bbox_pred.view(bbox_pred.size(0), 4)[pos_inds]
-            else:
-                pos_bbox_pred = bbox_pred.view(bbox_pred.size(0), -1,
-                                               4)[pos_inds, labels[pos_inds]]
-            losses['loss_bbox'] = self.loss_bbox(
-                pos_bbox_pred,
-                bbox_targets[pos_inds],
-                bbox_weights[pos_inds],
-                avg_factor=bbox_targets.size(0),
-                reduction_override=reduction_override)
+            if pos_inds.any():
+                if self.reg_class_agnostic:
+                    pos_bbox_pred = bbox_pred.view(
+                        bbox_pred.size(0), 4)[pos_inds]
+                else:
+                    pos_bbox_pred = bbox_pred.view(
+                        bbox_pred.size(0), -1, 4)[pos_inds, labels[pos_inds]]
+                losses['loss_bbox'] = self.loss_bbox(
+                    pos_bbox_pred,
+                    bbox_targets[pos_inds],
+                    bbox_weights[pos_inds],
+                    avg_factor=bbox_targets.size(0),
+                    reduction_override=reduction_override)
         return losses
 
     @force_fp32(apply_to=('cls_score', 'bbox_pred'))


### PR DESCRIPTION
When training with small batch sizes the assertion statement `assert pred.size() == target.size() and target.numel() > 0` in the `smooth_l1_loss` and `balanced_l1_loss` loss functions will sometimes be triggered because none of the proposals in the whole batch corresponds to an object and thus the number of valid `bbox_targets` is 0 (hence target.numel() = 0`). This will break the training, which could otherwise resume normally.

I see two ways of fixing this:
1. Remove the `target.numel() > 0` assertion statement. This will cause the loss functions to return an empty tensor `tensor([], device='cuda:0', size=(0, 4), grad_fn=<SWhereBackward>)` which will be turned into a `nan` when taking the mean in `parse_losses` in `mmdet/api/train.py`. I guess the assertion was added to avoid this `nan`, however in my experiments this was fixed somewhere downstream, such that the `nan` created no problems and training resumed normally.

2. Add an if statement `if pos_inds.any():` in the `BBoxHead` modules `loss` function. Then if in one step no proposal covers any ground truth box `losses['loss_bbox']` will not be created and it will automatically be ignored in `parse_losses` in `mmdet/api/train.py`.

I'd suggest using the second option, as it is cleaner and avoids potential problems if for any reason the downstream handling of the `nan` loss should fail in the future.