### PR TITLE
Async inference interface

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -111,32 +111,32 @@ Async interface allows not to block CPU on GPU bound inference code and enables 
 ```python
 import asyncio
 import torch
-from mmdet.apis import init_detector, inference_detector, show_result
+from mmdet.apis import init_detector, async_inference_detector, show_result
 
 async def main():
-	config_file = 'configs/faster_rcnn_r50_fpn_1x.py'
-	checkpoint_file = 'checkpoints/faster_rcnn_r50_fpn_1x_20181010-3d1b3351.pth'
-	device = 'cuda:0'
-	model = init_detector(config_file, checkpoint=checkpoint_file, device=device)
+    config_file = 'configs/faster_rcnn_r50_fpn_1x.py'
+    checkpoint_file = 'checkpoints/faster_rcnn_r50_fpn_1x_20181010-3d1b3351.pth'
+    device = 'cuda:0'
+    model = init_detector(config_file, checkpoint=checkpoint_file, device=device)
 
-	# queue is used for concurrent inference of multiple images
-	streamqueue = asyncio.Queue()
-	# queue size defines concurrency level
-	streamqueue_size = 3
+    # queue is used for concurrent inference of multiple images
+    streamqueue = asyncio.Queue()
+    # queue size defines concurrency level
+    streamqueue_size = 3
 
-	for _ in range(streamqueue_size):
-		streamqueue.put_nowait(torch.cuda.Stream(device=device))
+    for _ in range(streamqueue_size):
+        streamqueue.put_nowait(torch.cuda.Stream(device=device))
 
-	# test a single image and show the results
-	img = 'test.jpg'  # or img = mmcv.imread(img), which will only load it once
+    # test a single image and show the results
+    img = 'test.jpg'  # or img = mmcv.imread(img), which will only load it once
 
-	async with concurrent(streamqueue):
-		result = await async_inference_detector(model, img)
+    async with concurrent(streamqueue):
+        result = await async_inference_detector(model, img)
 
-	# visualize the results in a new window
-	show_result(img, result, model.CLASSES)
-	# or save the visualization results to image files
-	show_result(img, result, model.CLASSES, out_file='result.jpg')
+    # visualize the results in a new window
+    show_result(img, result, model.CLASSES)
+    # or save the visualization results to image files
+    show_result(img, result, model.CLASSES, out_file='result.jpg')
 
 
 asyncio.run(main())

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -74,6 +74,7 @@ python demo/webcam_demo.py configs/faster_rcnn_r50_fpn_1x.py \
 
 ### High-level APIs for testing images
 
+#### Synchronous interface
 Here is an example of building the model and test given images.
 
 ```python
@@ -102,6 +103,45 @@ for frame in video:
 ```
 
 A notebook demo can be found in [demo/inference_demo.ipynb](../demo/inference_demo.ipynb).
+
+#### Asynchronous interface - supported for Python 3.7+
+
+Async interface allows not to block CPU on GPU bound inference code and enables better CPU/GPU utilization for single threaded application. Inference can be done concurrently either between different input data samples or between different models of some inference pipeline.
+
+```python
+import asyncio
+import torch
+from mmdet.apis import init_detector, inference_detector, show_result
+
+async def main():
+	config_file = 'configs/faster_rcnn_r50_fpn_1x.py'
+	checkpoint_file = 'checkpoints/faster_rcnn_r50_fpn_1x_20181010-3d1b3351.pth'
+	device = 'cuda:0'
+	model = init_detector(config_file, checkpoint=checkpoint_file, device=device)
+
+	# queue is used for concurrent inference of multiple images
+	streamqueue = asyncio.Queue()
+	# queue size defines concurrency level
+	streamqueue_size = 3
+
+	for _ in range(streamqueue_size):
+		streamqueue.put_nowait(torch.cuda.Stream(device=device))
+
+	# test a single image and show the results
+	img = 'test.jpg'  # or img = mmcv.imread(img), which will only load it once
+
+	async with concurrent(streamqueue):
+		result = await async_inference_detector(model, img)
+
+	# visualize the results in a new window
+	show_result(img, result, model.CLASSES)
+	# or save the visualization results to image files
+	show_result(img, result, model.CLASSES, out_file='result.jpg')
+
+
+asyncio.run(main())
+
+```
 
 
 ## Train a model

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -108,10 +108,13 @@ A notebook demo can be found in [demo/inference_demo.ipynb](../demo/inference_de
 
 Async interface allows not to block CPU on GPU bound inference code and enables better CPU/GPU utilization for single threaded application. Inference can be done concurrently either between different input data samples or between different models of some inference pipeline.
 
+See `tests/async_benchmark.py` to compare the speed of synchronous and asynchronous interfaces.
+
 ```python
 import asyncio
 import torch
 from mmdet.apis import init_detector, async_inference_detector, show_result
+from mmdet.utils.contextmanagers import concurrent
 
 async def main():
     config_file = 'configs/faster_rcnn_r50_fpn_1x.py'

--- a/mmdet/apis/__init__.py
+++ b/mmdet/apis/__init__.py
@@ -1,9 +1,10 @@
 from .env import get_root_logger, init_dist, set_random_seed
-from .inference import (inference_detector, init_detector, show_result,
-                        show_result_pyplot)
+from .inference import (async_inference_detector, inference_detector,
+                        init_detector, show_result, show_result_pyplot)
 from .train import train_detector
 
 __all__ = [
-    'init_dist', 'get_root_logger', 'set_random_seed', 'train_detector',
-    'init_detector', 'inference_detector', 'show_result', 'show_result_pyplot'
+    'async_inference_detector', 'init_dist', 'get_root_logger',
+    'set_random_seed', 'train_detector', 'init_detector', 'inference_detector',
+    'show_result', 'show_result_pyplot'
 ]

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -108,9 +108,10 @@ async def async_inference_detector(model, img):
     data = test_pipeline(data)
     data = scatter(collate([data], samples_per_gpu=1), [device])[0]
 
-    # forward the model
-    with torch.no_grad():
-        result = await model.aforward_test(rescale=True, **data)
+    # We don't restore `torch.is_grad_enabled()` value during concurrent
+    # inference since execution can overlap
+    torch.set_grad_enabled(False)
+    result = await model.aforward_test(rescale=True, **data)
     return result
 
 

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -84,7 +84,33 @@ def inference_detector(model, img):
     # forward the model
     with torch.no_grad():
         result = model(return_loss=False, rescale=True, **data)
+    return result
 
+
+async def async_inference_detector(model, img):
+    """Async inference image(s) with the detector.
+
+    Args:
+        model (nn.Module): The loaded detector.
+        imgs (str/ndarray or list[str/ndarray]): Either image files or loaded
+            images.
+
+    Returns:
+        Awaitable detection results.
+    """
+    cfg = model.cfg
+    device = next(model.parameters()).device  # model device
+    # build the data pipeline
+    test_pipeline = [LoadImage()] + cfg.data.test.pipeline[1:]
+    test_pipeline = Compose(test_pipeline)
+    # prepare data
+    data = dict(img=img)
+    data = test_pipeline(data)
+    data = scatter(collate([data], samples_per_gpu=1), [device])[0]
+
+    # forward the model
+    with torch.no_grad():
+        result = await model.aforward_test(rescale=True, **data)
     return result
 
 

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -1,5 +1,7 @@
 from __future__ import division
 
+from typing import List, Tuple
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -94,8 +96,18 @@ class AnchorHead(nn.Module):
         bbox_pred = self.conv_reg(x)
         return cls_score, bbox_pred
 
