### PR TITLE
fix a scale bug according to the Non-local papaer

### DIFF
--- a/mmdet/models/plugins/non_local.py
+++ b/mmdet/models/plugins/non_local.py
@@ -76,7 +76,7 @@ class NonLocal2D(nn.Module):
         pairwise_weight = torch.matmul(theta_x, phi_x)
         if self.use_scale:
             # theta_x.shape[-1] is `self.inter_channels`
-            pairwise_weight /= theta_x.shape[-1]**-0.5
+            pairwise_weight /= theta_x.shape[-1]**0.5
         pairwise_weight = pairwise_weight.softmax(dim=-1)
         return pairwise_weight
 


### PR DESCRIPTION
According to [the original implementation of non-local](https://github.com/facebookresearch/video-nonlocal-net/blob/c253ed5eb004fa2cae0490ed46f5018a3c3b060f/lib/models/nonlocal_helper.py#L86), the correct formula of "Scaled Dot-Product Attention" should be 
![image](https://user-images.githubusercontent.com/14849005/66630727-6c8c4800-ec37-11e9-9d56-b2765061baad.png)
