### PR TITLE
fix gt_masks type in maskiou_head._get_area_ratio

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -833,9 +833,8 @@ class Albu(object):
                     results[label] = np.array(
                         [results[label][i] for i in results['idx_mapper']])
                 if 'masks' in results:
-                    results['masks'] = [
-                        results['masks'][i] for i in results['idx_mapper']
-                    ]
+                    results['masks'] = np.array(
+                        [results['masks'][i] for i in results['idx_mapper']])
 
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):


### PR DESCRIPTION
Current version throws an exception bellow:

`File "/home/user/mmdetection/mmdet/models/mask_heads/maskiou_head.py", line 160, in _get_area_ratio
gt_instance_mask_area = gt_masks.sum((-1, -2)) 
AttributeError: 'list' object has no attribute 'sum'`

`gt_masks` is a list of masks, so the simplest fix is to convert them into np.array.

(I'm actually surprised that no one faced with this bug before ¯\_(ツ)_/¯) 