-    def forward(self, feats):
-        return multi_apply(self.forward_single, feats)
+    def forward(
+            self,
+            feats: List[torch.Tensor],
+    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+        cls_scores = []
+        bbox_preds = []
+        for level, f in enumerate(feats):
+            flat = f.reshape(-1)
+            cls_score, bbox_pred = self.forward_single(f)
+            cls_scores.append(cls_score)
+            bbox_preds.append(bbox_pred)
+        return cls_scores, bbox_preds
 
     def get_anchors(self, featmap_sizes, img_metas, device='cuda'):
         """Get anchors according to feature map sizes.

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -1,5 +1,4 @@
 from __future__ import division
-from typing import List, Tuple
 
 import numpy as np
 import torch
@@ -95,17 +94,8 @@ class AnchorHead(nn.Module):
         bbox_pred = self.conv_reg(x)
         return cls_score, bbox_pred
 
-    def forward(
-            self,
-            feats: List[torch.Tensor],
-    ) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
-        cls_scores = []
-        bbox_preds = []
-        for level, f in enumerate(feats):
-            cls_score, bbox_pred = self.forward_single(f)
-            cls_scores.append(cls_score)
-            bbox_preds.append(bbox_pred)
-        return cls_scores, bbox_preds
+    def forward(self, feats):
+        return multi_apply(self.forward_single, feats)
 
     def get_anchors(self, featmap_sizes, img_metas, device='cuda'):
         """Get anchors according to feature map sizes.

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -1,5 +1,4 @@
 from __future__ import division
-
 from typing import List, Tuple
 
 import numpy as np
@@ -103,7 +102,6 @@ class AnchorHead(nn.Module):
         cls_scores = []
         bbox_preds = []
         for level, f in enumerate(feats):
-            flat = f.reshape(-1)
             cls_score, bbox_pred = self.forward_single(f)
             cls_scores.append(cls_score)
             bbox_preds.append(bbox_pred)

--- a/mmdet/models/anchor_heads/rpn_head.py
+++ b/mmdet/models/anchor_heads/rpn_head.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from mmcv.cnn import normal_init
 
 from mmdet.core import delta2bbox
@@ -65,7 +66,6 @@ class RPNHead(AnchorHead):
             rpn_cls_score = cls_scores[idx]
             rpn_bbox_pred = bbox_preds[idx]
             assert rpn_cls_score.size()[-2:] == rpn_bbox_pred.size()[-2:]
-            anchors = mlvl_anchors[idx]
             rpn_cls_score = rpn_cls_score.permute(1, 2, 0)
             if self.use_sigmoid_cls:
                 rpn_cls_score = rpn_cls_score.reshape(-1)
@@ -74,6 +74,7 @@ class RPNHead(AnchorHead):
                 rpn_cls_score = rpn_cls_score.reshape(-1, 2)
                 scores = rpn_cls_score.softmax(dim=1)[:, 1]
             rpn_bbox_pred = rpn_bbox_pred.permute(1, 2, 0).reshape(-1, 4)
+            anchors = mlvl_anchors[idx]
             if cfg.nms_pre > 0 and scores.shape[0] > cfg.nms_pre:
                 _, topk_inds = scores.topk(cfg.nms_pre)
                 rpn_bbox_pred = rpn_bbox_pred[topk_inds, :]

--- a/mmdet/models/anchor_heads/rpn_head.py
+++ b/mmdet/models/anchor_heads/rpn_head.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from mmcv.cnn import normal_init
 
 from mmdet.core import delta2bbox

--- a/mmdet/models/bbox_heads/bbox_head.py
+++ b/mmdet/models/bbox_heads/bbox_head.py
@@ -162,6 +162,7 @@ class BBoxHead(nn.Module):
         if cfg is None:
             return bboxes, scores
         else:
+            print("before_multiclass_nms", torch.is_grad_enabled())
             det_bboxes, det_labels = multiclass_nms(bboxes, scores,
                                                     cfg.score_thr, cfg.nms,
                                                     cfg.max_per_img)

--- a/mmdet/models/bbox_heads/bbox_head.py
+++ b/mmdet/models/bbox_heads/bbox_head.py
@@ -162,7 +162,6 @@ class BBoxHead(nn.Module):
         if cfg is None:
             return bboxes, scores
         else:
-            print("before_multiclass_nms", torch.is_grad_enabled())
             det_bboxes, det_labels = multiclass_nms(bboxes, scores,
                                                     cfg.score_thr, cfg.nms,
                                                     cfg.max_per_img)

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -62,7 +62,7 @@ class BaseDetector(nn.Module):
         pass
 
     @abstractmethod
-    async def async_test(self, img, img_meta, **kwargs):
+    async def async_simple_test(self, img, img_meta, **kwargs):
         pass
 
     @abstractmethod
@@ -94,7 +94,7 @@ class BaseDetector(nn.Module):
         assert imgs_per_gpu == 1
 
         if num_augs == 1:
-            return await self.async_test(img[0], img_meta[0], **kwargs)
+            return await self.async_simple_test(img[0], img_meta[0], **kwargs)
         else:
             raise NotImplementedError
 

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -62,6 +62,10 @@ class BaseDetector(nn.Module):
         pass
 
     @abstractmethod
+    async def async_test(self, img, img_meta, **kwargs):
+        pass
+
+    @abstractmethod
     def simple_test(self, img, img_meta, **kwargs):
         pass
 
@@ -73,6 +77,26 @@ class BaseDetector(nn.Module):
         if pretrained is not None:
             logger = logging.getLogger()
             logger.info('load model from: {}'.format(pretrained))
+
+    async def aforward_test(self, *, img, img_meta, **kwargs):
+        for var, name in [(img, 'img'), (img_meta, 'img_meta')]:
+            if not isinstance(var, list):
+                raise TypeError('{} must be a list, but got {}'.format(
+                    name, type(var)))
+
+        num_augs = len(img)
+        if num_augs != len(img_meta):
+            raise ValueError(
+                'num of augmentations ({}) != num of image meta ({})'.format(
+                    len(img), len(img_meta)))
+        # TODO: remove the restriction of imgs_per_gpu == 1 when prepared
+        imgs_per_gpu = img[0].size(0)
+        assert imgs_per_gpu == 1
+
+        if num_augs == 1:
+            return await self.async_test(img[0], img_meta[0], **kwargs)
+        else:
+            raise NotImplementedError
 
     def forward_test(self, imgs, img_metas, **kwargs):
         """

--- a/mmdet/models/detectors/test_mixins.py
+++ b/mmdet/models/detectors/test_mixins.py
@@ -69,11 +69,7 @@ class BBoxTestMixin(object):
                                     rescale=False,
                                     bbox_semaphore=None,
                                     global_lock=None):
-            """Async test only det bboxes without augmentation.
-
-            FIXME: this code crashes when runs concurrently.
-
-            """
+            """Async test only det bboxes without augmentation."""
             rois = bbox2roi(proposals)
             roi_feats = self.bbox_roi_extractor(
                 x[:len(self.bbox_roi_extractor.featmap_strides)], rois)

--- a/mmdet/models/detectors/test_mixins.py
+++ b/mmdet/models/detectors/test_mixins.py
@@ -1,8 +1,16 @@
+import logging
+
 import torch
 
 from mmdet.core import (bbox2roi, bbox_mapping, merge_aug_bboxes,
                         merge_aug_masks, merge_aug_proposals, multiclass_nms)
-from mmdet.utils.contextmanagers import completed
+
+logger = logging.getLogger(__name__)
+
+try:
+    from mmdet.utils.contextmanagers import completed
+except AttributeError:
+    logger.info("Async interface is disabled for Python version < 3.7")
 
 
 class RPNTestMixin(object):

--- a/mmdet/models/detectors/test_mixins.py
+++ b/mmdet/models/detectors/test_mixins.py
@@ -2,9 +2,20 @@ import torch
 
 from mmdet.core import (bbox2roi, bbox_mapping, merge_aug_bboxes,
                         merge_aug_masks, merge_aug_proposals, multiclass_nms)
+from mmdet.utils.contextmanagers import completed
 
 
 class RPNTestMixin(object):
+
+    async def async_test_rpn(self, x, img_meta, rpn_test_cfg):
+        sleep_interval = rpn_test_cfg.pop("async_sleep_interval", 0.05)
+        async with completed(
+                __name__, "rpn_head_forward", sleep_interval=sleep_interval):
+            rpn_outs = self.rpn_head(x)
+
+        proposal_inputs = rpn_outs + (img_meta, rpn_test_cfg)
+        proposal_list = self.rpn_head.get_bboxes(*proposal_inputs)
+        return proposal_list
 
     def simple_test_rpn(self, x, img_meta, rpn_test_cfg):
         rpn_outs = self.rpn_head(x)
@@ -36,6 +47,42 @@ class RPNTestMixin(object):
 
 
 class BBoxTestMixin(object):
+
+    async def async_test_bboxes(self,
+                                x,
+                                img_meta,
+                                proposals,
+                                rcnn_test_cfg,
+                                rescale=False,
+                                bbox_semaphore=None,
+                                global_lock=None):
+        """Async test only det bboxes without augmentation.
+
+        FIXME: this code crashes when runs concurrently.
+
+        """
+        rois = bbox2roi(proposals)
+        roi_feats = self.bbox_roi_extractor(
+            x[:len(self.bbox_roi_extractor.featmap_strides)], rois)
+        if self.with_shared_head:
+            roi_feats = self.shared_head(roi_feats)
+        sleep_interval = rcnn_test_cfg.get("async_sleep_interval", 0.017)
+
+        async with completed(
+                __name__, "bbox_head_forward", sleep_interval=sleep_interval):
+            cls_score, bbox_pred = self.bbox_head(roi_feats)
+
+        img_shape = img_meta[0]['img_shape']
+        scale_factor = img_meta[0]['scale_factor']
+        det_bboxes, det_labels = self.bbox_head.get_det_bboxes(
+            rois,
+            cls_score,
+            bbox_pred,
+            img_shape,
+            scale_factor,
+            rescale=rescale,
+            cfg=rcnn_test_cfg)
+        return det_bboxes, det_labels
 
     def simple_test_bboxes(self,
                            x,
@@ -101,6 +148,42 @@ class BBoxTestMixin(object):
 
 
 class MaskTestMixin(object):
+
+    async def async_test_mask(self,
+                              x,
+                              img_meta,
+                              det_bboxes,
+                              det_labels,
+                              rescale=False,
+                              mask_test_cfg=None):
+        # image shape of the first image in the batch (only one)
+        ori_shape = img_meta[0]['ori_shape']
+        scale_factor = img_meta[0]['scale_factor']
+        if det_bboxes.shape[0] == 0:
+            segm_result = [[] for _ in range(self.mask_head.num_classes - 1)]
+        else:
+            _bboxes = (
+                det_bboxes[:, :4] * scale_factor if rescale else det_bboxes)
+            mask_rois = bbox2roi([_bboxes])
+            mask_feats = self.mask_roi_extractor(
+                x[:len(self.mask_roi_extractor.featmap_strides)], mask_rois)
+
+            if self.with_shared_head:
+                mask_feats = self.shared_head(mask_feats)
+            if mask_test_cfg and mask_test_cfg.get('async_sleep_interval'):
+                sleep_interval = mask_test_cfg['async_sleep_interval']
+            else:
+                sleep_interval = 0.035
+            async with completed(
+                    __name__, "mask_head_forward",
+                    sleep_interval=sleep_interval):
+                mask_pred = self.mask_head(mask_feats)
+            segm_result = self.mask_head.get_seg_masks(mask_pred, _bboxes,
+                                                       det_labels,
+                                                       self.test_cfg.rcnn,
+                                                       ori_shape, scale_factor,
+                                                       rescale)
+        return segm_result
 
     def simple_test_mask(self,
                          x,

--- a/mmdet/models/detectors/test_mixins.py
+++ b/mmdet/models/detectors/test_mixins.py
@@ -8,12 +8,13 @@ from mmdet.utils.contextmanagers import completed
 class RPNTestMixin(object):
 
     async def async_test_rpn(self, x, img_meta, rpn_test_cfg):
-        sleep_interval = rpn_test_cfg.pop("async_sleep_interval", 0.05)
+        sleep_interval = rpn_test_cfg.pop("async_sleep_interval", 0.025)
         async with completed(
                 __name__, "rpn_head_forward", sleep_interval=sleep_interval):
             rpn_outs = self.rpn_head(x)
 
         proposal_inputs = rpn_outs + (img_meta, rpn_test_cfg)
+
         proposal_list = self.rpn_head.get_bboxes(*proposal_inputs)
         return proposal_list
 

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -260,7 +260,11 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
 
         return losses
 
-    async def async_test(self, img, img_meta, proposals=None, rescale=False):
+    async def async_simple_test(self,
+                                img,
+                                img_meta,
+                                proposals=None,
+                                rescale=False):
         """Async test without augmentation."""
         assert self.with_bbox, "Bbox head must be implemented."
         x = self.extract_feat(img)

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -260,14 +260,60 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
 
         return losses
 
+    async def async_test(self,
+                         img,
+                         img_meta,
+                         proposals=None,
+                         rescale=False,
+                         lock=None,
+                         global_lock=None):
+        """Async test without augmentation."""
+        assert self.with_bbox, "Bbox head must be implemented."
+        current_stream = torch.cuda.current_stream()
+        async with lock:
+            new_current_stream = torch.cuda.current_stream()
+            if current_stream != new_current_stream:
+                torch._C._cuda_setStream(current_stream._cdata)
+            x = self.extract_feat(img)
+
+            if proposals is None:
+                proposal_list = await self.async_test_rpn(
+                    x, img_meta, self.test_cfg.rpn)
+            else:
+                proposal_list = proposals
+
+            det_bboxes, det_labels = self.simple_test_bboxes(
+                x,
+                img_meta,
+                proposal_list,
+                self.test_cfg.rcnn,
+                rescale=rescale)
+            bbox_results = bbox2result(det_bboxes, det_labels,
+                                       self.bbox_head.num_classes)
+
+            if not self.with_mask:
+                return bbox_results
+            else:
+                segm_results = await self.async_test_mask(
+                    x,
+                    img_meta,
+                    det_bboxes,
+                    det_labels,
+                    rescale=rescale,
+                    mask_test_cfg=self.test_cfg.get('mask'))
+                return bbox_results, segm_results
+
     def simple_test(self, img, img_meta, proposals=None, rescale=False):
         """Test without augmentation."""
         assert self.with_bbox, "Bbox head must be implemented."
 
         x = self.extract_feat(img)
 
-        proposal_list = self.simple_test_rpn(
-            x, img_meta, self.test_cfg.rpn) if proposals is None else proposals
+        if proposals is None:
+            proposal_list = self.simple_test_rpn(x, img_meta,
+                                                 self.test_cfg.rpn)
+        else:
+            proposal_list = proposals
 
         det_bboxes, det_labels = self.simple_test_bboxes(
             x, img_meta, proposal_list, self.test_cfg.rcnn, rescale=rescale)

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -275,15 +275,8 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
         else:
             proposal_list = proposals
 
-        det_bboxes, det_labels = self.simple_test_bboxes(
+        det_bboxes, det_labels = await self.async_test_bboxes(
             x, img_meta, proposal_list, self.test_cfg.rcnn, rescale=rescale)
-        # FIXME: Illegal memory access
-        # det_bboxes, det_labels = await self.async_test_bboxes(
-        #     x,
-        #     img_meta,
-        #     proposal_list,
-        #     self.test_cfg.rcnn,
-        #     rescale=rescale)
         bbox_results = bbox2result(det_bboxes, det_labels,
                                    self.bbox_head.num_classes)
 

--- a/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
+++ b/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
@@ -61,6 +61,7 @@
 // modified from https://github.com/chengdazhi/Deformable-Convolution-V2-PyTorch/blob/mmdetection/mmdet/ops/dcn/src/deform_conv_cuda_kernel.cu
 
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <THC/THCAtomics.cuh>
 #include <stdio.h>
 #include <math.h>
@@ -261,7 +262,7 @@ void deformable_im2col(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, height, width, ksize_h, ksize_w,
             pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w,
             channel_per_deformable_group, parallel_imgs, channels, deformable_group,
@@ -355,7 +356,7 @@ void deformable_col2im(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, channels, height, width, ksize_h,
             ksize_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -454,7 +455,7 @@ void deformable_col2im_coord(
         const scalar_t *data_offset_ = data_offset.data<scalar_t>();
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
 
-        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, channels, height, width,
             ksize_h, ksize_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -784,7 +785,7 @@ void modulated_deformable_im2col_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *data_col_ = data_col.data<scalar_t>();
 
-        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        modulated_deformable_im2col_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_im_, data_offset_, data_mask_, height_im, width_im, kernel_h, kenerl_w,
             pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w, channel_per_deformable_group,
             batch_size, channels, deformable_group, height_col, width_col, data_col_);
@@ -816,7 +817,7 @@ void modulated_deformable_col2im_cuda(
         const scalar_t *data_mask_ = data_mask.data<scalar_t>();
         scalar_t *grad_im_ = grad_im.data<scalar_t>();
 
-        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        modulated_deformable_col2im_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,
@@ -851,7 +852,7 @@ void modulated_deformable_col2im_coord_cuda(
         scalar_t *grad_offset_ = grad_offset.data<scalar_t>();
         scalar_t *grad_mask_ = grad_mask.data<scalar_t>();
 
-        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS>>>(
+        modulated_deformable_col2im_coord_gpu_kernel<<<GET_BLOCKS(num_kernels), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             num_kernels, data_col_, data_im_, data_offset_, data_mask_, channels, height_im, width_im,
             kernel_h, kernel_w, pad_h, pad_w, stride_h, stride_w,
             dilation_h, dilation_w, channel_per_deformable_group,

--- a/mmdet/ops/dcn/src/deform_pool_cuda_kernel.cu
+++ b/mmdet/ops/dcn/src/deform_pool_cuda_kernel.cu
@@ -296,7 +296,7 @@ void DeformablePSROIPoolForward(const at::Tensor data,
         scalar_t *top_data = out.data<scalar_t>();
         scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS>>>(
+        DeformablePSROIPoolForwardKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             count, bottom_data, (scalar_t)spatial_scale, channels, height, width, pooled_height, pooled_width,
             bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part, output_dim,
             group_size, part_size, num_classes, channels_each_class, top_data, top_count_data);
@@ -349,7 +349,7 @@ void DeformablePSROIPoolBackwardAcc(const at::Tensor out_grad,
         scalar_t *bottom_trans_diff = no_trans ? NULL : trans_grad.data<scalar_t>();
         const scalar_t *top_count_data = top_count.data<scalar_t>();
 
-        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS>>>(
+        DeformablePSROIPoolBackwardAccKernel<<<GET_BLOCKS(count), CUDA_NUM_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
             count, top_diff, top_count_data, num_rois, (scalar_t)spatial_scale, channels, height, width,
             pooled_height, pooled_width, output_dim, bottom_data_diff, bottom_trans_diff,
             bottom_data, bottom_rois, bottom_trans, no_trans, (scalar_t)trans_std, sample_per_part,

--- a/mmdet/ops/masked_conv/src/masked_conv2d_kernel.cu
+++ b/mmdet/ops/masked_conv/src/masked_conv2d_kernel.cu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <THC/THCAtomics.cuh>
 
 #define CUDA_1D_KERNEL_LOOP(i, n)                            \
@@ -63,7 +64,8 @@ int MaskedIm2colForwardLaucher(const at::Tensor bottom_data, const int height,
         const int64_t *mask_w_idx_ = mask_w_idx.data<int64_t>();
         scalar_t *top_data_ = top_data.data<scalar_t>();
         MaskedIm2colForward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, at::cuda::getCurrentCUDAStream()
+>>>(
                 output_size, bottom_data_, height, width, kernel_h, kernel_w,
                 pad_h, pad_w, mask_h_idx_, mask_w_idx_, mask_cnt, top_data_);
       }));
@@ -103,7 +105,7 @@ int MaskedCol2imForwardLaucher(const at::Tensor bottom_data, const int height,
         scalar_t *top_data_ = top_data.data<scalar_t>();
 
         MaskedCol2imForward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, at::cuda::getCurrentCUDAStream()>>>(
                 output_size, bottom_data_, height, width, channels, mask_h_idx_,
                 mask_w_idx_, mask_cnt, top_data_);
       }));

--- a/mmdet/ops/roi_align/src/roi_align_cuda.cpp
+++ b/mmdet/ops/roi_align/src/roi_align_cuda.cpp
@@ -1,5 +1,8 @@
 #include <torch/extension.h>
 
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+
 #include <cmath>
 #include <vector>
 
@@ -8,14 +11,14 @@ int ROIAlignForwardLaucher(const at::Tensor features, const at::Tensor rois,
                            const int channels, const int height,
                            const int width, const int num_rois,
                            const int pooled_height, const int pooled_width,
-                           at::Tensor output);
+                           at::Tensor output, cudaStream_t stream);
 
 int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                             const float spatial_scale, const int sample_num,
                             const int channels, const int height,
                             const int width, const int num_rois,
                             const int pooled_height, const int pooled_width,
-                            at::Tensor bottom_grad);
+                            at::Tensor bottom_grad, cudaStream_t stream);
 
 #define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 #define CHECK_CONTIGUOUS(x) \
@@ -47,7 +50,7 @@ int roi_align_forward_cuda(at::Tensor features, at::Tensor rois,
 
   ROIAlignForwardLaucher(features, rois, spatial_scale, sample_num,
                          num_channels, data_height, data_width, num_rois,
-                         pooled_height, pooled_width, output);
+                         pooled_height, pooled_width, output, at::cuda::getCurrentCUDAStream());
 
   return 1;
 }
@@ -74,7 +77,7 @@ int roi_align_backward_cuda(at::Tensor top_grad, at::Tensor rois,
 
   ROIAlignBackwardLaucher(top_grad, rois, spatial_scale, sample_num,
                           num_channels, data_height, data_width, num_rois,
-                          pooled_height, pooled_width, bottom_grad);
+                          pooled_height, pooled_width, bottom_grad, at::cuda::getCurrentCUDAStream());
 
   return 1;
 }

--- a/mmdet/ops/roi_align/src/roi_align_cuda.cpp
+++ b/mmdet/ops/roi_align/src/roi_align_cuda.cpp
@@ -1,7 +1,6 @@
 #include <torch/extension.h>
 
 #include <ATen/ATen.h>
-#include <ATen/cuda/CUDAContext.h>
 
 #include <cmath>
 #include <vector>
@@ -11,14 +10,14 @@ int ROIAlignForwardLaucher(const at::Tensor features, const at::Tensor rois,
                            const int channels, const int height,
                            const int width, const int num_rois,
                            const int pooled_height, const int pooled_width,
-                           at::Tensor output, cudaStream_t stream);
+                           at::Tensor output);
 
 int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                             const float spatial_scale, const int sample_num,
                             const int channels, const int height,
                             const int width, const int num_rois,
                             const int pooled_height, const int pooled_width,
-                            at::Tensor bottom_grad, cudaStream_t stream);
+                            at::Tensor bottom_grad);
 
 #define CHECK_CUDA(x) AT_CHECK(x.type().is_cuda(), #x, " must be a CUDAtensor ")
 #define CHECK_CONTIGUOUS(x) \
@@ -50,7 +49,7 @@ int roi_align_forward_cuda(at::Tensor features, at::Tensor rois,
 
   ROIAlignForwardLaucher(features, rois, spatial_scale, sample_num,
                          num_channels, data_height, data_width, num_rois,
-                         pooled_height, pooled_width, output, at::cuda::getCurrentCUDAStream());
+                         pooled_height, pooled_width, output);
 
   return 1;
 }
@@ -77,7 +76,7 @@ int roi_align_backward_cuda(at::Tensor top_grad, at::Tensor rois,
 
   ROIAlignBackwardLaucher(top_grad, rois, spatial_scale, sample_num,
                           num_channels, data_height, data_width, num_rois,
-                          pooled_height, pooled_width, bottom_grad, at::cuda::getCurrentCUDAStream());
+                          pooled_height, pooled_width, bottom_grad);
 
   return 1;
 }

--- a/mmdet/ops/roi_align/src/roi_align_kernel.cu
+++ b/mmdet/ops/roi_align/src/roi_align_kernel.cu
@@ -122,7 +122,7 @@ int ROIAlignForwardLaucher(const at::Tensor features, const at::Tensor rois,
                            const int channels, const int height,
                            const int width, const int num_rois,
                            const int pooled_height, const int pooled_width,
-                           at::Tensor output) {
+                           at::Tensor output, cudaStream_t stream) {
   const int output_size = num_rois * pooled_height * pooled_width * channels;
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       features.scalar_type(), "ROIAlignLaucherForward", ([&] {
@@ -131,7 +131,7 @@ int ROIAlignForwardLaucher(const at::Tensor features, const at::Tensor rois,
         scalar_t *top_data = output.data<scalar_t>();
 
         ROIAlignForward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
                 output_size, bottom_data, rois_data, scalar_t(spatial_scale),
                 sample_num, channels, height, width, pooled_height,
                 pooled_width, top_data);
@@ -258,7 +258,7 @@ int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
                             const int channels, const int height,
                             const int width, const int num_rois,
                             const int pooled_height, const int pooled_width,
-                            at::Tensor bottom_grad) {
+                            at::Tensor bottom_grad, cudaStream_t stream) {
   const int output_size = num_rois * pooled_height * pooled_width * channels;
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
@@ -272,7 +272,7 @@ int ROIAlignBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
         }
 
         ROIAlignBackward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, stream>>>(
                 output_size, top_diff, rois_data, spatial_scale, sample_num,
                 channels, height, width, pooled_height, pooled_width,
                 bottom_diff);

--- a/mmdet/ops/roi_pool/src/roi_pool_kernel.cu
+++ b/mmdet/ops/roi_pool/src/roi_pool_kernel.cu
@@ -1,4 +1,5 @@
 #include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
 #include <THC/THCAtomics.cuh>
 
 #define CUDA_1D_KERNEL_LOOP(i, n)                            \
@@ -93,7 +94,7 @@ int ROIPoolForwardLaucher(const at::Tensor features, const at::Tensor rois,
         int *argmax_data = argmax.data<int>();
 
         ROIPoolForward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, at::cuda::getCurrentCUDAStream()>>>(
                 output_size, bottom_data, rois_data, scalar_t(spatial_scale),
                 channels, height, width, pooled_h, pooled_w, top_data,
                 argmax_data);
@@ -146,7 +147,7 @@ int ROIPoolBackwardLaucher(const at::Tensor top_grad, const at::Tensor rois,
         }
 
         ROIPoolBackward<scalar_t>
-            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK>>>(
+            <<<GET_BLOCKS(output_size), THREADS_PER_BLOCK, 0, at::cuda::getCurrentCUDAStream()>>>(
                 output_size, top_diff, rois_data, argmax_data,
                 scalar_t(spatial_scale), channels, height, width, pooled_h,
                 pooled_w, bottom_diff);

--- a/mmdet/ops/sigmoid_focal_loss/src/sigmoid_focal_loss_cuda.cu
+++ b/mmdet/ops/sigmoid_focal_loss/src/sigmoid_focal_loss_cuda.cu
@@ -120,7 +120,7 @@ at::Tensor SigmoidFocalLoss_forward_cuda(const at::Tensor &logits,
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       logits.scalar_type(), "SigmoidFocalLoss_forward", [&] {
-        SigmoidFocalLossForward<scalar_t><<<grid, block>>>(
+        SigmoidFocalLossForward<scalar_t><<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
             losses_size, logits.contiguous().data<scalar_t>(),
             targets.contiguous().data<int64_t>(), num_classes, gamma, alpha,
             num_samples, losses.data<scalar_t>());
@@ -159,7 +159,7 @@ at::Tensor SigmoidFocalLoss_backward_cuda(const at::Tensor &logits,
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
       logits.scalar_type(), "SigmoidFocalLoss_backward", [&] {
-        SigmoidFocalLossBackward<scalar_t><<<grid, block>>>(
+        SigmoidFocalLossBackward<scalar_t><<<grid, block, 0, at::cuda::getCurrentCUDAStream()>>>(
             d_logits_size, logits.contiguous().data<scalar_t>(),
             targets.contiguous().data<int64_t>(),
             d_losses.contiguous().data<scalar_t>(), num_classes, gamma, alpha,

--- a/mmdet/utils/contextmanagers.py
+++ b/mmdet/utils/contextmanagers.py
@@ -78,14 +78,17 @@ async def completed(trace_name="",
                     logger.info("%s %s completed: %s streams: %s", trace_name,
                                 name, are_done, streams)
 
+        current_stream = torch.cuda.current_stream()
+        assert current_stream == stream_before_context_switch
+
         if DEBUG_COMPLETED_TIME:
             cpu_time = (cpu_end - cpu_start) * 1000
             stream_times_ms = ""
             for i, stream in enumerate(streams):
                 elapsed_time = start.elapsed_time(end_events[i])
-                stream_times_ms += f" {stream} {elapsed_time:.2f} ms"
-            logger.info(f"{trace_name} {name} cpu_time {cpu_time:.2f} ms" +
-                        stream_times_ms)
+                stream_times_ms += " {stream} {elapsed_time:.2f} ms"
+            logger.info("{trace_name} {name} cpu_time {cpu_time:.2f} ms",
+                        trace_name, name, cpu_time, stream_times_ms)
 
 
 @contextlib.asynccontextmanager

--- a/mmdet/utils/contextmanagers.py
+++ b/mmdet/utils/contextmanagers.py
@@ -1,0 +1,98 @@
+# coding: utf-8
+import asyncio
+import contextlib
+import logging
+import os
+import time
+from typing import List
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+DEBUG_COMPLETED_TIME = bool(os.environ.get('DEBUG_COMPLETED_TIME', False))
+DEBUG_COMPLETED = bool(os.environ.get('DEBUG_COMPLETED', False))
+
+
+@contextlib.asynccontextmanager
+async def completed(trace_name="",
+                    name="",
+                    sleep_interval=0.05,
+                    streams: List[torch.cuda.Stream] = None):
+    """
+    Async context manager that waits for work to complete on
+    given CUDA streams.
+
+    """
+    if not torch.cuda.is_available():
+        yield
+        return
+
+    stream_before_context_switch = torch.cuda.current_stream()
+    if not streams:
+        streams = [stream_before_context_switch]
+    else:
+        streams = [s if s else stream_before_context_switch for s in streams]
+
+    end_events = [
+        torch.cuda.Event(enable_timing=DEBUG_COMPLETED_TIME) for _ in streams
+    ]
+
+    if DEBUG_COMPLETED_TIME:
+        start = torch.cuda.Event(enable_timing=True)
+        stream_before_context_switch.record_event(start)
+
+        cpu_start = time.monotonic()
+    if DEBUG_COMPLETED:
+        logger.info("%s %s starting, streams: %s", trace_name, name, streams)
+    grad_enabled_before = torch.is_grad_enabled()
+    try:
+        yield
+    finally:
+        if DEBUG_COMPLETED_TIME:
+            cpu_end = time.monotonic()
+        for i, stream in enumerate(streams):
+            event = end_events[i]
+            stream.record_event(event)
+
+        grad_enabled_after = torch.is_grad_enabled()
+
+        # observed change of torch.is_grad_enabled() during concurrent run of
+        # async_test_bboxes code
+        assert grad_enabled_before == grad_enabled_after, \
+            "Unexpected is_grad_enabled() value change"
+
+        device_before_context_switch = torch.cuda.current_device()
+
+        are_done = [e.query() for e in end_events]
+        if DEBUG_COMPLETED:
+            logger.info("%s %s completed: %s streams: %s", trace_name, name,
+                        are_done, streams)
+        while not all(are_done):
+            await asyncio.sleep(sleep_interval)
+            are_done = [e.query() for e in end_events]
+            if DEBUG_COMPLETED:
+                logger.info("%s %s completed: %s streams: %s", trace_name,
+                            name, are_done, streams)
+
+        current_device = torch.cuda.current_device()
+        current_stream = torch.cuda.current_stream()
+
+        if current_device != device_before_context_switch:
+            torch.cuda.set_device(device_before_context_switch)
+        if current_stream != stream_before_context_switch:
+            torch._C._cuda_setStream(stream_before_context_switch._cdata)
+
+        if DEBUG_COMPLETED_TIME:
+            cpu_time = (cpu_end - cpu_start) * 1000
+            stream_times_ms = ""
+            for i, stream in enumerate(streams):
+                elapsed_time = start.elapsed_time(end_events[i])
+                stream_times_ms += f" {stream} {elapsed_time:.2f} ms"
+            logger.info(f"{trace_name} {name} cpu_time {cpu_time:.2f} ms" +
+                        stream_times_ms)
+
+
+@contextlib.asynccontextmanager
+async def completed(trace_name="",
+                    name="",

--- a/mmdet/utils/contextmanagers.py
+++ b/mmdet/utils/contextmanagers.py
@@ -86,7 +86,8 @@ async def completed(trace_name="",
             stream_times_ms = ""
             for i, stream in enumerate(streams):
                 elapsed_time = start.elapsed_time(end_events[i])
-                stream_times_ms += " {stream} {elapsed_time:.2f} ms"
+                stream_times_ms += " {stream} {elapsed_time:.2f} ms".format(
+                    stream, elapsed_time)
             logger.info("{trace_name} {name} cpu_time {cpu_time:.2f} ms",
                         trace_name, name, cpu_time, stream_times_ms)
 

--- a/mmdet/utils/profiling.py
+++ b/mmdet/utils/profiling.py
@@ -1,0 +1,33 @@
+# coding: utf-8
+import contextlib
+import time
+import torch
+
+
+@contextlib.contextmanager
+def profile_time(trace_name, name, enabled=True, stream=None, end_stream=None):
+    """Print time spent by CPU and GPU.
+
+    Useful as a temporary context manager to find sweet spots of code suitable
+    for async implementation.
+
+    """
+    if (not enabled) or not torch.cuda.is_available():
+        yield
+        return
+    stream = stream if stream else torch.cuda.current_stream()
+    end_stream = end_stream if end_stream else stream
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    stream.record_event(start)
+    try:
+        cpu_start = time.monotonic()
+        yield
+    finally:
+        cpu_end = time.monotonic()
+        end_stream.record_event(end)
+        end.synchronize()
+        cpu_time = (cpu_end - cpu_start) * 1000
+        gpu_time = start.elapsed_time(end)
+        print(f"{trace_name} {name} cpu_time {cpu_time:.2f} ms "
+              f"gpu_time {gpu_time:.2f} ms stream {end_stream}")

--- a/mmdet/utils/profiling.py
+++ b/mmdet/utils/profiling.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import contextlib
 import sys
 import time

--- a/mmdet/utils/profiling.py
+++ b/mmdet/utils/profiling.py
@@ -1,34 +1,43 @@
 # coding: utf-8
+
 import contextlib
+import sys
 import time
 
 import torch
 
+if sys.version_info >= (3, 7):
 
-@contextlib.contextmanager
-def profile_time(trace_name, name, enabled=True, stream=None, end_stream=None):
-    """Print time spent by CPU and GPU.
+    @contextlib.contextmanager
+    def profile_time(trace_name,
+                     name,
+                     enabled=True,
+                     stream=None,
+                     end_stream=None):
+        """Print time spent by CPU and GPU.
 
-    Useful as a temporary context manager to find sweet spots of code suitable
-    for async implementation.
+        Useful as a temporary context manager to find sweet spots of
+        code suitable for async implementation.
 
-    """
-    if (not enabled) or not torch.cuda.is_available():
-        yield
-        return
-    stream = stream if stream else torch.cuda.current_stream()
-    end_stream = end_stream if end_stream else stream
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    stream.record_event(start)
-    try:
-        cpu_start = time.monotonic()
-        yield
-    finally:
-        cpu_end = time.monotonic()
-        end_stream.record_event(end)
-        end.synchronize()
-        cpu_time = (cpu_end - cpu_start) * 1000
-        gpu_time = start.elapsed_time(end)
-        print(f"{trace_name} {name} cpu_time {cpu_time:.2f} ms "
-              f"gpu_time {gpu_time:.2f} ms stream {end_stream}")
+        """
+        if (not enabled) or not torch.cuda.is_available():
+            yield
+            return
+        stream = stream if stream else torch.cuda.current_stream()
+        end_stream = end_stream if end_stream else stream
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        stream.record_event(start)
+        try:
+            cpu_start = time.monotonic()
+            yield
+        finally:
+            cpu_end = time.monotonic()
+            end_stream.record_event(end)
+            end.synchronize()
+            cpu_time = (cpu_end - cpu_start) * 1000
+            gpu_time = start.elapsed_time(end)
+            msg = "{} {} cpu_time {:.2f} ms ".format(trace_name, name,
+                                                     cpu_time)
+            msg += "gpu_time {:.2f} ms stream {}".format
+            print(gpu_time, end_stream)

--- a/mmdet/utils/profiling.py
+++ b/mmdet/utils/profiling.py
@@ -37,5 +37,5 @@ if sys.version_info >= (3, 7):
             gpu_time = start.elapsed_time(end)
             msg = "{} {} cpu_time {:.2f} ms ".format(trace_name, name,
                                                      cpu_time)
-            msg += "gpu_time {:.2f} ms stream {}".format
-            print(gpu_time, end_stream)
+            msg += "gpu_time {:.2f} ms stream {}".format(gpu_time, stream)
+            print(msg, end_stream)

--- a/mmdet/utils/profiling.py
+++ b/mmdet/utils/profiling.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import contextlib
 import time
+
 import torch
 
 

--- a/setup.py
+++ b/setup.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
         ],
         license='Apache License 2.0',
         setup_requires=['pytest-runner', 'cython', 'numpy'],
-        tests_require=['pytest', 'xdoctest'],
+        tests_require=['pytest', 'xdoctest', 'asynctest'],
         install_requires=get_requirements(),
         ext_modules=[
             make_cuda_ext(

--- a/tests/async_benchmark.py
+++ b/tests/async_benchmark.py
@@ -5,9 +5,9 @@ import os
 import shutil
 import urllib
 
+import mmcv
 import torch
 
-import mmcv
 from mmdet.apis import (async_inference_detector, inference_detector,
                         init_detector, show_result)
 from mmdet.utils.contextmanagers import concurrent
@@ -27,7 +27,8 @@ async def main():
     8074.52 ms	9660.94 ms
     7976.44 ms	9406.83 ms
 
-    Async variant takes about 0.83-0.85 of the time of the synchronous interface.
+    Async variant takes about 0.83-0.85 of the time of the synchronous
+    interface.
 
     """
     project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
@@ -37,18 +38,19 @@ async def main():
         project_dir, 'checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth')
 
     if not os.path.exists(checkpoint_file):
