### PR TITLE
Pass img_meta as list to simple_test

### DIFF
--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -90,7 +90,7 @@ class BaseDetector(nn.Module):
         assert imgs_per_gpu == 1
 
         if num_augs == 1:
-            return self.simple_test(imgs[0], img_metas[0], **kwargs)
+            return self.simple_test(imgs[0], img_metas[0:1], **kwargs)
         else:
             return self.aug_test(imgs, img_metas, **kwargs)
 

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -75,6 +75,15 @@ class BaseDetector(nn.Module):
             logger.info('load model from: {}'.format(pretrained))
 
     def forward_test(self, imgs, img_metas, **kwargs):
+        """
+        Args:
+            imgs (List[Tensor]): the outer list indicates test-time
+                augmentations and inner Tensor should have a shape NxCxHxW,
+                which contains all images in the batch.
+            img_meta (List[List[dict]]): the outer list indicates test-time
+                augs (multiscale, flip, etc.) and the inner list indicates
+                images in a batch
+        """
         for var, name in [(imgs, 'imgs'), (img_metas, 'img_metas')]:
             if not isinstance(var, list):
                 raise TypeError('{} must be a list, but got {}'.format(
@@ -90,12 +99,20 @@ class BaseDetector(nn.Module):
         assert imgs_per_gpu == 1
 
         if num_augs == 1:
-            return self.simple_test(imgs[0], img_metas[0:1], **kwargs)
+            return self.simple_test(imgs[0], img_metas[0], **kwargs)
         else:
             return self.aug_test(imgs, img_metas, **kwargs)
 
     @auto_fp16(apply_to=('img', ))
     def forward(self, img, img_meta, return_loss=True, **kwargs):
+        """
+        Calls either forward_train or forward_test depending on whether
+        return_loss=True. Note this setting will change the expected inputs.
+        When `return_loss=False`, img and img_meta are single-nested (i.e.
+        Tensor and List[dict]), and when `resturn_loss=True`, img and img_meta
+        should be double nested (i.e.  List[Tensor], List[List[dict]]), with
+        the outer list indicating test time augmentations.
+        """
         if return_loss:
             return self.forward_train(img, img_meta, **kwargs)
         else:

--- a/mmdet/models/detectors/fast_rcnn.py
+++ b/mmdet/models/detectors/fast_rcnn.py
@@ -44,7 +44,7 @@ class FastRCNN(TwoStageDetector):
         assert imgs_per_gpu == 1
 
         if num_augs == 1:
-            return self.simple_test(imgs[0], img_metas[0], proposals[0],
+            return self.simple_test(imgs[0], img_metas[0:1], proposals[0],
                                     **kwargs)
         else:
             return self.aug_test(imgs, img_metas, proposals, **kwargs)

--- a/mmdet/models/detectors/fast_rcnn.py
+++ b/mmdet/models/detectors/fast_rcnn.py
@@ -29,6 +29,17 @@ class FastRCNN(TwoStageDetector):
             pretrained=pretrained)
 
     def forward_test(self, imgs, img_metas, proposals, **kwargs):
+        """
+        Args:
+            imgs (List[Tensor]): the outer list indicates test-time
+                augmentations and inner Tensor should have a shape NxCxHxW,
+                which contains all images in the batch.
+            img_meta (List[List[dict]]): the outer list indicates test-time
+                augs (multiscale, flip, etc.) and the inner list indicates
+                images in a batch
+            proposals (List[List[Tensor | None]]): predefiend proposals for
+                each test-time augmentation and each item.
+        """
         for var, name in [(imgs, 'imgs'), (img_metas, 'img_metas')]:
             if not isinstance(var, list):
                 raise TypeError('{} must be a list, but got {}'.format(
@@ -44,7 +55,7 @@ class FastRCNN(TwoStageDetector):
         assert imgs_per_gpu == 1
 
         if num_augs == 1:
-            return self.simple_test(imgs[0], img_metas[0:1], proposals[0],
+            return self.simple_test(imgs[0], img_metas[0], proposals[0],
                                     **kwargs)
         else:
             return self.aug_test(imgs, img_metas, proposals, **kwargs)

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -76,7 +76,8 @@ def test_ssd300_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [[one_meta]], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]],
+                                      return_loss=False)
             batch_results.append(result)
 
 
@@ -104,7 +105,8 @@ def test_rpn_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [[one_meta]], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]],
+                                      return_loss=False)
             batch_results.append(result)
 
 
