### PR TITLE
Dockerfile updated to Pytorch 1.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,12 @@
-ARG PYTORCH="1.1.0"
-ARG CUDA="10.0"
-ARG CUDNN="7.5"
+ARG PYTORCH="1.3"
+ARG CUDA="10.1"
+ARG CUDNN="7"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
+
+ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
+ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
+ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
 RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6 \
  && apt-get clean \


### PR DESCRIPTION
Issue https://github.com/open-mmlab/mmdetection/issues/1591

1. Dockefile updated to Pytorch 1.3 and cuda 10.1
2. CUDNN downgraded from 7 to 7.5. There is no pytorch docker image for pytorch 1.3 and cudnn 7.5
3. Extra lines with environmental variables added. Without them the build breaks.

