### PR TITLE
shuffle passed as function argument instead of kwargs

### DIFF
--- a/mmdet/datasets/loader/build_loader.py
+++ b/mmdet/datasets/loader/build_loader.py
@@ -19,8 +19,8 @@ def build_dataloader(dataset,
                      workers_per_gpu,
                      num_gpus=1,
                      dist=True,
+                     shuffle=True,
                      **kwargs):
-    shuffle = kwargs.get('shuffle', True)
     if dist:
         rank, world_size = get_dist_info()
         if shuffle:


### PR DESCRIPTION
shuffle=True is now a function argument. when passed as kwargs, it was crashing function in the non distributed case. so now shuffle does what we want, if True we use the different group sampler, if False (should not be used for training, only for debugging purposes), the data is always fed in the same order. 
reference issue: https://github.com/open-mmlab/mmdetection/issues/1649