### PR TITLE
fix a bug in issue #1570

### DIFF
--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -113,7 +113,7 @@ def show_result(img,
         np.ndarray or None: If neither `show` nor `out_file` is specified, the
             visualized image is returned, otherwise None is returned.
     """
-    assert isinstance(class_names, (tuple, list))
+    assert isinstance(class_names, (tuple, list, str))
     img = mmcv.imread(img)
     img = img.copy()
     if isinstance(result, tuple):


### PR DESCRIPTION
the bug is in mmdet/apis/inference.py -line 116 assert isinstance(class_names, (tuple, list))
the bug will arise when there is only one class in class_names, which will raise AssertionError