### PR TITLE
Enable doctests in CI with xdoctest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - yapf -r -d --style .style.yapf mmdet/ tools/ tests/
   - python setup.py check -m -s
   - python setup.py build_ext --inplace
-  - coverage run --source mmdet -m py.test tests -v --doctest-modules
+  - coverage run --source mmdet -m py.test -v --xdoctest-modules tests mmdet
 
 after_success:
   - coverage report

--- a/mmdet/models/bbox_heads/convfc_bbox_head.py
+++ b/mmdet/models/bbox_heads/convfc_bbox_head.py
@@ -7,7 +7,7 @@ from .bbox_head import BBoxHead
 
 @HEADS.register_module
 class ConvFCBBoxHead(BBoxHead):
-    """More general bbox head, with shared conv and fc layers and two optional
+    r"""More general bbox head, with shared conv and fc layers and two optional
     separated branches.
 
                                 /-> cls convs -> cls fcs -> cls

--- a/mmdet/models/bbox_heads/double_bbox_head.py
+++ b/mmdet/models/bbox_heads/double_bbox_head.py
@@ -71,7 +71,7 @@ class BasicResBlock(nn.Module):
 
 @HEADS.register_module
 class DoubleConvFCBBoxHead(BBoxHead):
-    """Bbox head used in Double-Head R-CNN
+    r"""Bbox head used in Double-Head R-CNN
 
                                       /-> cls
                   /-> shared convs ->

--- a/mmdet/models/losses/utils.py
+++ b/mmdet/models/losses/utils.py
@@ -64,6 +64,7 @@ def weighted_loss(loss_func):
 
     :Example:
 
+    >>> import torch
     >>> @weighted_loss
     >>> def l1_loss(pred, target):
     >>>     return (pred - target).abs()

--- a/mmdet/models/mask_heads/fused_semantic_head.py
+++ b/mmdet/models/mask_heads/fused_semantic_head.py
@@ -9,7 +9,7 @@ from ..utils import ConvModule
 
 @HEADS.register_module
 class FusedSemanticHead(nn.Module):
-    """Multi-level fused semantic segmentation head.
+    r"""Multi-level fused semantic segmentation head.
 
     in_1 -> 1x1 conv ---
                         |

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = --xdoctest --xdoctest-style=auto
+norecursedirs = .git ignore build __pycache__ data docker docs
+
+filterwarnings= default
+                ignore:.*No cfgstr given in Cacher constructor or call.*:Warning
+                ignore:.*Define the __nice__ method for.*:Warning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = --xdoctest --xdoctest-style=auto
-norecursedirs = .git ignore build __pycache__ data docker docs
+norecursedirs = .git ignore build __pycache__ data docker docs .eggs
 
 filterwarnings= default
                 ignore:.*No cfgstr given in Cacher constructor or call.*:Warning

--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ if __name__ == '__main__':
         ],
         license='Apache License 2.0',
         setup_requires=['pytest-runner', 'cython', 'numpy'],
-        tests_require=['pytest'],
+        tests_require=['pytest', 'xdoctest'],
         install_requires=get_requirements(),
         ext_modules=[
             make_cython_ext(

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,4 @@ flake8
 yapf
 pytest-cov
 codecov
+xdoctest >= 0.10.0


### PR DESCRIPTION
This PR enables doctests in in pytest. Instead of using the builtin doctest module I used xdoctest, which has pytest integration by default. I also mentioned [xdoctest](https://github.com/Erotemic/xdoctest)  in #1474.

The main benefit of xdoctest over buildin-doctest is you can prefix normal code with `>>> ` and the doctest will just work. In the old-style you would have to prefix certain lines with `>>> ` and other lines with `... `. Hopefully this helps the maintainers write more doctests, which can be both illustrative for newcomers to this library and practical for ensuring the integrity of the library. 

You may have noticed that the doctest in `mmdetection/mmdet/models/losses/utils.py` wasn't working. This is because the builtin doctest module has a very restrictive syntax (which prevented the l1_loss function from being defined) due to fundamental flaws in its parser, however xdoctest (which is a drop-in replacement) does not have this issue. I did have to import torch to make this test work, but if all goes well you should see an increase in the number of test run on the CI with this PR. 

