### PR TITLE
Reorganize requirements, make albumentations optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ install:
   - pip install Pillow==6.2.2  # remove this line when torchvision>=0.5
   - pip install Cython torch==1.2 torchvision==0.4.0  # TODO: fix CI for pytorch>1.2
   - pip install -r requirements.txt
-  - pip install -r tests/requirements.txt
 
 before_script:
   - flake8 .

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,8 +42,7 @@ cd mmdetection
 d. Install mmdetection (other dependencies will be installed automatically).
 
 ```shell
-pip install mmcv
-python setup.py develop  # or "pip install -v -e ."
+pip install -v -e .[all]
 ```
 
 Note:
@@ -55,6 +54,8 @@ It is recommended that you run step d each time you pull some updates from githu
 
 3. If you would like to use `opencv-python-headless` instead of `opencv-python`,
 you can install it before installing MMCV.
+
+4. Some dependencies are optional simply running `pip install -v -e .` will only install the minimum runtime requirements. To use optional dependencies like `albumentations` and `imagecorruptions` either install them manually with `pip install -r requirements/optional.txt` or tell pip that optional dependencies are desired with `pip install -v -e .[optional]`.
 
 ### Another option: Docker Image
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -42,7 +42,7 @@ cd mmdetection
 d. Install mmdetection (other dependencies will be installed automatically).
 
 ```shell
-pip install -v -e .[all]
+pip install -v -e .
 ```
 
 Note:
@@ -55,7 +55,7 @@ It is recommended that you run step d each time you pull some updates from githu
 3. If you would like to use `opencv-python-headless` instead of `opencv-python`,
 you can install it before installing MMCV.
 
-4. Some dependencies are optional simply running `pip install -v -e .` will only install the minimum runtime requirements. To use optional dependencies like `albumentations` and `imagecorruptions` either install them manually with `pip install -r requirements/optional.txt` or tell pip that optional dependencies are desired with `pip install -v -e .[optional]`.
+4. Some dependencies are optional. Simply running `pip install -v -e .` will only install the minimum runtime requirements. To use optional dependencies like `albumentations` and `imagecorruptions` either install them manually with `pip install -r requirements/optional.txt` or specify desired extras when calling `pip` (e.g. `pip install -v -e .[optional]`). Valid keys for the extras field are: `all`, `tests`, `build`, and `optional`.
 
 ### Another option: Docker Image
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,10 +39,11 @@ git clone https://github.com/open-mmlab/mmdetection.git
 cd mmdetection
 ```
 
-d. Install mmdetection (other dependencies will be installed automatically).
+d. Install build requirements and then install mmdetection.
 
 ```shell
