### PR TITLE
Fix loader for images with no proposals

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -145,7 +145,7 @@ class LoadProposals(object):
             proposals = proposals[:self.num_max_proposals]
 
         if len(proposals) == 0:
-            proposals = np.array([0, 0, 0, 0], dtype=np.float32)
+            proposals = np.array([[0, 0, 0, 0]], dtype=np.float32)
         results['proposals'] = proposals
         results['bbox_fields'].append('proposals')
         return results


### PR DESCRIPTION
Since proposals of an image should be a [k, 4] or [k, 5] tensor, the dummy proposals ought to have the same number of dimensions as well.