-        url = ('https://s3.ap-northeast-2.amazonaws.com/open-mmlab/mmdetection/'
-               'models/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth')
-        print(f'Downloading {url} ...')
+        url = ('https://s3.ap-northeast-2.amazonaws.com/open-mmlab/mmdetection'
+               '/models/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth')
+        print('Downloading {} ...'.format(url))
         local_filename, _ = urllib.request.urlretrieve(url)
         os.makedirs(os.path.dirname(checkpoint_file), exist_ok=True)
         shutil.move(local_filename, checkpoint_file)
-        print(f'Saved as {checkpoint_file}')
+        print('Saved as {}'.format(checkpoint_file))
     else:
-        print(f'Using existing checkpoint {checkpoint_file}')
+        print('Using existing checkpoint {}'.format(checkpoint_file))
 
     device = 'cuda:0'
-    model = init_detector(config_file, checkpoint=checkpoint_file, device=device)
+    model = init_detector(
+        config_file, checkpoint=checkpoint_file, device=device)
 
     # queue is used for concurrent inference of multiple images
     streamqueue = asyncio.Queue()
@@ -70,17 +72,33 @@ async def main():
 
     num_of_images = 20
     with profile_time('benchmark', 'async'):
-        tasks = [asyncio.create_task(detect(img)) for _ in range(num_of_images)]
+        tasks = [
+            asyncio.create_task(detect(img)) for _ in range(num_of_images)
+        ]
         async_results = await asyncio.gather(*tasks)
 
     with torch.cuda.stream(torch.cuda.default_stream()):
         with profile_time('benchmark', 'sync'):
