### PR TITLE
Fixed coco_eval bug where seg length check could be wrong (#1376)

### DIFF
--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if isinstance(seg, tuple) and label in seg[0]:
+            if isinstance(seg, tuple):
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if len(seg) == 2:
+            if len(seg) == 2 and len(seg) != len(dataset.CLASSES):
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if len(seg) == 2 and label in seg[0]:
+            if isinstance(seg, tuple) and label in seg[0]:
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if len(seg) == 2 and label in seg[0] and len(seg[0][label]) == bboxes.shape[0] and label in seg[1] and len(seg[1][label]) == bboxes.shape[0]:
+            if label in seg[0]:
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if len(seg) == 2 and len(seg) != len(dataset.CLASSES):
+            if len(seg) == 2 and label in seg[0] and len(seg[0][label]) == bboxes.shape[0] and label in seg[1] and len(seg[1][label]) == bboxes.shape[0]:
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -153,7 +153,8 @@ def segm2json(dataset, results):
                 data['image_id'] = img_id
                 data['score'] = float(mask_score[i])
                 data['category_id'] = dataset.cat_ids[label]
-                segms[i]['counts'] = segms[i]['counts'].decode()
+                if isinstance(segms[i]['counts'], bytes):
+                    segms[i]['counts'] = segms[i]['counts'].decode()
                 data['segmentation'] = segms[i]
                 segm_json_results.append(data)
     return bbox_json_results, segm_json_results

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -142,7 +142,7 @@ def segm2json(dataset, results):
 
             # segm results
             # some detectors use different score for det and segm
-            if label in seg[0]:
+            if len(seg) == 2 and label in seg[0]:
                 segms = seg[0][label]
                 mask_score = seg[1][label]
             else:


### PR DESCRIPTION
Commit 8d010d7de9c2643e715aaf6033ff7fd5c60ebdc2 added a change where seg would be checked to have a length of 2 (denoting it was a different detector result). When a dataset has two classes this breaks, so this PR simply adds an additional check to ensure in the event the dataset has two classes the script doesn't break. Also ensures the segms counts has the decode method.