### PR TITLE
Fix issues with default 'img_prefix' value set to None when training

### DIFF
--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -37,7 +37,7 @@ class CustomDataset(Dataset):
                  ann_file,
                  pipeline,
                  data_root=None,
-                 img_prefix=None,
+                 img_prefix='',
                  seg_prefix=None,
                  proposal_file=None,
                  test_mode=False):

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -15,8 +15,11 @@ class LoadImageFromFile(object):
         self.to_float32 = to_float32
 
     def __call__(self, results):
-        filename = osp.join(results['img_prefix'],
-                            results['img_info']['filename'])
+        if results['img_prefix'] is not None:
+            filename = osp.join(results['img_prefix'],
+                                results['img_info']['filename'])
+        else:
+            filename = results['img_info']['filename']
         img = mmcv.imread(filename)
         if self.to_float32:
             img = img.astype(np.float32)
@@ -52,8 +55,11 @@ class LoadAnnotations(object):
         ann_info = results['ann_info']
         results['gt_bboxes'] = ann_info['bboxes']
         if len(results['gt_bboxes']) == 0 and self.skip_img_without_anno:
-            file_path = osp.join(results['img_prefix'],
-                                 results['img_info']['filename'])
+            if results['img_prefix'] is not None:
+                file_path = osp.join(results['img_prefix'],
+                                     results['img_info']['filename'])
+            else:
+                file_path = results['img_info']['filename']
             warnings.warn(
                 'Skip the image "{}" that has no valid gt bbox'.format(
                     file_path))


### PR DESCRIPTION
CustomDataset sets this img_prefix variable to None unless set. Without this fix, when using CustomDataset with it's defaults I get the below error. An alternative fix would be to, in the CustomDataset init function,  set the default value to empty string '' instead of None



  what():  TypeError: Caught TypeError in DataLoader worker process 0.
Original Traceback (most recent call last):
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/torch/utils/data/_utils/worker.py", line 178, in _worker_loop
    data = fetcher.fetch(index)
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/torch/utils/data/_utils/fetch.py", line 44, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/mmdet/datasets/custom.py", line 128, in __getitem__
    data = self.prepare_train_img(idx)
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/mmdet/datasets/custom.py", line 141, in prepare_train_img
    return self.pipeline(results)
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/mmdet/datasets/pipelines/compose.py", line 24, in __call__
    data = t(data)
  File "/run/media/matt/Storage/Dev/viame/build/install/lib/python3.6/site-packages/mmdet/datasets/pipelines/loading.py", line 22, in __call__
    results['img_info']['filename'])
  File "/home/matt/Dev/python3/lib/python3.6/posixpath.py", line 80, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