-            sync_results = [inference_detector(model, img) for _ in range(num_of_images)]
+            sync_results = [
+                inference_detector(model, img) for _ in range(num_of_images)
+            ]
 
     result_dir = os.path.join(project_dir, 'demo')
-    show_result(img, async_results[0], model.CLASSES, score_thr=0.5, show=False,
-                out_file=os.path.join(result_dir, 'result_async.jpg'))
-    show_result(img, sync_results[0], model.CLASSES, score_thr=0.5, show=False,
-                out_file=os.path.join(result_dir, 'result_sync.jpg'))
+    show_result(
+        img,
+        async_results[0],
+        model.CLASSES,
+        score_thr=0.5,
+        show=False,
+        out_file=os.path.join(result_dir, 'result_async.jpg'))
+    show_result(
+        img,
+        sync_results[0],
+        model.CLASSES,
+        score_thr=0.5,
+        show=False,
+        out_file=os.path.join(result_dir, 'result_sync.jpg'))
 
-asyncio.run(main())
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/tests/async_benchmark.py
+++ b/tests/async_benchmark.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+
+import asyncio
+import os
+import shutil
+import urllib
+
+import torch
+
+import mmcv
+from mmdet.apis import (async_inference_detector, inference_detector,
+                        init_detector, show_result)
+from mmdet.utils.contextmanagers import concurrent
+from mmdet.utils.profiling import profile_time
+
+
+async def main():
+    """
+
+    Benchmark between async and synchronous inference interfaces.
+
+    Sample runs for 20 demo images on K80 GPU, model - mask_rcnn_r50_fpn_1x:
+
+    async	sync
+
+    7981.79 ms	9660.82 ms
+    8074.52 ms	9660.94 ms
+    7976.44 ms	9406.83 ms
+
+    Async variant takes about 0.83-0.85 of the time of the synchronous interface.
+
+    """
+    project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+
+    config_file = os.path.join(project_dir, 'configs/mask_rcnn_r50_fpn_1x.py')
+    checkpoint_file = os.path.join(
+        project_dir, 'checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth')
+
+    if not os.path.exists(checkpoint_file):
+        url = ('https://s3.ap-northeast-2.amazonaws.com/open-mmlab/mmdetection/'
+               'models/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth')
+        print(f'Downloading {url} ...')
+        local_filename, _ = urllib.request.urlretrieve(url)
+        os.makedirs(os.path.dirname(checkpoint_file), exist_ok=True)
+        shutil.move(local_filename, checkpoint_file)
+        print(f'Saved as {checkpoint_file}')
+    else:
+        print(f'Using existing checkpoint {checkpoint_file}')
+
+    device = 'cuda:0'
+    model = init_detector(config_file, checkpoint=checkpoint_file, device=device)
+
+    # queue is used for concurrent inference of multiple images
+    streamqueue = asyncio.Queue()
+    # queue size defines concurrency level
+    streamqueue_size = 4
+
+    for _ in range(streamqueue_size):
+        streamqueue.put_nowait(torch.cuda.Stream(device=device))
+
+    # test a single image and show the results
+    img = mmcv.imread(os.path.join(project_dir, 'demo/demo.jpg'))
+
+    # warmup
+    await async_inference_detector(model, img)
+
+    async def detect(img):
+        async with concurrent(streamqueue):
+            return await async_inference_detector(model, img)
+
+    num_of_images = 20
+    with profile_time('benchmark', 'async'):
+        tasks = [asyncio.create_task(detect(img)) for _ in range(num_of_images)]
+        async_results = await asyncio.gather(*tasks)
+
+    with torch.cuda.stream(torch.cuda.default_stream()):
+        with profile_time('benchmark', 'sync'):
+            sync_results = [inference_detector(model, img) for _ in range(num_of_images)]
+
+    result_dir = os.path.join(project_dir, 'demo')
+    show_result(img, async_results[0], model.CLASSES, score_thr=0.5, show=False,
+                out_file=os.path.join(result_dir, 'result_async.jpg'))
+    show_result(img, sync_results[0], model.CLASSES, score_thr=0.5, show=False,
+                out_file=os.path.join(result_dir, 'result_sync.jpg'))
+
+asyncio.run(main())

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ yapf
 pytest-cov
 codecov
 xdoctest >= 0.10.0
