### PR TITLE
bug for distributed training

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -31,7 +31,7 @@ def parse_losses(losses):
     log_vars['loss'] = loss
     for loss_name, loss_value in log_vars.items():
         # reduce loss when distributed training
-        if dist.is_initialized():
+        if dist.is_available() and dist.is_initialized():
             loss_value = loss_value.data.clone()
             dist.all_reduce(loss_value.div_(dist.get_world_size()))
         log_vars[loss_name] = loss_value.item()


### PR DESCRIPTION
fix a bug for distributed training in windows platform

in windows, pytorch 1.2, the dist.is_available() is False, it means the distributed training is not support in pytorch 1.2, so dist.is_initialized() could not be called