### PR TITLE
Fix Sampler bug: index out of range when num_extra < len(indice)

### DIFF
--- a/mmdet/datasets/loader/sampler.py
+++ b/mmdet/datasets/loader/sampler.py
@@ -57,7 +57,7 @@ class GroupSampler(Sampler):
             np.random.shuffle(indice)
             num_extra = int(np.ceil(size / self.samples_per_gpu)
                             ) * self.samples_per_gpu - len(indice)
-            indice = np.concatenate([indice, indice[:num_extra]])
+            indice = np.concatenate([indice, np.random.choice(indice,num_extra)])
             indices.append(indice)
         indices = np.concatenate(indices)
         indices = [

--- a/mmdet/datasets/loader/sampler.py
+++ b/mmdet/datasets/loader/sampler.py
@@ -57,7 +57,8 @@ class GroupSampler(Sampler):
             np.random.shuffle(indice)
             num_extra = int(np.ceil(size / self.samples_per_gpu)
                             ) * self.samples_per_gpu - len(indice)
-            indice = np.concatenate([indice, np.random.choice(indice, num_extra)])
+            indice = np.concatenate(
+                [indice, np.random.choice(indice, num_extra)])
             indices.append(indice)
         indices = np.concatenate(indices)
         indices = [

--- a/mmdet/datasets/loader/sampler.py
+++ b/mmdet/datasets/loader/sampler.py
@@ -57,7 +57,7 @@ class GroupSampler(Sampler):
             np.random.shuffle(indice)
             num_extra = int(np.ceil(size / self.samples_per_gpu)
                             ) * self.samples_per_gpu - len(indice)
-            indice = np.concatenate([indice, np.random.choice(indice,num_extra)])
+            indice = np.concatenate([indice, np.random.choice(indice, num_extra)])
             indices.append(indice)
         indices = np.concatenate(indices)
         indices = [


### PR DESCRIPTION
When `num_extra < len(indice)`, `len(indice[:num_extra]) != num_extra`, 
```
assert len(indices) == self.num_samples  # line 70
```
will arise error.
So , I modified as follows.
```
indice = np.concatenate([indice, indice[:num_extra]])
```
to 
```
indice = np.concatenate([indice, np.random.choice(indice,num_extra)])
```