+asynctest

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -2,13 +2,16 @@
 
 import asyncio
 import os
+import sys
 
 import asynctest
 import mmcv
 import torch
 
 from mmdet.apis import async_inference_detector, init_detector
-from mmdet.utils.contextmanagers import concurrent
+
+if sys.version_info >= (3, 7):
+    from mmdet.utils.contextmanagers import concurrent
 
 
 class AsyncTestCase(asynctest.TestCase):
@@ -44,21 +47,25 @@ class MaskRCNNDetector:
         for _ in range(self.streamqueue_size):
             self.streamqueue.put_nowait(torch.cuda.Stream(device=self.device))
 
-    async def apredict(self, img):
-        if isinstance(img, str):
-            img = mmcv.imread(img)
-        async with concurrent(self.streamqueue):
-            result = await async_inference_detector(self.model, img)
-        return result
+    if sys.version_info >= (3, 7):
+
+        async def apredict(self, img):
+            if isinstance(img, str):
+                img = mmcv.imread(img)
+            async with concurrent(self.streamqueue):
+                result = await async_inference_detector(self.model, img)
+            return result
 
 
 class AsyncInferenceTestCase(AsyncTestCase):
 
-    async def test_simple_inference(self):
-        root_dir = os.path.dirname(os.path.dirname(__name__))
-        model_config = os.path.join(root_dir,
-                                    "configs/mask_rcnn_r50_fpn_1x.py")
-        detector = MaskRCNNDetector(model_config)
-        await detector.init()
-        img_path = os.path.join(root_dir, "demo/demo.jpg")
-        await detector.apredict(img_path)
+    if sys.version_info >= (3, 7):
+
+        async def test_simple_inference(self):
+            root_dir = os.path.dirname(os.path.dirname(__name__))
+            model_config = os.path.join(root_dir,
+                                        "configs/mask_rcnn_r50_fpn_1x.py")
+            detector = MaskRCNNDetector(model_config)
+            await detector.init()
+            img_path = os.path.join(root_dir, "demo/demo.jpg")
+            await detector.apredict(img_path)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -24,19 +24,22 @@ class AsyncTestCase(asynctest.TestCase):
         result = method()
         if asyncio.iscoroutine(result):
             self.loop.run_until_complete(
-                asyncio.wait_for(result, timeout=self.TEST_TIMEOUT)
-            )
+                asyncio.wait_for(result, timeout=self.TEST_TIMEOUT))
 
 
 class MaskRCNNDetector:
