### PR TITLE
End-to-end Faster/Mask R-CNN models export to ONNX

### DIFF
--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -1,5 +1,7 @@
 import torch
 
+from mmdet.core.utils.misc import arange
+
 
 class AnchorGenerator(object):
 
@@ -45,8 +47,9 @@ class AnchorGenerator(object):
         return base_anchors
 
     def _meshgrid(self, x, y, row_major=True):
-        xx = x.repeat(len(y))
-        yy = y.view(-1, 1).repeat(1, len(x)).view(-1)
+        n, m = y.shape[0], x.shape[0]
+        yy = y.view(-1, 1).expand(n, m).reshape(-1)
+        xx = x.view(1, -1).expand(n, m).reshape(-1)
         if row_major:
             return xx, yy
         else:
@@ -55,12 +58,12 @@ class AnchorGenerator(object):
     def grid_anchors(self, featmap_size, stride=16, device='cuda'):
         base_anchors = self.base_anchors.to(device)
 
-        feat_h, feat_w = featmap_size
-        shift_x = torch.arange(0, feat_w, device=device) * stride
-        shift_y = torch.arange(0, feat_h, device=device) * stride
+        shift_x = arange(start=0, end=featmap_size[1], dtype=torch.float32, device=device) * stride
+        shift_y = arange(start=0, end=featmap_size[0], dtype=torch.float32, device=device) * stride
         shift_xx, shift_yy = self._meshgrid(shift_x, shift_y)
-        shifts = torch.stack([shift_xx, shift_yy, shift_xx, shift_yy], dim=-1)
+        shifts = torch.stack([shift_xx, shift_yy, shift_xx, shift_yy], dim=1)
         shifts = shifts.type_as(base_anchors)
+
         # first feat_w elements correspond to the first row of shifts
         # add A anchors (1, A, 4) to K shifts (K, 1, 4) to get
         # shifted anchors (K, A, 4), reshape to (K*A, 4)

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -58,8 +58,12 @@ class AnchorGenerator(object):
     def grid_anchors(self, featmap_size, stride=16, device='cuda'):
         base_anchors = self.base_anchors.to(device)
 
-        shift_x = arange(start=0, end=featmap_size[1], dtype=torch.float32, device=device) * stride
-        shift_y = arange(start=0, end=featmap_size[0], dtype=torch.float32, device=device) * stride
+        shift_x = arange(
+            start=0, end=featmap_size[1], dtype=torch.float32,
+            device=device) * stride
+        shift_y = arange(
+            start=0, end=featmap_size[0], dtype=torch.float32,
+            device=device) * stride
         shift_xx, shift_yy = self._meshgrid(shift_x, shift_y)
         shifts = torch.stack([shift_xx, shift_yy, shift_xx, shift_yy], dim=1)
         shifts = shifts.type_as(base_anchors)

--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -1,9 +1,9 @@
 import mmcv
 import numpy as np
 import torch
+from torch.onnx import is_in_onnx_export
 
 from ..utils.misc import to_numpy
-from torch.onnx import is_in_onnx_export
 
 
 def bbox2delta(proposals, gt, means=[0, 0, 0, 0], stds=[1, 1, 1, 1]):
@@ -37,16 +37,20 @@ def bbox2delta(proposals, gt, means=[0, 0, 0, 0], stds=[1, 1, 1, 1]):
 def clamp(x, min, max):
     if is_in_onnx_export():
         device = x.device
-        dtype= x.dtype
+        dtype = x.dtype
 
         y = x
 
         min_val = torch.as_tensor(min, dtype=dtype, device=device)
-        y = torch.stack([y, min_val.view([1, ] * y.dim()).expand_as(y)], dim=0)
+        y = torch.stack([y, min_val.view([
+            1,
+        ] * y.dim()).expand_as(y)], dim=0)
         y = torch.max(y, dim=0, keepdim=False)[0]
 
         max_val = torch.as_tensor(max, dtype=dtype, device=device)
-        y = torch.stack([y, max_val.view([1, ] * y.dim()).expand_as(y)], dim=0)
+        y = torch.stack([y, max_val.view([
+            1,
+        ] * y.dim()).expand_as(y)], dim=0)
         y = torch.min(y, dim=0, keepdim=False)[0]
     else:
         y = x.clamp(min=min, max=max)

--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -2,6 +2,9 @@ import mmcv
 import numpy as np
 import torch
 
+from ..utils.misc import to_numpy
+from torch.onnx import is_in_onnx_export
+
 
 def bbox2delta(proposals, gt, means=[0, 0, 0, 0], stds=[1, 1, 1, 1]):
     assert proposals.size() == gt.size()
@@ -31,14 +34,34 @@ def bbox2delta(proposals, gt, means=[0, 0, 0, 0], stds=[1, 1, 1, 1]):
     return deltas
 
 
+def clamp(x, min, max):
+    if is_in_onnx_export():
+        device = x.device
+        dtype= x.dtype
+
+        y = x
+
+        min_val = torch.as_tensor(min, dtype=dtype, device=device)
+        y = torch.stack([y, min_val.view([1, ] * y.dim()).expand_as(y)], dim=0)
+        y = torch.max(y, dim=0, keepdim=False)[0]
+
+        max_val = torch.as_tensor(max, dtype=dtype, device=device)
+        y = torch.stack([y, max_val.view([1, ] * y.dim()).expand_as(y)], dim=0)
+        y = torch.min(y, dim=0, keepdim=False)[0]
+    else:
+        y = x.clamp(min=min, max=max)
+
+    return y
+
+
 def delta2bbox(rois,
                deltas,
-               means=[0, 0, 0, 0],
-               stds=[1, 1, 1, 1],
+               means=(0, 0, 0, 0),
+               stds=(1, 1, 1, 1),
                max_shape=None,
                wh_ratio_clip=16 / 1000):