@@ -138,7 +140,8 @@ def test_retina_ghm_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [[one_meta]], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]],
+                                      return_loss=False)
             batch_results.append(result)
 
     if torch.cuda.is_available():
@@ -160,7 +163,8 @@ def test_retina_ghm_forward():
             img_list = [g[None, :] for g in imgs]
             batch_results = []
             for one_img, one_meta in zip(img_list, img_metas):
-                result = detector.forward([one_img], [[one_meta]], return_loss=False)
+                result = detector.forward([one_img], [[one_meta]],
+                                          return_loss=False)
                 batch_results.append(result)
 
 

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,0 +1,224 @@
+import copy
+from os.path import dirname, exists, join
+
+import numpy as np
+import torch
+
+
+def _get_config_directory():
+    """ Find the predefined detector config directory """
+    try:
+        # Assume we are running in the source mmdetection repo
+        repo_dpath = dirname(dirname(__file__))
+    except NameError:
+        # For IPython development when this __file__ is not defined
+        import mmdet
+        repo_dpath = dirname(dirname(mmdet.__file__))
+    config_dpath = join(repo_dpath, 'configs')
+    if not exists(config_dpath):
+        raise Exception('Cannot find config path')
+    return config_dpath
+
+
+def _get_config_module(fname):
+    """
+    Load a configuration as a python module
+    """
+    from xdoctest.utils import import_module_from_path
+    config_dpath = _get_config_directory()
+    config_fpath = join(config_dpath, fname)
+    config_mod = import_module_from_path(config_fpath)
+    return config_mod
+
+
+def _get_detector_cfg(fname):
+    """
+    Grab configs necessary to create a detector. These are deep copied to allow
+    for safe modification of parameters without influencing other tests.
+    """
+    import mmcv
+    config = _get_config_module(fname)
+    model = copy.deepcopy(config.model)
+    train_cfg = mmcv.Config(copy.deepcopy(config.train_cfg))
+    test_cfg = mmcv.Config(copy.deepcopy(config.test_cfg))
+    return model, train_cfg, test_cfg
+
+
+def test_ssd300_forward():
+    model, train_cfg, test_cfg = _get_detector_cfg('ssd300_coco.py')
+    model['pretrained'] = None
+
+    from mmdet.models import build_detector
+    detector = build_detector(model, train_cfg=train_cfg, test_cfg=test_cfg)
+
+    input_shape = (1, 3, 300, 300)
+    mm_inputs = _demo_mm_inputs(input_shape)
+
+    imgs = mm_inputs.pop('imgs')
+    img_metas = mm_inputs.pop('img_metas')
+
+    # Test forward train
+    gt_bboxes = mm_inputs['gt_bboxes']
+    gt_labels = mm_inputs['gt_labels']
+    losses = detector.forward(
+        imgs,
+        img_metas,
+        gt_bboxes=gt_bboxes,
+        gt_labels=gt_labels,
+        return_loss=True)
+    assert isinstance(losses, dict)
+
+    # Test forward test
+    with torch.no_grad():
+        img_list = [g[None, :] for g in imgs]
+        batch_results = []
+        for one_img, one_meta in zip(img_list, img_metas):
+            result = detector.forward([one_img], [one_meta], return_loss=False)
+            batch_results.append(result)
+
+
+def test_rpn_forward():
+    model, train_cfg, test_cfg = _get_detector_cfg('rpn_r50_fpn_1x.py')
+    model['pretrained'] = None
+
+    from mmdet.models import build_detector
+    detector = build_detector(model, train_cfg=train_cfg, test_cfg=test_cfg)
+
+    input_shape = (1, 3, 224, 224)
+    mm_inputs = _demo_mm_inputs(input_shape)
+
+    imgs = mm_inputs.pop('imgs')
+    img_metas = mm_inputs.pop('img_metas')
+
+    # Test forward train
+    gt_bboxes = mm_inputs['gt_bboxes']
+    losses = detector.forward(
+        imgs, img_metas, gt_bboxes=gt_bboxes, return_loss=True)
+    assert isinstance(losses, dict)
+
+    # Test forward test
+    with torch.no_grad():
+        img_list = [g[None, :] for g in imgs]
+        batch_results = []
+        for one_img, one_meta in zip(img_list, img_metas):
+            result = detector.forward([one_img], [one_meta], return_loss=False)
+            batch_results.append(result)
+
+
+def test_retina_ghm_forward():
+    model, train_cfg, test_cfg = _get_detector_cfg(
+        'ghm/retinanet_ghm_r50_fpn_1x.py')
+    model['pretrained'] = None
+
+    from mmdet.models import build_detector
+    detector = build_detector(model, train_cfg=train_cfg, test_cfg=test_cfg)
+
+    input_shape = (1, 3, 224, 224)
+    mm_inputs = _demo_mm_inputs(input_shape)
+
+    imgs = mm_inputs.pop('imgs')
+    img_metas = mm_inputs.pop('img_metas')
+
+    # Test forward train
+    gt_bboxes = mm_inputs['gt_bboxes']
+    gt_labels = mm_inputs['gt_labels']
+    losses = detector.forward(
+        imgs,
+        img_metas,
+        gt_bboxes=gt_bboxes,
+        gt_labels=gt_labels,
+        return_loss=True)
+    assert isinstance(losses, dict)
+
+    # Test forward test
+    with torch.no_grad():
+        img_list = [g[None, :] for g in imgs]
+        batch_results = []
+        for one_img, one_meta in zip(img_list, img_metas):
+            result = detector.forward([one_img], [one_meta], return_loss=False)
+            batch_results.append(result)
+
+    if torch.cuda.is_available():
+        detector = detector.cuda()
+        imgs = imgs.cuda()
+        # Test forward train
+        gt_bboxes = [b.cuda() for b in mm_inputs['gt_bboxes']]
+        gt_labels = [g.cuda() for g in mm_inputs['gt_labels']]
+        losses = detector.forward(
+            imgs,
+            img_metas,
+            gt_bboxes=gt_bboxes,
+            gt_labels=gt_labels,
+            return_loss=True)
+        assert isinstance(losses, dict)
+
+        # Test forward test
+        with torch.no_grad():
+            img_list = [g[None, :] for g in imgs]
+            batch_results = []
+            for one_img, one_meta in zip(img_list, img_metas):
+                result = detector.forward([one_img], [one_meta],
+                                          return_loss=False)
+                batch_results.append(result)
+
+
+def _demo_mm_inputs(
+        input_shape=(1, 3, 300, 300), num_items=None, num_classes=10):
+    """
+    Create a superset of inputs needed to run test or train batches.
+
+    Args:
+        input_shape (tuple):
+            input batch dimensions
+
+        num_items (None | List[int]):
+            specifies the number of boxes in each batch item
+
+        num_classes (int):
+            number of different labels a box might have
+    """
+    (N, C, H, W) = input_shape
+
+    rng = np.random.RandomState(0)
+
+    imgs = rng.rand(*input_shape)
+
+    img_metas = [{
+        'img_shape': (H, W, C),
+        'ori_shape': (H, W, C),
+        'pad_shape': (H, W, C),
+        'filename': '<demo>.png',
+        'scale_factor': 1.0,
+        'flip': False,
+    } for _ in range(N)]
+
+    gt_bboxes = []
+    gt_labels = []
+
+    for batch_idx in range(N):
+        if num_items is None:
+            num_boxes = rng.randint(1, 10)
+        else:
+            num_boxes = num_items[batch_idx]
+
+        cx, cy, bw, bh = rng.rand(num_boxes, 4).T
+
+        tl_x = ((cx * W) - (W * bw / 2)).clip(0, W)
+        tl_y = ((cy * H) - (H * bh / 2)).clip(0, H)
+        br_x = ((cx * W) + (W * bw / 2)).clip(0, W)
+        br_y = ((cy * H) + (H * bh / 2)).clip(0, H)
+
+        boxes = np.vstack([tl_x, tl_y, br_x, br_y]).T
+        class_idxs = rng.randint(1, num_classes, size=num_boxes)
+
+        gt_bboxes.append(torch.FloatTensor(boxes))
+        gt_labels.append(torch.LongTensor(class_idxs))
+
+    mm_inputs = {
+        'imgs': torch.FloatTensor(imgs),
+        'img_metas': img_metas,
+        'gt_bboxes': gt_bboxes,
+        'gt_labels': gt_labels,
+        'gt_bboxes_ignore': None,
+    }
+    return mm_inputs