-pip install -v -e .
+pip install -r requirements/build.txt
+pip install -v -e .  # or "python setup.py develop"
 ```
 
 Note:

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -1,14 +1,19 @@
 import inspect
 
-import albumentations
 import mmcv
 import numpy as np
-from albumentations import Compose
 from imagecorruptions import corrupt
 from numpy import random
 
 from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
 from ..registry import PIPELINES
+
+try:
+    import albumentations
+    from albumentations import Compose
+except ImportError:
+    albumentations = None
+    Compose = None
 
 
 @PIPELINES.register_module
@@ -728,6 +733,8 @@ class Albu(object):
         skip_img_without_anno (bool): whether to skip the image
                                       if no ann left after aug
         """
+        if Compose is None:
+            raise RuntimeError('albumentations is not installed')
 
         self.transforms = transforms
         self.filter_lost_elements = False
@@ -771,6 +778,8 @@ class Albu(object):
 
         obj_type = args.pop("type")
         if mmcv.is_str(obj_type):
+            if albumentations is None:
+                raise RuntimeError('albumentations is not installed')
             obj_cls = getattr(albumentations, obj_type)
         elif inspect.isclass(obj_type):
             obj_cls = obj_type

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2,11 +2,15 @@ import inspect
 
 import mmcv
 import numpy as np
-from imagecorruptions import corrupt
 from numpy import random
 
 from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
 from ..registry import PIPELINES
+
+try:
+    from imagecorruptions import corrupt
+except ImportError:
+    corrupt = None
 
 try:
     import albumentations
@@ -700,6 +704,8 @@ class Corrupt(object):
         self.severity = severity
 
     def __call__(self, results):
+        if corrupt is None:
+            raise RuntimeError('imagecorruptions is not installed')
         results['img'] = corrupt(
             results['img'].astype(np.uint8),
             corruption_name=self.corruption,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
-albumentations>=0.3.2
-imagecorruptions
-matplotlib
-mmcv>=0.2.16
-numpy
-pycocotools
-six
-terminaltables
-torch>=1.1
-torchvision
+-r requirements/runtime.txt
+-r requirements/optional.txt
+-r requirements/tests.txt
+-r requirements/build.txt

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,3 @@
+pytest-runner
+cython
+numpy

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
-pytest-runner
+# These must be installed before building mmdetection
 cython
 numpy
+torch>=1.1

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,0 +1,1 @@
+albumentations>=0.3.2

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,1 +1,2 @@
 albumentations>=0.3.2
+imagecorruptions

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,9 @@
+imagecorruptions
+matplotlib
+mmcv>=0.2.15
+numpy
+pycocotools
+six
+terminaltables
+torch>=1.1
+torchvision

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,4 +6,6 @@ six
 terminaltables
 torch>=1.1
 torchvision
+
+# need older pillow until torchvision is fixed
 Pillow<=6.2.2

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -7,3 +7,4 @@ six
 terminaltables
 torch>=1.1
 torchvision
+Pillow<=6.2.2

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,3 @@
-imagecorruptions
 matplotlib
 mmcv>=0.2.15
 numpy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,10 +1,10 @@
-isort
-flake8
-yapf
-pytest-cov
-codecov
-xdoctest >= 0.10.0
 asynctest
-
+codecov
+flake8
+isort
+pytest 
+pytest-cov
+xdoctest >= 0.10.0
+yapf
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.
 kwarray

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -4,6 +4,7 @@ flake8
 isort
 pytest 
 pytest-cov
+pytest-runner
 xdoctest >= 0.10.0
 yapf
 # Note: used for kwarray.group_items, this may be ported to mmcv in the future.

--- a/setup.py
+++ b/setup.py
@@ -133,14 +133,14 @@ def make_cython_ext(name, module, sources):
     return extension
 
 
-def parse_requirements(fname='requirements.txt', with_version=False):
+def parse_requirements(fname='requirements.txt', with_version=True):
     """
     Parse the package dependencies listed in a requirements file but strips
     specific versioning information.
 
     Args:
         fname (str): path to requirements file
-        with_version (bool, default=False): if true include version specs
+        with_version (bool, default=False): if True include version specs
 
     Returns:
         List[str]: list of requirements items

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,8 @@ def parse_requirements(fname='requirements.txt', with_version=False):
                     if ';' in rest:
                         # Handle platform specific dependencies
                         # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
-                        version, platform_deps = map(str.strip, rest.split(';'))
+                        version, platform_deps = map(str.strip,
+                                                     rest.split(';'))
                         info['platform_deps'] = platform_deps
                     else:
                         version = rest  # NOQA

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import os
 import platform
 import subprocess
@@ -131,11 +133,82 @@ def make_cython_ext(name, module, sources):
     return extension
 
 
-def get_requirements(filename='requirements.txt'):
-    here = os.path.dirname(os.path.realpath(__file__))
-    with open(os.path.join(here, filename), 'r') as f:
-        requires = [line.replace('\n', '') for line in f.readlines()]
-    return requires
+def parse_requirements(fname='requirements.txt', with_version=False):
+    """
+    Parse the package dependencies listed in a requirements file but strips
+    specific versioning information.
+
+    Args:
+        fname (str): path to requirements file
+        with_version (bool, default=False): if true include version specs
+
+    Returns:
+        List[str]: list of requirements items
+
+    CommandLine:
+        python -c "import setup; print(setup.parse_requirements())"
+    """
+    import sys
+    from os.path import exists
+    import re
+    require_fpath = fname
+
+    def parse_line(line):
+        """
+        Parse information from a line in a requirements text file
+        """
+        if line.startswith('-r '):
+            # Allow specifying requirements in other files
+            target = line.split(' ')[1]
+            for info in parse_require_file(target):
+                yield info
+        else:
+            info = {'line': line}
+            if line.startswith('-e '):
+                info['package'] = line.split('#egg=')[1]
+            else:
+                # Remove versioning from the package
+                pat = '(' + '|'.join(['>=', '==', '>']) + ')'
+                parts = re.split(pat, line, maxsplit=1)
+                parts = [p.strip() for p in parts]
+
+                info['package'] = parts[0]
+                if len(parts) > 1:
+                    op, rest = parts[1:]
+                    if ';' in rest:
+                        # Handle platform specific dependencies
+                        # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
+                        version, platform_deps = map(str.strip, rest.split(';'))
+                        info['platform_deps'] = platform_deps
+                    else:
+                        version = rest  # NOQA
+                    info['version'] = (op, version)
+            yield info
+
+    def parse_require_file(fpath):
+        with open(fpath, 'r') as f:
+            for line in f.readlines():
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    for info in parse_line(line):
+                        yield info
+
+    def gen_packages_items():
+        if exists(require_fpath):
+            for info in parse_require_file(require_fpath):
+                parts = [info['package']]
+                if with_version and 'version' in info:
+                    parts.extend(info['version'])
+                if not sys.version.startswith('3.4'):
+                    # apparently package_deps are broken in 3.4
+                    platform_deps = info.get('platform_deps')
+                    if platform_deps is not None:
+                        parts.append(';' + platform_deps)
+                item = ''.join(parts)
+                yield item
+
+    packages = list(gen_packages_items())
+    return packages
 
 
 if __name__ == '__main__':
@@ -161,9 +234,15 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.7',
         ],
         license='Apache License 2.0',
-        setup_requires=['pytest-runner', 'cython', 'numpy'],
-        tests_require=['pytest', 'xdoctest', 'asynctest'],
-        install_requires=get_requirements(),
+        setup_requires=parse_requirements('requirements/build.txt'),
+        tests_require=parse_requirements('requirements/tests.txt'),
+        install_requires=parse_requirements('requirements/runtime.txt'),
+        extras_require={
+            'all': parse_requirements('requirements.txt'),
+            'tests': parse_requirements('requirements/tests.txt'),
+            'build': parse_requirements('requirements/build.txt'),
+            'optional': parse_requirements('requirements/optional.txt'),
+        },
         ext_modules=[
             make_cuda_ext(
                 name='compiling_info',


### PR DESCRIPTION
The albumentations requires an old version of the `imgaug` library, which is incompatible with a lot of other software stacks (namely the one I'm using) which uses the latest `imgaug` library. 

It looks like `albumentations` is not tightly coupled with the system and mmdet can work just fine if it isn't installed. Therefore I'd like to propose to make it an optional requirement instead of a forced requirement. 

This PR does that and also reorganizes the requirements into a format that should be easier to use. Namely, requirements are broken down by what they are required for (e.g. runtime, tests, build, and options) and they all live in a `requirements` folder now. The base requirements.txt file uses the `-r` syntax to refer to each of those files, so `pip install -r requirements.txt` will install all requirements. 

I added an enhanced version of the `parse_requirements` function being used in the `setup.py` script, which handles the `-r` syntax. I also used `extras_require` to register each type of requirements separately. So by default when you `pip install mmdet` you will only get the runtime requirements, but if you `pip install mmdet[all]` you will get everything. Similarly you can `pip install mmdet[optional]` to only grab runtime and optional requirements. 

