### PR TITLE
Added pre-commit hook

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,6 +29,24 @@ We use the following tools for linting and formatting:
 
 Style configurations of yapf and isort can be found in [.style.yapf](../.style.yapf) and [.isort.cfg](../.isort.cfg).
 
+We use [pre-commit hook](https://pre-commit.com/) that checks and formats for `flake8`, `yapf`, `isort`, `trailing whitespaces`,
+ fixes `end-of-files`, sorts `requirments.txt` automatically on every commit.
+The config for a pre-commit hook is stored in [.pre-commit-config](../.pre-commit-config.yaml).
+
+After you clone the repository, you will need to install initialize pre-commit hook.
+
+```
+pip install -U pre-commit
+```
+
+From the repository folder
+```
+pre-commit install
+```
+
+After this on every commit check code linters and formatter will be enforced.
+
+
 >Before you create a PR, make sure that your code lints and is formatted by yapf.
 
 ### C++ and CUDA

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,6 +2,6 @@
 line_length = 79
 multi_line_output = 0
 known_first_party = mmdet
-known_third_party = mmcv,numpy,matplotlib,pycocotools,six,seaborn,terminaltables,torch,torchvision
+known_third_party = Cython,albumentations,cv2,imagecorruptions,matplotlib,mmcv,numpy,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,setuptools,six,terminaltables,torch
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,21 @@
+repos:
+- repo: https://github.com/asottile/seed-isort-config
+  rev: v1.9.3
+  hooks:
+      - id: seed-isort-config
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: v4.3.21
+  hooks:
+      - id: isort
+- repo: https://github.com/pre-commit/mirrors-yapf
+  rev: 80b9cd2f0f3b1f3456a77eff3ddbaf08f18c08ae
+  hooks:
+    - id: yapf
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+    - id: flake8
+    - id: trailing-whitespace
+    - id: check-yaml
+    - id: end-of-file-fixer
+    - id: requirements-txt-fixer


### PR DESCRIPTION
The [pre-commit hook](https://pre-commit.com) showed a lot of value in the projects that I work on.

One can enable to check for `flake8` errors and enforce formatters like:
1. `yapf`
2. `isort`
3. fix the end of files
4. fix trailing whitespaces

to be enforced automatically on every commit. This saves a lot of files, finding these errors earlier at your computer, rather than waiting for CI tool to find them for you later.

In this PR I added config for the pre-commit hook, and updated contributing guide.

basically one needs to once in the folder with mmdetection:

```
pip install pre-commit
```

```
pre-commit install
```

After this everything will work automatically.