### PR TITLE
fix mAP w.r.t. object scales

### DIFF
--- a/mmdet/core/evaluation/coco_utils.py
+++ b/mmdet/core/evaluation/coco_utils.py
@@ -188,6 +188,7 @@ def segm2json(dataset, results):
             for i in range(bboxes.shape[0]):
                 data = dict()
                 data['image_id'] = img_id
+                data['bbox'] = xyxy2xywh(bboxes[i])
                 data['score'] = float(mask_score[i])
                 data['category_id'] = dataset.cat_ids[label]
                 if isinstance(segms[i]['counts'], bytes):


### PR DESCRIPTION
This PR related to #1672 that the mAP w.r.t. object scales has been changed after some code refactoring. I think it is important, especially for publications since reviewers may ask about abnormal performance changes.

|      Model     | AP   | AP50 | AP75 | APS  | APM  | APL  |
|:--------------:|------|------|------|------|------|------|
| HTC from paper | 38.0 | 59.4 | 40.7 | 20.3 | 40.9 | 52.3 |
| Before fix     | 38.1 | 59.4 | 41.0 | 17.9 | 40.7 | 56.6 |
| After fix      | 38.1 | 59.4 | 41.0 | 20.3 | 41.1 | 52.8 |

The bug stems from commit [#976629](https://github.com/open-mmlab/mmdetection/commit/976629d4e604f07280eb621b8fc7e6023fc94a90) which separates the results into independent files for ``bbox`` and ``segm``. However, the segmentation results do not have ``bbox`` field which makes the cocotools create default ``bbox`` by the segmentation results (Check [here](https://github.com/cocodataset/cocoapi/blob/636becdc73d54283b3aac6d4ec363cffbb6f9b20/PythonAPI/pycocotools/coco.py#L339)). 

I would suggest keeping the behavior as before that uses a single file for the results. If you agree i am willing to do that. 




