### PR TITLE
Travis: build freeze PyTorch 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: bionic  # ubuntu 18.04
 language: python
 
 python:
@@ -6,7 +6,7 @@ python:
   - "3.6"
   - "3.7"
 
-env: CUDA=9.2.148-1 CUDA_SHORT=9.2 UBUNTU_VERSION=ubuntu1604
+env: CUDA=10.1.105-1 CUDA_SHORT=10.1 UBUNTU_VERSION=ubuntu1804
 
 # Ref to CUDA installation in Travis: https://github.com/jeremad/cuda-travis
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - PATH=${CUDA_HOME}/bin:${PATH}
 
 install:
-  - pip install Cython
+  - pip install Cython torch==1.2
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
   - PATH=${CUDA_HOME}/bin:${PATH}
 
 install:
-  - pip install Cython torch==1.2
+  - pip install Cython
   - pip install -r requirements.txt
   - pip install -r tests/requirements.txt
 


### PR DESCRIPTION
freeze PyTorch version 1.2 since compilation with the 1.3 on Travis CI fails with following error:
```
RuntimeError: cuda runtime error (100) : no CUDA-capable device is detected at /pytorch/aten/src/THC/THCGeneral.cpp:50
```
see https://travis-ci.org/Borda/mmdetection/jobs/596941932