### PR TITLE
Fix #1223

### DIFF
--- a/mmdet/datasets/loader/sampler.py
+++ b/mmdet/datasets/loader/sampler.py
@@ -132,8 +132,12 @@ class DistributedGroupSampler(Sampler):
                     math.ceil(
                         size * 1.0 / self.samples_per_gpu / self.num_replicas)
                 ) * self.samples_per_gpu * self.num_replicas - len(indice)
-                indice += indice[:extra]
-                indices += indice
+                # pad indice
+                tmp = indice.copy()
+                for _ in range(extra//size):
+                    indice.extend(tmp)
+                indice.extend(tmp[:extra%size])
+                indices.extend(indice)
 
         assert len(indices) == self.total_size
 

--- a/mmdet/datasets/loader/sampler.py
+++ b/mmdet/datasets/loader/sampler.py
@@ -134,9 +134,9 @@ class DistributedGroupSampler(Sampler):
                 ) * self.samples_per_gpu * self.num_replicas - len(indice)
                 # pad indice
                 tmp = indice.copy()
-                for _ in range(extra//size):
+                for _ in range(extra // size):
                     indice.extend(tmp)
-                indice.extend(tmp[:extra%size])
+                indice.extend(tmp[:extra % size])
                 indices.extend(indice)
 
         assert len(indices) == self.total_size


### PR DESCRIPTION
#1223  is caused by extra > len(indice), so I add a loop to properly pad the indice list. I also changed the list concatenation from ```+=``` to ```.extend```.