### PR TITLE
Fix bbox_flip, so that it can handle multiple-scale input, as bbox_flip in mmdet/datasets/pipelines/transforms.py#L183

### DIFF
--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -81,8 +81,8 @@ def bbox_flip(bboxes, img_shape):
     if isinstance(bboxes, torch.Tensor):
         assert bboxes.shape[-1] % 4 == 0
         flipped = bboxes.clone()
-        flipped[:, 0::4] = img_shape[1] - bboxes[:, 2::4] - 1
-        flipped[:, 2::4] = img_shape[1] - bboxes[:, 0::4] - 1
+        flipped[..., 0::4] = img_shape[1] - bboxes[..., 2::4] - 1
+        flipped[..., 2::4] = img_shape[1] - bboxes[..., 0::4] - 1
         return flipped
     elif isinstance(bboxes, np.ndarray):
         return mmcv.bbox_flip(bboxes, img_shape)


### PR DESCRIPTION
Fix bbox_flip, so that it can handle multiple-scale input, as bbox_flip in [mmdet/datasets/pipelines/transforms.py#L183](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/pipelines/transforms.py#L183)