-    means = deltas.new_tensor(means).repeat(1, deltas.size(1) // 4)
-    stds = deltas.new_tensor(stds).repeat(1, deltas.size(1) // 4)
+    means = deltas.new_tensor(means).view(1, -1).repeat(1, deltas.size(1) // 4)
+    stds = deltas.new_tensor(stds).view(1, -1).repeat(1, deltas.size(1) // 4)
     denorm_deltas = deltas * stds + means
     dx = denorm_deltas[:, 0::4]
     dy = denorm_deltas[:, 1::4]
@@ -53,18 +76,18 @@ def delta2bbox(rois,
     ph = (rois[:, 3] - rois[:, 1] + 1.0).unsqueeze(1).expand_as(dh)
     gw = pw * dw.exp()
     gh = ph * dh.exp()
-    gx = torch.addcmul(px, 1, pw, dx)  # gx = px + pw * dx
-    gy = torch.addcmul(py, 1, ph, dy)  # gy = py + ph * dy
+    gx = torch.addcmul(px, 1.0, pw, dx)  # gx = px + pw * dx
+    gy = torch.addcmul(py, 1.0, ph, dy)  # gy = py + ph * dy
     x1 = gx - gw * 0.5 + 0.5
     y1 = gy - gh * 0.5 + 0.5
     x2 = gx + gw * 0.5 - 0.5
     y2 = gy + gh * 0.5 - 0.5
     if max_shape is not None:
-        x1 = x1.clamp(min=0, max=max_shape[1] - 1)
-        y1 = y1.clamp(min=0, max=max_shape[0] - 1)
-        x2 = x2.clamp(min=0, max=max_shape[1] - 1)
-        y2 = y2.clamp(min=0, max=max_shape[0] - 1)
-    bboxes = torch.stack([x1, y1, x2, y2], dim=-1).view_as(deltas)
+        x1 = clamp(x1, min=0, max=max_shape[1] - 1)
+        y1 = clamp(y1, min=0, max=max_shape[0] - 1)
+        x2 = clamp(x2, min=0, max=max_shape[1] - 1)
+        y2 = clamp(y2, min=0, max=max_shape[0] - 1)
+    bboxes = torch.stack([x1, y1, x2, y2], dim=2).view_as(deltas)
     return bboxes
 
 
@@ -116,8 +139,8 @@ def bbox2roi(bbox_list):
     rois_list = []
     for img_id, bboxes in enumerate(bbox_list):
         if bboxes.size(0) > 0:
-            img_inds = bboxes.new_full((bboxes.size(0), 1), img_id)
-            rois = torch.cat([img_inds, bboxes[:, :4]], dim=-1)
+            rois = bboxes[:, :4].reshape(-1, 4)
+            rois = torch.nn.functional.pad(rois, (1, 0, 0, 0), value=img_id)
         else:
             rois = bboxes.new_zeros((0, 5))
         rois_list.append(rois)
@@ -151,8 +174,8 @@ def bbox2result(bboxes, labels, num_classes):
             np.zeros((0, 5), dtype=np.float32) for i in range(num_classes - 1)
         ]
     else:
-        bboxes = bboxes.cpu().numpy()
-        labels = labels.cpu().numpy()
+        bboxes = to_numpy(bboxes)
+        labels = to_numpy(labels)
         return [bboxes[labels == i, :] for i in range(num_classes - 1)]
 
 

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -153,8 +153,8 @@ def segm2json(dataset, results):
                 data['image_id'] = img_id
                 data['score'] = float(mask_score[i])
                 data['category_id'] = dataset.cat_ids[label]
-                segms[i]['counts'] = segms[i]['counts'].decode()
-                data['segmentation'] = segms[i]
+                data['segmentation'] = {'size': segms[i]['size'],
+                                        'counts': segms[i]['counts'].decode()}
                 segm_json_results.append(data)
     return bbox_json_results, segm_json_results
 

--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -153,8 +153,10 @@ def segm2json(dataset, results):
                 data['image_id'] = img_id
                 data['score'] = float(mask_score[i])
                 data['category_id'] = dataset.cat_ids[label]
-                data['segmentation'] = {'size': segms[i]['size'],
-                                        'counts': segms[i]['counts'].decode()}
+                data['segmentation'] = {
+                    'size': segms[i]['size'],
+                    'counts': segms[i]['counts'].decode()
+                }
                 segm_json_results.append(data)
     return bbox_json_results, segm_json_results
 

--- a/mmdet/core/mask/transforms.py
+++ b/mmdet/core/mask/transforms.py
@@ -1,0 +1,35 @@
+import mmcv
+import numpy as np
+import pycocotools.mask as mask_util
+
+from ..utils.misc import to_numpy
+
+
+def mask2result(det_bboxes, det_labels, det_masks, num_classes,
+                mask_thr_binary=0.5, rle=True, full_size=True, img_size=None):
+
+    masks = to_numpy(det_masks)
+    bboxes = to_numpy(det_bboxes, np.int32)[:, :4]
+    labels = to_numpy(det_labels, np.int32)
+
+    cls_masks = [[] for _ in range(num_classes - 1)]
+
+    for bbox, label, mask in zip(bboxes, labels, masks):
+        w = max(bbox[2] - bbox[0] + 1, 1)
+        h = max(bbox[3] - bbox[1] + 1, 1)
+
+        mask = mmcv.imresize(mask, (w, h))
+        mask = (mask > mask_thr_binary).astype(np.uint8)
+
+        if full_size:
+            assert img_size is not None
+            im_mask = np.zeros(img_size[:2], dtype=np.uint8)
+            im_mask[bbox[1]:bbox[1] + h, bbox[0]:bbox[0] + w] = mask
+            mask = im_mask
+
+        if rle:
+            mask = mask_util.encode(np.array(mask[:, :, np.newaxis], order='F'))[0]
+
+        cls_masks[label].append(mask)
+
+    return cls_masks

--- a/mmdet/core/mask/transforms.py
+++ b/mmdet/core/mask/transforms.py
@@ -5,8 +5,14 @@ import pycocotools.mask as mask_util
 from ..utils.misc import to_numpy
 
 
-def mask2result(det_bboxes, det_labels, det_masks, num_classes,
-                mask_thr_binary=0.5, rle=True, full_size=True, img_size=None):
+def mask2result(det_bboxes,
+                det_labels,
+                det_masks,
+                num_classes,
+                mask_thr_binary=0.5,
+                rle=True,
+                full_size=True,
+                img_size=None):
 
     masks = to_numpy(det_masks)
     bboxes = to_numpy(det_bboxes, np.int32)[:, :4]
@@ -28,7 +34,8 @@ def mask2result(det_bboxes, det_labels, det_masks, num_classes,
             mask = im_mask
 
         if rle:
-            mask = mask_util.encode(np.array(mask[:, :, np.newaxis], order='F'))[0]
+            mask = mask_util.encode(
+                np.array(mask[:, :, np.newaxis], order='F'))[0]
 
         cls_masks[label].append(mask)
 

--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -1,5 +1,10 @@
 import torch
+import torch.onnx.symbolic_helper as sym_help
+from torch.autograd import Function
+from torch.onnx.symbolic_opset10 import _slice
+from torch.onnx.symbolic_opset9 import reshape
 
+from mmdet.core.utils.misc import topk
 from mmdet.ops.nms import nms_wrapper
 
 
@@ -16,7 +21,7 @@ def multiclass_nms(multi_bboxes,
         multi_scores (Tensor): shape (n, #class)
         score_thr (float): bbox threshold, bboxes with scores lower than it
             will not be considered.
-        nms_thr (float): NMS IoU threshold
+        nms_cfg (float): NMS operation config
         max_num (int): if there are more than max_num bboxes after NMS,
             only top max_num will be kept.
         score_factors (Tensor): The factors multiplied to scores before
@@ -26,40 +31,125 @@ def multiclass_nms(multi_bboxes,
         tuple: (bboxes, labels), tensors of shape (k, 5) and (k, 1). Labels
             are 0-based.
     """
-    num_classes = multi_scores.shape[1]
-    bboxes, labels = [], []
-    nms_cfg_ = nms_cfg.copy()
-    nms_type = nms_cfg_.pop('type', 'nms')
-    nms_op = getattr(nms_wrapper, nms_type)
-    for i in range(1, num_classes):
-        cls_inds = multi_scores[:, i] > score_thr
-        if not cls_inds.any():
-            continue
-        # get bboxes and scores of this class
-        if multi_bboxes.shape[1] == 4:
-            _bboxes = multi_bboxes[cls_inds, :]
-        else:
-            _bboxes = multi_bboxes[cls_inds, i * 4:(i + 1) * 4]
-        _scores = multi_scores[cls_inds, i]
-        if score_factors is not None:
-            _scores *= score_factors[cls_inds]
-        cls_dets = torch.cat([_bboxes, _scores[:, None]], dim=1)
-        cls_dets, _ = nms_op(cls_dets, **nms_cfg_)
-        cls_labels = multi_bboxes.new_full((cls_dets.shape[0], ),
-                                           i - 1,
-                                           dtype=torch.long)
-        bboxes.append(cls_dets)
-        labels.append(cls_labels)
-    if bboxes:
-        bboxes = torch.cat(bboxes)
-        labels = torch.cat(labels)
-        if bboxes.shape[0] > max_num:
-            _, inds = bboxes[:, -1].sort(descending=True)
-            inds = inds[:max_num]
-            bboxes = bboxes[inds]
-            labels = labels[inds]
-    else:
-        bboxes = multi_bboxes.new_zeros((0, 5))
-        labels = multi_bboxes.new_zeros((0, ), dtype=torch.long)
-
+    combined_bboxes = GenericMulticlassNMS.apply(multi_bboxes,
+                                                 multi_scores,
+                                                 score_thr,
+                                                 nms_cfg,
+                                                 max_num,
+                                                 score_factors)
+    _, topk_inds = topk(combined_bboxes[:, 4].view(-1), max_num)
+    combined_bboxes = combined_bboxes[topk_inds]
+    bboxes = combined_bboxes[:, :5]
+    labels = combined_bboxes[:, 5].long().view(-1)
     return bboxes, labels
+
+
+class GenericMulticlassNMS(Function):
+
+    @staticmethod
+    def forward(ctx,
+                multi_bboxes,
+                multi_scores,
+                score_thr,
+                nms_cfg,
+                max_num=-1,
+                score_factors=None):
+        nms_op_cfg = nms_cfg.copy()
+        nms_op_type = nms_op_cfg.pop('type', 'nms')
+        nms_op = getattr(nms_wrapper, nms_op_type)
+
+        num_classes = multi_scores.shape[1]
+        bboxes, labels = [], []
+        for i in range(num_classes):
+            cls_inds = multi_scores[:, i] > score_thr
+            if not cls_inds.any():
+                continue
+            # Get bboxes and scores of this class.
+            if multi_bboxes.shape[1] == 4:
+                _bboxes = multi_bboxes[cls_inds, :]
+            else:
+                _bboxes = multi_bboxes[cls_inds, i * 4:(i + 1) * 4]
+            _scores = multi_scores[cls_inds, i]
+            if score_factors is not None:
+                _scores *= score_factors[cls_inds]
+            cls_dets = torch.cat([_bboxes, _scores[:, None]], dim=1)
+            cls_dets, _ = nms_op(cls_dets, **nms_op_cfg)
+            cls_labels = multi_bboxes.new_full((cls_dets.shape[0],),
+                                               i,
+                                               dtype=torch.long)
+            bboxes.append(cls_dets)
+            labels.append(cls_labels)
+
+        if bboxes:
+            bboxes = torch.cat(bboxes)
+            labels = torch.cat(labels)
+            if bboxes.shape[0] > max_num:
+                _, inds = bboxes[:, -1].topk(max_num, sorted=True)
+                bboxes = bboxes[inds]
+                labels = labels[inds]
+            combined_bboxes = torch.cat([bboxes,
+                                         labels.to(bboxes.dtype).unsqueeze(-1)],
+                                        dim=1)
+        else:
+            combined_bboxes = multi_bboxes.new_zeros((0, 6))
+
+        return combined_bboxes
+
+    @staticmethod
+    def symbolic(g, multi_bboxes, multi_scores, score_thr,
+                 nms_cfg, max_num=-1, score_factors=None):
+
+        def cast(x, dtype):
+            return g.op('Cast', x, to_i=sym_help.cast_pytorch_to_onnx[dtype])
+
+        assert score_factors is None
+        nms_op_type = nms_cfg.get('type', 'nms')
+        assert nms_op_type == 'nms'
+        assert 'iou_thr' in nms_cfg
+        iou_threshold = nms_cfg['iou_thr']
+        assert 0 <= iou_threshold <= 1
+
+        # Transpose and reshape input tensors to fit ONNX NonMaxSuppression.
+        multi_bboxes = g.op('Transpose',
+                            reshape(g, multi_bboxes, [0, -1, 4]),
+                            perm_i=[1, 0, 2])
+        multi_scores = g.op('Unsqueeze',
+                            g.op('Transpose', multi_scores, perm_i=[1, 0]),
+                            axes_i=[1])
+
+        assert max_num > 0
+
+        indices = g.op('NonMaxSuppression', multi_bboxes, multi_scores,
+                       g.op('Constant', value_t=torch.LongTensor([max_num])),
+                       g.op('Constant', value_t=torch.FloatTensor([iou_threshold])),
+                       g.op('Constant', value_t=torch.FloatTensor([score_thr])))
+
+        # Flatten bboxes and scores.
+        multi_bboxes_flat = reshape(g, multi_bboxes, [-1, 4])
+        multi_scores_flat = reshape(g, multi_scores, [-1, ])
+
+        # Flatten indices.
+        class_indices = cast(_slice(g, indices, axes=[1], starts=[0], ends=[1]), 'Long')
+        box_indices = cast(_slice(g, indices, axes=[1], starts=[2], ends=[3]), 'Long')
+
+        num_boxes = cast(_slice(g, g.op('Shape', multi_bboxes),
+                                axes=[0], starts=[1], ends=[2]), 'Long')
+        flat_indices = cast(g.op('Add',
+                                 cast(g.op('Mul', class_indices, num_boxes), 'Long'),
+                                 box_indices),
+                            'Long')
+
+        # Select bboxes.
+        out_bboxes = reshape(g, g.op('Gather', multi_bboxes_flat,
+                                     flat_indices, axis_i=0), [-1, 4])
+        out_scores = reshape(g, g.op('Gather', multi_scores_flat,
+                                     flat_indices, axis_i=0), [-1, 1])
+        class_indices = reshape(g, cast(class_indices, 'Float'), [-1, 1])
+
+        # Combine bboxes, scores and labels into a single tensor.
+        # This a workaround for a PyTorch bug (feature?),
+        # limiting ONNX operations to output only single tensor.
+        out_combined_bboxes = g.op('Concat', out_bboxes,
+                                   out_scores, class_indices, axis_i=1)
+
+        return out_combined_bboxes

--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -1,8 +1,8 @@
 import torch
 import torch.onnx.symbolic_helper as sym_help
 from torch.autograd import Function
-from torch.onnx.symbolic_opset10 import _slice
 from torch.onnx.symbolic_opset9 import reshape
+from torch.onnx.symbolic_opset10 import _slice
 
 from mmdet.core.utils.misc import topk
 from mmdet.ops.nms import nms_wrapper
@@ -31,11 +31,8 @@ def multiclass_nms(multi_bboxes,
         tuple: (bboxes, labels), tensors of shape (k, 5) and (k, 1). Labels
             are 0-based.
     """
-    combined_bboxes = GenericMulticlassNMS.apply(multi_bboxes,
-                                                 multi_scores,
-                                                 score_thr,
-                                                 nms_cfg,
-                                                 max_num,
+    combined_bboxes = GenericMulticlassNMS.apply(multi_bboxes, multi_scores,
+                                                 score_thr, nms_cfg, max_num,
                                                  score_factors)
     _, topk_inds = topk(combined_bboxes[:, 4].view(-1), max_num)
     combined_bboxes = combined_bboxes[topk_inds]
@@ -74,7 +71,7 @@ class GenericMulticlassNMS(Function):
                 _scores *= score_factors[cls_inds]
             cls_dets = torch.cat([_bboxes, _scores[:, None]], dim=1)
             cls_dets, _ = nms_op(cls_dets, **nms_op_cfg)
-            cls_labels = multi_bboxes.new_full((cls_dets.shape[0],),
+            cls_labels = multi_bboxes.new_full((cls_dets.shape[0], ),
                                                i,
                                                dtype=torch.long)
             bboxes.append(cls_dets)
@@ -87,17 +84,21 @@ class GenericMulticlassNMS(Function):
                 _, inds = bboxes[:, -1].topk(max_num, sorted=True)
                 bboxes = bboxes[inds]
                 labels = labels[inds]
-            combined_bboxes = torch.cat([bboxes,
-                                         labels.to(bboxes.dtype).unsqueeze(-1)],
-                                        dim=1)
+            combined_bboxes = torch.cat(
+                [bboxes, labels.to(bboxes.dtype).unsqueeze(-1)], dim=1)
         else:
             combined_bboxes = multi_bboxes.new_zeros((0, 6))
 
         return combined_bboxes
 
     @staticmethod
-    def symbolic(g, multi_bboxes, multi_scores, score_thr,
-                 nms_cfg, max_num=-1, score_factors=None):
+    def symbolic(g,
+                 multi_bboxes,
+                 multi_scores,
+                 score_thr,
+                 nms_cfg,
+                 max_num=-1,
+                 score_factors=None):
 
         def cast(x, dtype):
             return g.op('Cast', x, to_i=sym_help.cast_pytorch_to_onnx[dtype])
@@ -110,46 +111,56 @@ class GenericMulticlassNMS(Function):
         assert 0 <= iou_threshold <= 1
 
         # Transpose and reshape input tensors to fit ONNX NonMaxSuppression.
-        multi_bboxes = g.op('Transpose',
-                            reshape(g, multi_bboxes, [0, -1, 4]),
-                            perm_i=[1, 0, 2])
-        multi_scores = g.op('Unsqueeze',
-                            g.op('Transpose', multi_scores, perm_i=[1, 0]),
-                            axes_i=[1])
+        multi_bboxes = g.op(
+            'Transpose',
+            reshape(g, multi_bboxes, [0, -1, 4]),
+            perm_i=[1, 0, 2])
+        multi_scores = g.op(
+            'Unsqueeze',
+            g.op('Transpose', multi_scores, perm_i=[1, 0]),
+            axes_i=[1])
 
         assert max_num > 0
 
-        indices = g.op('NonMaxSuppression', multi_bboxes, multi_scores,
-                       g.op('Constant', value_t=torch.LongTensor([max_num])),
-                       g.op('Constant', value_t=torch.FloatTensor([iou_threshold])),
-                       g.op('Constant', value_t=torch.FloatTensor([score_thr])))
+        indices = g.op(
+            'NonMaxSuppression', multi_bboxes, multi_scores,
+            g.op('Constant', value_t=torch.LongTensor([max_num])),
+            g.op('Constant', value_t=torch.FloatTensor([iou_threshold])),
+            g.op('Constant', value_t=torch.FloatTensor([score_thr])))
 
         # Flatten bboxes and scores.
         multi_bboxes_flat = reshape(g, multi_bboxes, [-1, 4])
-        multi_scores_flat = reshape(g, multi_scores, [-1, ])
+        multi_scores_flat = reshape(g, multi_scores, [
+            -1,
+        ])
 
         # Flatten indices.
-        class_indices = cast(_slice(g, indices, axes=[1], starts=[0], ends=[1]), 'Long')
-        box_indices = cast(_slice(g, indices, axes=[1], starts=[2], ends=[3]), 'Long')
+        class_indices = cast(
+            _slice(g, indices, axes=[1], starts=[0], ends=[1]), 'Long')
+        box_indices = cast(
+            _slice(g, indices, axes=[1], starts=[2], ends=[3]), 'Long')
 
-        num_boxes = cast(_slice(g, g.op('Shape', multi_bboxes),
-                                axes=[0], starts=[1], ends=[2]), 'Long')
-        flat_indices = cast(g.op('Add',
-                                 cast(g.op('Mul', class_indices, num_boxes), 'Long'),
-                                 box_indices),
-                            'Long')
+        num_boxes = cast(
+            _slice(
+                g, g.op('Shape', multi_bboxes), axes=[0], starts=[1],
+                ends=[2]), 'Long')
+        flat_indices = cast(
+            g.op('Add', cast(g.op('Mul', class_indices, num_boxes), 'Long'),
+                 box_indices), 'Long')
 
         # Select bboxes.
-        out_bboxes = reshape(g, g.op('Gather', multi_bboxes_flat,
-                                     flat_indices, axis_i=0), [-1, 4])
-        out_scores = reshape(g, g.op('Gather', multi_scores_flat,
-                                     flat_indices, axis_i=0), [-1, 1])
+        out_bboxes = reshape(
+            g, g.op('Gather', multi_bboxes_flat, flat_indices, axis_i=0),
+            [-1, 4])
+        out_scores = reshape(
+            g, g.op('Gather', multi_scores_flat, flat_indices, axis_i=0),
+            [-1, 1])
         class_indices = reshape(g, cast(class_indices, 'Float'), [-1, 1])
 
         # Combine bboxes, scores and labels into a single tensor.
         # This a workaround for a PyTorch bug (feature?),
         # limiting ONNX operations to output only single tensor.
-        out_combined_bboxes = g.op('Concat', out_bboxes,
-                                   out_scores, class_indices, axis_i=1)
+        out_combined_bboxes = g.op(
+            'Concat', out_bboxes, out_scores, class_indices, axis_i=1)
 
         return out_combined_bboxes

--- a/mmdet/core/utils/misc.py
+++ b/mmdet/core/utils/misc.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import mmcv
 import numpy as np
+import torch
 from six.moves import map, zip
 
 
@@ -35,3 +36,91 @@ def unmap(data, count, inds, fill=0):
         ret = data.new_full(new_size, fill)
         ret[inds, :] = data
     return ret
+
+
+def arange(start=0, end=None, step=1, out=None, dtype=None,
+           layout=torch.strided, device=None, requires_grad=False):
+    if torch.onnx.is_in_onnx_export():
+        if end is None:
+            raise ValueError('End of range must be defined.')
+        assert out is None
+        assert layout == torch.strided
+
+        start_tensor = torch.as_tensor(start, dtype=torch.long, device=device)
+        end_tensor = torch.as_tensor(end, dtype=torch.long, device=device)
+        n = end_tensor - start_tensor
+
+        if isinstance(step, torch.Tensor):
+            n = (n + step - 1) // step
+
+        result = torch.ones(n, layout=layout, device=device)\
+            .nonzero().view(-1) + start_tensor
+
+        if isinstance(step, torch.Tensor) or step > 1:
+            result = result.view(-1, step)\
+                .index_select(1, torch.zeros(1, dtype=torch.long))\
+                .view(-1)
+
+        if dtype is not None:
+            result = result.to(dtype)
+
+        return result
+    else:
+        return torch.arange(start=start, end=end, step=step,
+                            out=out, dtype=dtype,
+                            layout=layout, device=device,
+                            requires_grad=requires_grad)
+
+
+def topk(x, k, dim=None, **kwargs):
+    from torch.onnx import operators, is_in_onnx_export
+
+    if dim is None:
+        dim = x.dim() - 1
+
+    if is_in_onnx_export():
+        n = operators.shape_as_tensor(x)[dim].unsqueeze(0)
+        if not isinstance(k, torch.Tensor):
+            k = torch.tensor([k], dtype=torch.long)
+        # Workaround for ONNXRuntime: convert values to int to get minimum.
+        n = torch.min(torch.cat((k, n), dim=0).int()).long()
+        # ONNX OpSet 10 does not support non-floating point input for TopK.
+        original_dtype = x.dtype
+        require_cast = original_dtype not in {torch.float16, torch.float32, torch.float64}
+        if require_cast:
+            x = x.to(torch.float32)
+        values, keep = torch.topk(x, n, dim=dim, **kwargs)
+        if require_cast:
+            values = values.to(original_dtype)
+    else:
+        values, keep = torch.topk(x, min(int(k), x.shape[dim]), dim=dim, **kwargs)
+    return values, keep
+
+
+def dummy_pad(x, padding):
+
+    class DummyPad(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x, padding):
+            return torch.nn.functional.pad(x, padding)
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            grad_input = None
+            if ctx.needs_input_grad[0]:
+                grad_output = grad_input
+            return grad_output, None
+
+        @staticmethod
+        def symbolic(g, x, padding):
+            return g.op("Identity", x)
+
+    return DummyPad.apply(x, padding)
+
+
+def to_numpy(x, dtype=np.float32):
+    if isinstance(x, torch.Tensor):
+        x = x.cpu().numpy()
+    assert isinstance(x, np.ndarray)
+    x = x.astype(dtype)
+    return x

--- a/mmdet/core/utils/misc.py
+++ b/mmdet/core/utils/misc.py
@@ -38,8 +38,14 @@ def unmap(data, count, inds, fill=0):
     return ret
 
 
-def arange(start=0, end=None, step=1, out=None, dtype=None,
-           layout=torch.strided, device=None, requires_grad=False):
+def arange(start=0,
+           end=None,
+           step=1,
+           out=None,
+           dtype=None,
+           layout=torch.strided,
+           device=None,
+           requires_grad=False):
     if torch.onnx.is_in_onnx_export():
         if end is None:
             raise ValueError('End of range must be defined.')
@@ -66,10 +72,15 @@ def arange(start=0, end=None, step=1, out=None, dtype=None,
 
         return result
     else:
-        return torch.arange(start=start, end=end, step=step,
-                            out=out, dtype=dtype,
-                            layout=layout, device=device,
-                            requires_grad=requires_grad)
+        return torch.arange(
+            start=start,
+            end=end,
+            step=step,
+            out=out,
+            dtype=dtype,
+            layout=layout,
+            device=device,
+            requires_grad=requires_grad)
 
 
 def topk(x, k, dim=None, **kwargs):
@@ -86,20 +97,24 @@ def topk(x, k, dim=None, **kwargs):
         n = torch.min(torch.cat((k, n), dim=0).int()).long()
         # ONNX OpSet 10 does not support non-floating point input for TopK.
         original_dtype = x.dtype
-        require_cast = original_dtype not in {torch.float16, torch.float32, torch.float64}
+        require_cast = original_dtype not in {
+            torch.float16, torch.float32, torch.float64
+        }
         if require_cast:
             x = x.to(torch.float32)
         values, keep = torch.topk(x, n, dim=dim, **kwargs)
         if require_cast:
             values = values.to(original_dtype)
     else:
-        values, keep = torch.topk(x, min(int(k), x.shape[dim]), dim=dim, **kwargs)
+        values, keep = torch.topk(
+            x, min(int(k), x.shape[dim]), dim=dim, **kwargs)
     return values, keep
 
 
 def dummy_pad(x, padding):
 
     class DummyPad(torch.autograd.Function):
+
         @staticmethod
         def forward(ctx, x, padding):
             return torch.nn.functional.pad(x, padding)

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -209,9 +209,8 @@ class AnchorHead(nn.Module):
                 size = operators.shape_as_tensor(cls_scores[i])[2:4]
             else:
                 size = cls_scores[i].size()[-2:]
-            level_anchors = self.anchor_generators[i].grid_anchors(size,
-                                                                   self.anchor_strides[i],
-                                                                   device=cls_scores[0].device)
+            level_anchors = self.anchor_generators[i].grid_anchors(
+                size, self.anchor_strides[i], device=cls_scores[0].device)
             mlvl_anchors.append(level_anchors)
 
         result_list = []

--- a/mmdet/models/anchor_heads/rpn_head.py
+++ b/mmdet/models/anchor_heads/rpn_head.py
@@ -5,8 +5,8 @@ from mmcv.cnn import normal_init
 
 from mmdet.core import delta2bbox, multiclass_nms
 from mmdet.core.utils.misc import topk
-from .anchor_head import AnchorHead
 from ..registry import HEADS
+from .anchor_head import AnchorHead
 
 
 @HEADS.register_module
@@ -88,15 +88,18 @@ class RPNHead(AnchorHead):
                 proposals = proposals[valid_inds, :]
                 scores = scores[valid_inds]
             proposals, _ = multiclass_nms(proposals, scores.unsqueeze(1), 0.0,
-                                          {'type': 'nms', 'iou_thr': cfg.nms_thr},
-                                          cfg.nms_post)
+                                          {
+                                              'type': 'nms',
+                                              'iou_thr': cfg.nms_thr
+                                          }, cfg.nms_post)
             mlvl_proposals.append(proposals)
         proposals = torch.cat(mlvl_proposals, 0)
         if cfg.nms_across_levels:
             proposals, _ = multiclass_nms(proposals[:, :4],
-                                          proposals[:, 4].unsqueeze(1), 0.0,
-                                          {'type': 'nms', 'iou_thr': cfg.nms_thr},
-                                          cfg.max_num)
+                                          proposals[:, 4].unsqueeze(1), 0.0, {
+                                              'type': 'nms',
+                                              'iou_thr': cfg.nms_thr
+                                          }, cfg.max_num)
         else:
             scores = proposals[:, 4]
             _, topk_inds = topk(scores, cfg.max_num)

--- a/mmdet/models/bbox_heads/bbox_head.py
+++ b/mmdet/models/bbox_heads/bbox_head.py
@@ -151,6 +151,11 @@ class BBoxHead(nn.Module):
                 bboxes[:, [0, 2]].clamp_(min=0, max=img_shape[1] - 1)
                 bboxes[:, [1, 3]].clamp_(min=0, max=img_shape[0] - 1)
 
+        # Remove data for background.
+        scores = scores[:, 1:]
+        if not self.reg_class_agnostic:
+            bboxes = bboxes[:, 4:]
+
         if rescale:
             if isinstance(scale_factor, float):
                 bboxes /= scale_factor
@@ -163,7 +168,6 @@ class BBoxHead(nn.Module):
             det_bboxes, det_labels = multiclass_nms(bboxes, scores,
                                                     cfg.score_thr, cfg.nms,
                                                     cfg.max_per_img)
-
             return det_bboxes, det_labels
 
     @force_fp32(apply_to=('bbox_preds', ))

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -4,7 +4,9 @@ from abc import ABCMeta, abstractmethod
 import mmcv
 import numpy as np
 import pycocotools.mask as maskUtils
+import torch
 import torch.nn as nn
+import torch.onnx
 
 from mmdet.core import auto_fp16, get_classes, tensor2imgs
 
@@ -86,6 +88,21 @@ class BaseDetector(nn.Module):
             return self.forward_train(img, img_meta, **kwargs)
         else:
             return self.forward_test(img, img_meta, **kwargs)
+
+    def forward_export(self, imgs):
+        from torch.onnx import operators
+        img_shape = operators.shape_as_tensor(imgs[0])
+        imgs_per_gpu = int(imgs[0].size(0))
+        assert imgs_per_gpu == 1
+        self.img_metas[0][0]['img_shape'] = img_shape[2:4]
+        return self.simple_test(imgs[0], self.img_metas[0], postprocess=False)
+
+    def export(self, img, img_meta, export_name='', **kwargs):
+        self.img_metas = img_meta
+        self.forward_backup = self.forward
+        self.forward = self.forward_export
+        torch.onnx.export(self, img, export_name, **kwargs)
+        self.forward = self.forward_backup
 
     def show_result(self, data, result, dataset=None, score_thr=0.3):
         if isinstance(result, tuple):

--- a/mmdet/models/detectors/test_mixins.py
+++ b/mmdet/models/detectors/test_mixins.py
@@ -115,12 +115,16 @@ class MaskTestMixin(object):
 
         if torch.onnx.is_in_onnx_export() and det_bboxes.shape[0] == 0:
             # If there are no detection there is nothing to do for a mask head.
-            # But during ONNX export we should run mask head for it to appear in the graph.
-            # So add one zero / dummy ROI that will be mapped to an Identity op in the graph.
+            # But during ONNX export we should run mask head
+            # for it to appear in the graph.
+            # So add one zero / dummy ROI that will be mapped
+            # to an Identity op in the graph.
             det_bboxes = dummy_pad(det_bboxes, (0, 0, 0, 1))
 
         if det_bboxes.shape[0] == 0:
-            det_masks = torch.empty([0, 0, 0], dtype=det_bboxes.dtype, device=det_bboxes.device)
+            det_masks = torch.empty([0, 0, 0],
+                                    dtype=det_bboxes.dtype,
+                                    device=det_bboxes.device)
         else:
             # if det_bboxes is rescaled to the original image size, we need to
             # rescale it back to the testing scale to obtain RoIs.

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -223,7 +223,12 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
 
         return losses
 
-    def simple_test(self, img, img_meta, proposals=None, rescale=False, postprocess=True):
+    def simple_test(self,
+                    img,
+                    img_meta,
+                    proposals=None,
+                    rescale=False,
+                    postprocess=True):
         """Test without augmentation."""
         assert self.with_bbox, "Bbox head must be implemented."
 
@@ -241,31 +246,45 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
                 x, img_meta, det_bboxes, det_labels, rescale=False)
 
         if postprocess:
-            return self.postprocess(det_bboxes, det_labels, det_masks, img_meta, rescale=rescale)
+            return self.postprocess(
+                det_bboxes, det_labels, det_masks, img_meta, rescale=rescale)
         else:
             if det_masks is None:
                 return det_bboxes, det_labels
             else:
                 return det_bboxes, det_labels, det_masks
 
-    def postprocess(self, det_bboxes, det_labels, det_masks, img_meta, rescale=False):
+    def postprocess(self,
+                    det_bboxes,
+                    det_labels,
+                    det_masks,
+                    img_meta,
+                    rescale=False):
         img_h, img_w = img_meta[0]['ori_shape'][:2]
         scale_factor = img_meta[0]['scale_factor']
         num_classes = self.bbox_head.num_classes
 
         if rescale:
-            # Keep original image resolution unchanged and scale bboxes and masks to it.
+            # Keep original image resolution unchanged
+            # and scale bboxes and masks to it.
             det_bboxes[:, :4] /= scale_factor
         else:
-            # Resize image to test resolution and keep bboxes and masks in test scale.
+            # Resize image to test resolution
+            # and keep bboxes and masks in test scale.
             img_h = np.round(img_h * scale_factor).astype(np.int32)
             img_w = np.round(img_w * scale_factor).astype(np.int32)
 
         bbox_results = bbox2result(det_bboxes, det_labels, num_classes)
         if self.with_mask:
-            segm_results = mask2result(det_bboxes, det_labels, det_masks, num_classes,
-                                       mask_thr_binary=self.test_cfg.rcnn.mask_thr_binary,
-                                       rle=True, full_size=True, img_size=(img_h, img_w))
+            segm_results = mask2result(
+                det_bboxes,
+                det_labels,
+                det_masks,
+                num_classes,
+                mask_thr_binary=self.test_cfg.rcnn.mask_thr_binary,
+                rle=True,
+                full_size=True,
+                img_size=(img_h, img_w))
             return bbox_results, segm_results
 
         return bbox_results

--- a/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/mask_heads/fcn_mask_head.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from torch.nn.modules.utils import _pair
 
 from mmdet.core import auto_fp16, force_fp32, mask_target
+from mmdet.core.utils.misc import arange
 from ..builder import build_loss
 from ..registry import HEADS
 from ..utils import ConvModule
@@ -122,60 +123,26 @@ class FCNMaskHead(nn.Module):
         loss['loss_mask'] = loss_mask
         return loss
 
-    def get_seg_masks(self, mask_pred, det_bboxes, det_labels, rcnn_test_cfg,
-                      ori_shape, scale_factor, rescale):
+    def get_seg_masks(self, det_masks, det_labels):
         """Get segmentation masks from mask_pred and bboxes.
 
         Args:
-            mask_pred (Tensor or ndarray): shape (n, #class+1, h, w).
+            det_masks (Tensor): shape (n, #class+1, h, w).
                 For single-scale testing, mask_pred is the direct output of
                 model, whose type is Tensor, while for multi-scale testing,
                 it will be converted to numpy array outside of this method.
-            det_bboxes (Tensor): shape (n, 4/5)
             det_labels (Tensor): shape (n, )
-            img_shape (Tensor): shape (3, )
-            rcnn_test_cfg (dict): rcnn testing config
-            ori_shape: original image size
 
         Returns:
-            list[list]: encoded masks
+            Tensor of shape (n, 1, h, w) with mask heatmaps for all detected boxes.
         """
-        if isinstance(mask_pred, torch.Tensor):
-            mask_pred = mask_pred.sigmoid().cpu().numpy()
-        assert isinstance(mask_pred, np.ndarray)
-        # when enabling mixed precision training, mask_pred may be float16
-        # numpy array
-        mask_pred = mask_pred.astype(np.float32)
 
-        cls_segms = [[] for _ in range(self.num_classes - 1)]
-        bboxes = det_bboxes.cpu().numpy()[:, :4]
-        labels = det_labels.cpu().numpy() + 1
-
-        if rescale:
-            img_h, img_w = ori_shape[:2]
+        if not self.class_agnostic:
+            class_indices = det_labels + 1
         else:
-            img_h = np.round(ori_shape[0] * scale_factor).astype(np.int32)
-            img_w = np.round(ori_shape[1] * scale_factor).astype(np.int32)
-            scale_factor = 1.0
+            class_indices = 0
 
-        for i in range(bboxes.shape[0]):
-            bbox = (bboxes[i, :] / scale_factor).astype(np.int32)
-            label = labels[i]
-            w = max(bbox[2] - bbox[0] + 1, 1)
-            h = max(bbox[3] - bbox[1] + 1, 1)
-
-            if not self.class_agnostic:
-                mask_pred_ = mask_pred[i, label, :, :]
-            else:
-                mask_pred_ = mask_pred[i, 0, :, :]
-            im_mask = np.zeros((img_h, img_w), dtype=np.uint8)
-
-            bbox_mask = mmcv.imresize(mask_pred_, (w, h))
-            bbox_mask = (bbox_mask > rcnn_test_cfg.mask_thr_binary).astype(
-                np.uint8)
-            im_mask[bbox[1]:bbox[1] + h, bbox[0]:bbox[0] + w] = bbox_mask
-            rle = mask_util.encode(
-                np.array(im_mask[:, :, np.newaxis], order='F'))[0]
-            cls_segms[label - 1].append(rle)
-
-        return cls_segms
+        segm_result = det_masks[arange(end=det_labels.shape[0],
+                                       device=det_masks.device),
+                                class_indices].sigmoid()
+        return segm_result

--- a/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/mask_heads/fcn_mask_head.py
@@ -1,6 +1,3 @@
-import mmcv
-import numpy as np
-import pycocotools.mask as mask_util
 import torch
 import torch.nn as nn
 from torch.nn.modules.utils import _pair
@@ -134,7 +131,8 @@ class FCNMaskHead(nn.Module):
             det_labels (Tensor): shape (n, )
 
         Returns:
-            Tensor of shape (n, 1, h, w) with mask heatmaps for all detected boxes.
+            Tensor of shape (n, 1, h, w) with mask heatmaps
+            for all detected boxes.
         """
 
         if not self.class_agnostic:
@@ -142,7 +140,7 @@ class FCNMaskHead(nn.Module):
         else:
             class_indices = 0
 
-        segm_result = det_masks[arange(end=det_labels.shape[0],
-                                       device=det_masks.device),
-                                class_indices].sigmoid()
+        segm_result = det_masks[arange(
+            end=det_labels.shape[0], device=det_masks.device
+        ), class_indices].sigmoid()
         return segm_result

--- a/mmdet/models/roi_extractors/single_level.py
+++ b/mmdet/models/roi_extractors/single_level.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 
 from mmdet import ops
 from mmdet.core import force_fp32
+from mmdet.core.utils.misc import topk
 from ..registry import ROI_EXTRACTORS
 
 
@@ -68,7 +69,8 @@ class SingleRoIExtractor(nn.Module):
         """
         scale = torch.sqrt(
             (rois[:, 3] - rois[:, 1] + 1) * (rois[:, 4] - rois[:, 2] + 1))
-        target_lvls = torch.floor(torch.log2(scale / self.finest_scale + 1e-6))
+        eps = torch.tensor([1e-6], dtype=scale.dtype, device=scale.device)
+        target_lvls = torch.floor(torch.log2(scale / self.finest_scale + eps))
         target_lvls = target_lvls.clamp(min=0, max=num_levels - 1).long()
         return target_lvls
 
@@ -86,22 +88,32 @@ class SingleRoIExtractor(nn.Module):
         new_rois = torch.stack((rois[:, 0], x1, y1, x2, y2), dim=-1)
         return new_rois
 
-    @force_fp32(apply_to=('feats', ), out_fp16=True)
+    @force_fp32(apply_to=('feats',), out_fp16=True)
     def forward(self, feats, rois, roi_scale_factor=None):
+        from torch.onnx import operators
+
         if len(feats) == 1:
             return self.roi_layers[0](feats[0], rois)
 
-        out_size = self.roi_layers[0].out_size
         num_levels = len(feats)
         target_lvls = self.map_roi_levels(rois, num_levels)
-        roi_feats = feats[0].new_zeros(
-            rois.size(0), self.out_channels, *out_size)
         if roi_scale_factor is not None:
             rois = self.roi_rescale(rois, roi_scale_factor)
-        for i in range(num_levels):
-            inds = target_lvls == i
-            if inds.any():
-                rois_ = rois[inds, :]
-                roi_feats_t = self.roi_layers[i](feats[i], rois_)
-                roi_feats[inds] = roi_feats_t
+
+        indices = []
+        roi_feats = []
+        for level, (feat, extractor) in enumerate(zip(feats, self.roi_layers)):
+            # Explicit casting to int is required for ONNXRuntime.
+            level_indices = torch.nonzero((target_lvls == level).int()).view(-1)
+            level_rois = rois[level_indices]
+            indices.append(level_indices)
+
+            level_feats = extractor(feat, level_rois)
+            roi_feats.append(level_feats)
+        # Concatenate roi features from different pyramid levels
+        # and rearrange them to match original ROIs order.
+        indices = torch.cat(indices, dim=0)
+        k = operators.shape_as_tensor(indices)
+        _, indices = topk(indices, k, dim=0, largest=False)
+        roi_feats = torch.cat(roi_feats, dim=0)[indices]
         return roi_feats

--- a/mmdet/models/roi_extractors/single_level.py
+++ b/mmdet/models/roi_extractors/single_level.py
@@ -88,7 +88,7 @@ class SingleRoIExtractor(nn.Module):
         new_rois = torch.stack((rois[:, 0], x1, y1, x2, y2), dim=-1)
         return new_rois
 
-    @force_fp32(apply_to=('feats',), out_fp16=True)
+    @force_fp32(apply_to=('feats', ), out_fp16=True)
     def forward(self, feats, rois, roi_scale_factor=None):
         from torch.onnx import operators
 
@@ -104,7 +104,8 @@ class SingleRoIExtractor(nn.Module):
         roi_feats = []
         for level, (feat, extractor) in enumerate(zip(feats, self.roi_layers)):
             # Explicit casting to int is required for ONNXRuntime.
-            level_indices = torch.nonzero((target_lvls == level).int()).view(-1)
+            level_indices = torch.nonzero(
+                (target_lvls == level).int()).view(-1)
             level_rois = rois[level_indices]
             indices.append(level_indices)
 

--- a/mmdet/ops/roi_align/roi_align.py
+++ b/mmdet/ops/roi_align/roi_align.py
@@ -1,7 +1,10 @@
 import torch.nn as nn
+import torch.onnx.symbolic_helper as sym_help
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.nn.modules.utils import _pair
+from torch.onnx.symbolic_opset10 import _slice
+from torch.onnx.symbolic_opset9 import reshape
 
 from . import roi_align_cuda
 
@@ -22,8 +25,9 @@ class RoIAlignFunction(Function):
 
         output = features.new_zeros(num_rois, num_channels, out_h, out_w)
         if features.is_cuda:
-            roi_align_cuda.forward(features, rois, out_h, out_w, spatial_scale,
-                                   sample_num, output)
+            if rois.numel() > 0:
+                roi_align_cuda.forward(features, rois, out_h, out_w, spatial_scale,
+                                       sample_num, output)
         else:
             raise NotImplementedError
 
@@ -50,7 +54,20 @@ class RoIAlignFunction(Function):
                                     out_w, spatial_scale, sample_num,
                                     grad_input)
 
-        return grad_input, grad_rois, None, None, None
+        return grad_input, grad_rois, None, None, None, None
+
+    @staticmethod
+    def symbolic(g, features, rois, out_size, spatial_scale, sample_num=0):
+        batch_indices = reshape(g,
+                                g.op('Cast',
+                                     _slice(g, rois, axes=[1], starts=[0], ends=[1]),
+                                     to_i=sym_help.cast_pytorch_to_onnx['Long']),
+                                [-1])
+        bboxes = _slice(g, rois, axes=[1], starts=[1], ends=[5])
+        out_h, out_w = _pair(out_size)
+        return g.op('RoiAlign', features, bboxes, batch_indices,
+                    output_height_i=out_h, output_width_i=out_w,
+                    sampling_ratio_i=sample_num, spatial_scale_f=spatial_scale)
 
 
 roi_align = RoIAlignFunction.apply

--- a/tools/export.py
+++ b/tools/export.py
@@ -1,0 +1,146 @@
+import argparse
+
+import numpy as np
+import onnx
+import torch
+import torch.onnx.symbolic_helper as sym_help
+from mmcv.parallel import collate, scatter
+from torch.onnx.symbolic_helper import parse_args, _unimplemented
+from torch.onnx.symbolic_registry import register_op
+
+from mmdet.apis import init_detector
+from mmdet.apis.inference import LoadImage
+from mmdet.datasets.pipelines import Compose
+
+
+@parse_args('v', 'v', 'v', 'v', 'none')
+def addcmul_symbolic(g, self, tensor1, tensor2, value=1, out=None):
+    from torch.onnx.symbolic_opset9 import add, mul
+
+    if out is not None:
+        _unimplemented("addcmul", "Out parameter is not supported for addcmul")
+
+    x = mul(g, tensor1, tensor2)
+    value = sym_help._maybe_get_scalar(value)
+    if sym_help._scalar(value) != 1:
+        value = sym_help._if_scalar_type_as(g, value, x)
+        if not sym_help._is_value(value):
+            value = g.op("Constant", value_t=torch.tensor(value, dtype=torch.float32))
+        x = mul(g, x, value)
+    return add(g, self, x)
+
+
+def view_as_symbolic(g, self, other):
+    from torch.onnx.symbolic_opset9 import reshape_as
+    return reshape_as(g, self, other)
+
+
+@parse_args('v', 'v', 'i', 'i', 'i', 'none')
+def topk_symbolic(g, self, k, dim, largest, sorted, out=None):
+    def reverse(x):
+        from torch.onnx.symbolic_opset9 import reshape, transpose, size
+
+        y = transpose(g, x, 0, dim)
+        shape = g.op("Shape", y)
+        y = reshape(g, y, [0, 1, -1])
+        n = size(g, y, g.op("Constant", value_t=torch.LongTensor([0])))
+        y = g.op("ReverseSequence", y, n, batch_axis_i=1, time_axis_i=0)
+        y = reshape(g, y, shape)
+        y = transpose(g, y, 0, dim)
+        return y
+
+    if out is not None:
+        _unimplemented("TopK", "Out parameter is not supported for topk")
+    k = sym_help._maybe_get_const(k, 'i')
+    if not sym_help._is_value(k):
+        k = g.op("Constant", value_t=torch.tensor(k, dtype=torch.int64))
+    from torch.onnx.symbolic_opset9 import unsqueeze
+    k = unsqueeze(g, k, 0)
+    top_values, top_indices = g.op("TopK", self, k, axis_i=dim, outputs=2)
+    if not largest:
+        top_values = reverse(top_values)
+        top_indices = reverse(top_indices)
+    return top_values, top_indices
+
+
+def export(model, img, export_name="/tmp/model.onnx", verbose=False, strip_doc_string=False):
+    register_op("addcmul", addcmul_symbolic, "", 10)
+    register_op("view_as", view_as_symbolic, "", 10)
+    register_op("topk", topk_symbolic, "", 10)
+
+    cfg = model.cfg
+    device = next(model.parameters()).device  # model device
+    # build the data pipeline
+    test_pipeline = [LoadImage()] + cfg.data.test.pipeline[1:]
+    test_pipeline = Compose(test_pipeline)
+    # prepare data
+    data = dict(img=img)
+    data = test_pipeline(data)
+    data = scatter(collate([data], samples_per_gpu=1), [device])[0]
+    # forward the model
+    output_names = ["boxes", "labels"]
+    dynamic_axes = {"image": {2: "height", 3: "width"},
+                    "boxes": {0: "objects_num"},
+                    "labels": {0: "objects_num"}}
+    if model.with_mask:
+        output_names.append("masks")
+        dynamic_axes["masks"] = {0: "objects_num"}
+    with torch.no_grad():
+        model.export(**data, export_name=export_name, verbose=verbose,
+                     opset_version=10, strip_doc_string=strip_doc_string,
+                     operator_export_type=torch.onnx.OperatorExportTypes.ONNX,
+                     input_names=["image"],
+                     output_names=output_names,
+                     dynamic_axes=dynamic_axes
+                     )
+
+
+def check_onnx_model(export_name):
+    model = onnx.load(export_name)
+
+    try:
+        onnx.checker.check_model(model)
+        print("ONNX check passed.")
+    except onnx.onnx_cpp2py_export.checker.ValidationError as ex:
+        print("ONNX check failed.")
+        print(ex)
+
+
+def add_node_names(export_name):
+    model = onnx.load(export_name)
+    for n in model.graph.node:
+        n.name = "in: " + ";".join([i for i in n.input]) + ". " + \
+                 "out: " + ";".join([i for i in n.output])
+    onnx.save(model, export_name)
+
+
+def main(args):
+    model = init_detector(args.config, args.checkpoint, device="cpu")
+    model.eval().cuda()
+    torch.set_default_tensor_type(torch.FloatTensor)
+
+    image = np.zeros((128, 128, 3), dtype=np.uint8)
+    with torch.no_grad():
+        export(model, image, export_name=args.model)
+
+    add_node_names(args.model)
+
+    if args.check:
+        check_onnx_model(args.model)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Export model to ONNX")
+    parser.add_argument("config", help="test config file path")
+    parser.add_argument("model", help="path to output onnx model file")
+    parser.add_argument("--check", action="store_true",
+                        help="check that resulting onnx model is valid")
+    parser.add_argument("--checkpoint", default=None, type=str,
+                        help="path to file with model's weights")
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    main(args)

--- a/tools/test_onnx.py
+++ b/tools/test_onnx.py
@@ -1,0 +1,219 @@
+import argparse
+
+import mmcv
+import numpy as np
+import onnx
+import onnxruntime
+import torch
+from onnx import shape_inference, helper
+from onnx.utils import polish_model
+
+from mmdet.core import coco_eval, results2json
+from mmdet.core.bbox.transforms import bbox2result
+from mmdet.core.mask.transforms import mask2result
+from mmdet.datasets import build_dataloader, build_dataset
+from mmdet.models import build_detector
+
+
+def postprocess(result, img_meta, num_classes=81, rescale=True):
+    det_bboxes = result['boxes']
+    det_labels = result['labels']
+    det_masks = result.get('masks', None)
+
+    if rescale:
+        img_h, img_w = img_meta[0]['ori_shape'][:2]
+        scale = img_meta[0]['scale_factor']
+        det_bboxes[:, :4] /= scale
+    else:
+        img_h, img_w = img_meta[0]['img_shape'][:2]
+
+    det_bboxes[:, 0:4:2] = np.clip(det_bboxes[:, 0:4:2], 0, img_w - 1)
+    det_bboxes[:, 1:4:2] = np.clip(det_bboxes[:, 1:4:2], 0, img_h - 1)
+
+    bbox_results = bbox2result(det_bboxes, det_labels, num_classes)
+    if det_masks is not None:
+        segm_results = mask2result(det_bboxes, det_labels, det_masks, num_classes,
+                                   mask_thr_binary=0.5,
+                                   rle=True, full_size=True, img_size=(img_h, img_w))
+        return bbox_results, segm_results
+    return bbox_results
+
+
+def empty_result(num_classes=81, with_mask=False):
+    bbox_results = [np.zeros((0, 5), dtype=np.float32)
+                    for _ in range(num_classes - 1)]
+    if with_mask:
+        segm_results = [[] for _ in range(num_classes - 1)]
+        return bbox_results, segm_results
+    return bbox_results
+
+
+class ONNXModel(object):
+    def __init__(self, model_file_path, cfg=None, classes=None):
+        self.device = onnxruntime.get_device()
+        self.model = onnx.load(model_file_path)
+        self.model = polish_model(self.model)
+        self.classes = classes
+        self.pt_model = None
+        if cfg is not None:
+            self.pt_model = build_detector(cfg.model, train_cfg=None,
+                                           test_cfg=cfg.test_cfg)
+            if classes is not None:
+                self.pt_model.CLASSES = classes
+
+        self.sess_options = onnxruntime.SessionOptions()
+        self.sess_options.enable_sequential_execution = True
+        self.sess_options.set_graph_optimization_level(2)
+        self.sess_options.enable_profiling = False
+
+        self.session = onnxruntime.InferenceSession(self.model.SerializeToString(),
+                                                    self.sess_options)
+        self.input_names = []
+        self.output_names = []
+        for input in self.session.get_inputs():
+            self.input_names.append(input.name)
+        for output in self.session.get_outputs():
+            self.output_names.append(output.name)
+
+    def show(self, data, result, dataset=None, score_thr=0.3):
+        if self.pt_model is not None:
+            self.pt_model.show_result(data, result, dataset=dataset,
+                                      score_thr=score_thr)
+
+    def add_output(self, output_ids):
+        if not isinstance(output_ids, (tuple, list, set)):
+            output_ids = [output_ids, ]
+
+        inferred_model = shape_inference.infer_shapes(self.model)
+        all_blobs_info = {value_info.name: value_info
+                          for value_info in inferred_model.graph.value_info}
+
+        extra_outputs = []
+        for output_id in output_ids:
+            value_info = all_blobs_info.get(output_id, None)
+            if value_info is None:
+                print('WARNING! No blob with name {}'.format(output_id))
+                extra_outputs.append(helper.make_empty_tensor_value_info(output_id))
+            else:
+                extra_outputs.append(value_info)
+
+        self.model.graph.output.extend(extra_outputs)
+        self.output_names.extend(output_ids)
+        self.session = onnxruntime.InferenceSession(self.model.SerializeToString(),
+                                                    self.sess_options)
+
+    def __call__(self, inputs, *args, **kwargs):
+        if isinstance(inputs, (list, tuple)):
+            inputs = dict(zip(self.input_names, inputs))
+        outputs = self.session.run(None, inputs, *args, **kwargs)
+        outputs = dict(zip(self.output_names, outputs))
+        return outputs
+
+
+def main(args):
+    cfg = mmcv.Config.fromfile(args.config)
+    cfg.model.pretrained = None
+    cfg.data.test.test_mode = True
+
+    dataset = build_dataset(cfg.data.test)
+    data_loader = build_dataloader(
+        dataset,
+        imgs_per_gpu=1,
+        workers_per_gpu=0,
+        dist=False,
+        shuffle=False)
+
+    if args.model is None:
+        print('No model file provided. Trying to load evaluation results.')
+        results = mmcv.load(args.out)
+    else:
+        dataset = data_loader.dataset
+        classes_num = len(dataset.CLASSES)
+
+        model = ONNXModel(args.model, cfg=cfg, classes=dataset.CLASSES)
+        run_opts = onnxruntime.RunOptions()
+
+        results = []
+        prog_bar = mmcv.ProgressBar(len(dataset))
+
+        for i, data in enumerate(data_loader):
+            with torch.no_grad():
+                im_data = data['img'][0].cpu().numpy()
+                try:
+                    result = model([im_data], run_options=run_opts)
+                    result = postprocess(result, data['img_meta'][0].data[0],
+                                         num_classes=classes_num,
+                                         rescale=not args.show)
+                except Exception as ex:
+                    result = empty_result(num_classes=classes_num,
+                                          with_mask=model.pt_model.with_mask)
+            results.append(result)
+
+            if args.show:
+                model.show(data, result, score_thr=args.score_thr)
+
+            batch_size = data['img'][0].size(0)
+            for _ in range(batch_size):
+                prog_bar.update()
+
+        print('')
+        session_profile_path = model.session.end_profiling()
+        if session_profile_path:
+            print('Session profile saved to {}'.format(session_profile_path))
+        print('Writing results to {}'.format(args.out))
+        mmcv.dump(results, args.out)
+
+    eval_types = args.eval
+    if eval_types:
+        print('Starting evaluate {}'.format(' and '.join(eval_types)))
+        if eval_types == ['proposal_fast']:
+            result_file = args.out
+            coco_eval(result_file, eval_types, dataset.coco)
+        else:
+            if not isinstance(results[0], dict):
+                result_files = results2json(dataset, results, args.out)
+                coco_eval(result_files, eval_types, dataset.coco)
+            else:
+                for name in results[0]:
+                    print('\nEvaluating {}'.format(name))
+                    outputs_ = [out[name] for out in results]
+                    result_file = args.out + '.{}'.format(name)
+                    result_files = results2json(dataset, outputs_,
+                                                result_file)
+                    coco_eval(result_files, eval_types, dataset.coco)
+
+    # Save predictions in the COCO json format
+    if args.json_out:
+        if not isinstance(results[0], dict):
+            results2json(dataset, results, args.json_out)
+        else:
+            for name in results[0]:
+                outputs_ = [out[name] for out in results]
+                result_file = args.json_out + '.{}'.format(name)
+                results2json(dataset, outputs_, result_file)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Test ONNX model')
+    parser.add_argument('config', help='path to configuration file')
+    parser.add_argument('--model', type=str,
+                        help='path to onnx model file. If not set, try to load results'
+                             'from the file specified by `--out` key.')
+    parser.add_argument('--out', type=str,
+                        help='path to file with inference results')
+    parser.add_argument('--json_out', type=str,
+                        help='output result file name without extension')
+    parser.add_argument('--eval', type=str, nargs='+',
+                        choices=['proposal', 'proposal_fast', 'bbox', 'segm', 'keypoints'],
+                        help='eval types')
+    parser.add_argument('--show', action='store_true',
+                        help='visualize results')
+    parser.add_argument('--score_thr', type=float, default=0.3,
+                        help='show only detection with confidence larger than threshold')
+    args = parser.parse_args()
+    return args
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
Since primitives like ROIAlign and NonMaxSuppression required for most of the detection/instance segmentation models from this repository were added to ONNX opset 10 it is now possible to export models to ONNX format in and end-to-end fashion. This PR adds export support for Faster/Mask R-CNN models. For other models some more actions might be required, but, as I understand, this is also true for the current effort of adding ONNX support (#1082).

The code was tested in PyTorch 1.2, ONNX 1.5.0 and ONNXRuntime 0.5.0.

Some outlines of the changes and notes:

* ROIAlign and NMS as long as `torch.topk`, `torch.arange` and `torch.clamp` functions were wrapped to enable or ease their export.

* As long as there are some differences in implementation of ROIAlign and NMS operations in mmdetection and ONNX, models are not equivalent. Though with the export and test code provided in this PR I've obtained the same test metrics numbers with ONNX model running in ONNXRuntime as for corresponding mmdetection models with torchvision version of ROIAlign.

* Unfortunately PyTorch's export mechanism does not support list/tuple inputs/outputs to the model. That's why some changes were introduced to a common testing pipeline (see `simple_test` in `mmdet/models/detectors/two_stage.py`). It's proposed to split postprocessing procedure into two stages: first one does transformations storing results in `Tensor`s, second (optional) scales data to the original image's size and rearranges outputs to a "detections per-class" format. In the end, first postprocessing stage will appear as part of ONNX graph, while the second won't be there. Described changes were made for Faster/Mask R-CNN models and should be implemented for some other models that have some specific logic in these parts.

* Detectors get images and their meta-data as an input. While from ONNX export perspective images are Ok, meta-data is not. Two obvious solutions here would be:
  1. To pass some portions of meta-data in a form of `Tensor`s to the exported model. This is, for example, how Caffe models from `py-faster-rcnn` were used to be designed: they had an extra `im_info` tensor input, containing original image size and scaling factors used for pre-processing.
  1. Get rid of this extra information at all, cause it's mostly required during training, rather than testing. This option is implemented in this PR. Input image `Tensor` shape is used instead of the original image size and scaling factors. Those differ only because of padding and the difference for batch size of one is neglidgable. I saw no effect on Mask R-CNN models' test quality metrics with this change introduced.

@hellock please take a look and say what you think about all of this stuff. 