-    def __init__(
-        self, model_config, checkpoint=None, streamqueue_size=3, device="cuda:0"
-    ):
+
+    def __init__(self,
+                 model_config,
+                 checkpoint=None,
+                 streamqueue_size=3,
+                 device="cuda:0"):
 
         self.streamqueue_size = streamqueue_size
         self.device = device
         # build the model and load checkpoint
-        self.model = init_detector(model_config, checkpoint=None, device=self.device)
+        self.model = init_detector(
+            model_config, checkpoint=None, device=self.device)
         self.streamqueue = None
 
     async def init(self):
@@ -66,7 +69,8 @@ class AsyncInferenceTestCase(AsyncTestCase):
                 pytest.skip("test requires GPU and torch+cuda")
 
             root_dir = os.path.dirname(os.path.dirname(__name__))
-            model_config = os.path.join(root_dir, "configs/mask_rcnn_r50_fpn_1x.py")
+            model_config = os.path.join(root_dir,
+                                        "configs/mask_rcnn_r50_fpn_1x.py")
             detector = MaskRCNNDetector(model_config)
             await detector.init()
             img_path = os.path.join(root_dir, "demo/demo.jpg")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,64 @@
+"""Tests for async interface."""
+
+import asyncio
+import os
+
+import asynctest
+import mmcv
+import torch
+
+from mmdet.apis import async_inference_detector, init_detector
+from mmdet.utils.contextmanagers import concurrent
+
+
+class AsyncTestCase(asynctest.TestCase):
+    use_default_loop = False
+    forbid_get_event_loop = True
+
+    TEST_TIMEOUT = int(os.getenv("ASYNCIO_TEST_TIMEOUT", "30"))
+
+    def _run_test_method(self, method):
+        result = method()
+        if asyncio.iscoroutine(result):
+            self.loop.run_until_complete(
+                asyncio.wait_for(result, timeout=self.TEST_TIMEOUT))
+
+
+class MaskRCNNDetector:
+
+    def __init__(self,
+                 model_config,
+                 checkpoint=None,
+                 streamqueue_size=3,
+                 device="cuda:0"):
+
+        # build the model and load checkpoint
+        self.device = device
+        self.model = init_detector(
+            model_config, checkpoint=None, device=self.device)
+        self.streamqueue = None
+        self.streamqueue_size = streamqueue_size
+
+    async def init(self):
+        self.streamqueue = asyncio.Queue()
+        for _ in range(self.streamqueue_size):
+            self.streamqueue.put_nowait(torch.cuda.Stream(device=self.device))
+
+    async def apredict(self, img):
+        if isinstance(img, str):
+            img = mmcv.imread(img)
+        async with concurrent(self.streamqueue):
+            result = await async_inference_detector(self.model, img)
+        return result
+
+
+class AsyncInferenceTestCase(AsyncTestCase):
+
+    async def test_simple_inference(self):
+        root_dir = os.path.dirname(os.path.dirname(__name__))
+        model_config = os.path.join(root_dir,
+                                    "configs/mask_rcnn_r50_fpn_1x.py")
+        detector = MaskRCNNDetector(model_config)
+        await detector.init()
+        img_path = os.path.join(root_dir, "demo/demo.jpg")
+        await detector.apredict(img_path)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -35,16 +35,17 @@ class MaskRCNNDetector:
                  streamqueue_size=3,
                  device="cuda:0"):
 