--- a/tests/test_forward.py
+++ b/tests/test_forward.py
@@ -1,3 +1,6 @@
+"""
+pytest tests/test_forward.py
+"""
 import copy
 from os.path import dirname, exists, join
 
@@ -73,7 +76,7 @@ def test_ssd300_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [one_meta], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]], return_loss=False)
             batch_results.append(result)
 
 
@@ -101,7 +104,7 @@ def test_rpn_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [one_meta], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]], return_loss=False)
             batch_results.append(result)
 
 
@@ -113,7 +116,7 @@ def test_retina_ghm_forward():
     from mmdet.models import build_detector
     detector = build_detector(model, train_cfg=train_cfg, test_cfg=test_cfg)
 
-    input_shape = (1, 3, 224, 224)
+    input_shape = (3, 3, 224, 224)
     mm_inputs = _demo_mm_inputs(input_shape)
 
     imgs = mm_inputs.pop('imgs')
@@ -135,7 +138,7 @@ def test_retina_ghm_forward():
         img_list = [g[None, :] for g in imgs]
         batch_results = []
         for one_img, one_meta in zip(img_list, img_metas):
-            result = detector.forward([one_img], [one_meta], return_loss=False)
+            result = detector.forward([one_img], [[one_meta]], return_loss=False)
             batch_results.append(result)
 
     if torch.cuda.is_available():
