### PR TITLE
Add two doctest examples for resnet and resnext

### DIFF
--- a/mmdet/models/backbones/resnet.py
+++ b/mmdet/models/backbones/resnet.py
@@ -352,6 +352,20 @@ class ResNet(nn.Module):
             memory while slowing down the training speed.
         zero_init_residual (bool): whether to use zero init for last norm layer
             in resblocks to let them behave as identity.
+
+    Example:
+        >>> from mmdet.models.backbones.resnet import *  # NOQA
+        >>> import torch
+        >>> self = ResNet(depth=18)
+        >>> self.eval()
+        >>> inputs = torch.rand(1, 3, 32, 32)
+        >>> level_outputs = self.forward(inputs)
+        >>> for level_out in level_outputs:
+        ...     print(tuple(level_out.shape))
+        (1, 64, 8, 8)
+        (1, 128, 4, 4)
+        (1, 256, 2, 2)
+        (1, 512, 1, 1)
     """
 
     arch_settings = {

--- a/mmdet/models/backbones/resnet.py
+++ b/mmdet/models/backbones/resnet.py
@@ -354,7 +354,7 @@ class ResNet(nn.Module):
             in resblocks to let them behave as identity.
 
     Example:
-        >>> from mmdet.models.backbones.resnet import *  # NOQA
+        >>> from mmdet.models import ResNet
         >>> import torch
         >>> self = ResNet(depth=18)
         >>> self.eval()

--- a/mmdet/models/backbones/resnext.py
+++ b/mmdet/models/backbones/resnext.py
@@ -179,6 +179,19 @@ class ResNeXt(ResNet):
             memory while slowing down the training speed.
         zero_init_residual (bool): whether to use zero init for last norm layer
             in resblocks to let them behave as identity.
+
+    Example:
+        >>> from mmdet.models.backbones.resnext import *  # NOQA
+        >>> self = ResNeXt(depth=50)
+        >>> self.eval()
+        >>> inputs = torch.rand(1, 3, 32, 32)
+        >>> level_outputs = self.forward(inputs)
+        >>> for level_out in level_outputs:
+        ...     print(tuple(level_out.shape))
+        (1, 256, 8, 8)
+        (1, 512, 4, 4)
+        (1, 1024, 2, 2)
+        (1, 2048, 1, 1)
     """
 
     arch_settings = {

--- a/mmdet/models/backbones/resnext.py
+++ b/mmdet/models/backbones/resnext.py
@@ -182,6 +182,7 @@ class ResNeXt(ResNet):
 
     Example:
         >>> from mmdet.models import ResNeXt
+        >>> import torch
         >>> self = ResNeXt(depth=50)
         >>> self.eval()
         >>> inputs = torch.rand(1, 3, 32, 32)

--- a/mmdet/models/backbones/resnext.py
+++ b/mmdet/models/backbones/resnext.py
@@ -181,7 +181,7 @@ class ResNeXt(ResNet):
             in resblocks to let them behave as identity.
 
     Example:
-        >>> from mmdet.models.backbones.resnext import *  # NOQA
+        >>> from mmdet.models import ResNeXt
         >>> self = ResNeXt(depth=50)
         >>> self.eval()
         >>> inputs = torch.rand(1, 3, 32, 32)


### PR DESCRIPTION
When I'm trying to learn a library it helps to be able to get into the code and start stepping through it.  Doctest examples help with this a lot. 

As a side note: you may want to consider using [xdoctest](https://github.com/Erotemic/xdoctest) instead of Python's builtin doctest module in CI testing. Full disclosure: I wrote xdoctest, so I may be biased, but I do believe it offers a better features and syntax and makes it easier to write and debug doctests in general. 