-        # build the model and load checkpoint
-        self.device = device
-        self.model = init_detector(
-            model_config, checkpoint=None, device=self.device)
-        self.streamqueue = None
         if torch.cuda.is_available():
             self.streamqueue_size = streamqueue_size
+            self.device = device
         else:
             # concurrent execution makes sense only on GPU
             self.streamqueue_size = 1
+            self.device = "cpu"
+        # build the model and load checkpoint
+        self.model = init_detector(
+            model_config, checkpoint=None, device=self.device)
+        self.streamqueue = None
 
     async def init(self):
         self.streamqueue = asyncio.Queue()


### PR DESCRIPTION
This PR adds async inference interface implemented for two stage detector with RPN head.

Concurrency is supported by two async context managers:

1. `completed` allows to switch execution context during GPU bound computations like convolutions. CUDA stream is restored when the context is switched back.
2. `concurrent` makes it possible to execute block of code concurrently in a dedicated pool of CUDA streams. The pool is constructed and passed via `asyncio.Queue`. It's an alternative to tensor-level batch inference.

I've tested this implementation on my current project that uses single thread for inference. Async variant has ~30% higher throughput than blocking one but the GPU is still underutilized and there is a room for improvement.

Concurrency can be increased by using `BBoxTestMixin.async_test_bboxes`. At the moment it crashes on memory errors. Probably there are some operations that need to be fixed for concurrent execution.