@@ -157,8 +160,7 @@ def test_retina_ghm_forward():
             img_list = [g[None, :] for g in imgs]
             batch_results = []
             for one_img, one_meta in zip(img_list, img_metas):
-                result = detector.forward([one_img], [one_meta],
-                                          return_loss=False)
+                result = detector.forward([one_img], [[one_meta]], return_loss=False)
                 batch_results.append(result)
 
 


### PR DESCRIPTION
As discussed in #1477, there is an issue with the way `forward_test` calls `simple_test` when num_augs is 1. Previously the line was  `self.simple_test(imgs[0], img_metas[0], **kwargs)`, which passes img_metas in as a `dict` and not a `list[dict]`. It results in this error:

```python
~/code/mmdetection/mmdet/models/detectors/base.py in forward_test(self, imgs, img_metas, **kwargs)
     92         if num_augs == 1:
     93             # return self.simple_test(imgs[0], img_metas[0:1], **kwargs)
---> 94             return self.simple_test(imgs[0], img_metas[0], **kwargs)
     95         else:
     96             return self.aug_test(imgs, img_metas, **kwargs)

~/code/mmdetection/mmdet/models/detectors/rpn.py in simple_test(self, img, img_meta, rescale)
     62     def simple_test(self, img, img_meta, rescale=False):
     63         x = self.extract_feat(img)
---> 64         proposal_list = self.simple_test_rpn(x, img_meta, self.test_cfg.rpn)
     65         if rescale:
     66             for proposals, meta in zip(proposal_list, img_meta):

~/code/mmdetection/mmdet/models/detectors/test_mixins.py in simple_test_rpn(self, x, img_meta, rpn_test_cfg)
      8         rpn_outs = self.rpn_head(x)
      9         proposal_inputs = rpn_outs + (img_meta, rpn_test_cfg)
---> 10         proposal_list = self.rpn_head.get_bboxes(*proposal_inputs)
     11         return proposal_list
     12 

~/code/mmdetection/mmdet/core/fp16/decorators.py in new_func(*args, **kwargs)
    125                                 'method of nn.Module')
    126             if not (hasattr(args[0], 'fp16_enabled') and args[0].fp16_enabled):
--> 127                 return old_func(*args, **kwargs)
    128             # get the arg spec of the decorated method
    129             args_info = getfullargspec(old_func)

~/code/mmdetection/mmdet/models/anchor_heads/anchor_head.py in get_bboxes(self, cls_scores, bbox_preds, img_metas, cfg, rescale)
    268                 bbox_preds[i][img_id].detach() for i in range(num_levels)
    269             ]
--> 270             img_shape = img_metas[img_id]['img_shape']
    271             scale_factor = img_metas[img_id]['scale_factor']
    272             proposals = self.get_bboxes_single(cls_score_list, bbox_pred_list,

KeyError: 0
```

Changing this line to `self.simple_test(imgs[0], img_metas[0:1], **kwargs)` fixes the issue. 

I've also added a test, which both demonstrates this errors and tests the fix. These tests build a few select detectors and passes some dummy data to them in a forward pass. I don't check the results in detail, the main purpose it just to make sure the forward pass runs without crashing. 

To make these tests work on the CI I had to fix cuda/cpu issues in ssd_head and ghm_loss. In the first case ssd_head simply failed to pass device to get_anchors. 

In the second case the GHMC/GHMR loss assumed that the edges and acc_sum were always cuda tensors. I fixed this so they default to the CPU, but I registered them as buffers so if the user calls `.cuda(0)` or `.to(0)` then these are appropriately moved to the GPU with the rest of the model parameters and buffers (note a buffer does not compute gradients, so this is safe). In my tests I checked that the new code works on both CPU and GPU (if available). 

