### PR TITLE
options for FCNMaskHead during testtime

### DIFF
--- a/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/mask_heads/fcn_mask_head.py
@@ -175,17 +175,17 @@ class FCNMaskHead(nn.Module):
             bbox_mask = (bbox_mask > rcnn_test_cfg.mask_thr_binary).astype(
                 np.uint8)
 
-            if rcnn_test_cfg.get("box_rel_masks"):
+            if rcnn_test_cfg.get('crop_mask', False):
                 im_mask = bbox_mask
             else:
                 im_mask = np.zeros((img_h, img_w), dtype=np.uint8)
                 im_mask[bbox[1]:bbox[1] + h, bbox[0]:bbox[0] + w] = bbox_mask
 
-            if rcnn_test_cfg.get("no_test_rle"):
-                cls_segms[label - 1].append(im_mask)
-            else:
+            if rcnn_test_cfg.get('rle_mask_encode', True):
                 rle = mask_util.encode(
-                    np.array(im_mask[:, :, np.newaxis], order="F"))[0]
+                    np.array(im_mask[:, :, np.newaxis], order='F'))[0]
                 cls_segms[label - 1].append(rle)
+            else:
+                cls_segms[label - 1].append(im_mask)
 
         return cls_segms

--- a/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/mask_heads/fcn_mask_head.py
@@ -170,14 +170,22 @@ class FCNMaskHead(nn.Module):
                 mask_pred_ = mask_pred[i, label, :, :]
             else:
                 mask_pred_ = mask_pred[i, 0, :, :]
-            im_mask = np.zeros((img_h, img_w), dtype=np.uint8)
 
             bbox_mask = mmcv.imresize(mask_pred_, (w, h))
             bbox_mask = (bbox_mask > rcnn_test_cfg.mask_thr_binary).astype(
                 np.uint8)
-            im_mask[bbox[1]:bbox[1] + h, bbox[0]:bbox[0] + w] = bbox_mask
-            rle = mask_util.encode(
-                np.array(im_mask[:, :, np.newaxis], order='F'))[0]
-            cls_segms[label - 1].append(rle)
+
+            if rcnn_test_cfg.get("box_rel_masks"):
+                im_mask = bbox_mask
+            else:
+                im_mask = np.zeros((img_h, img_w), dtype=np.uint8)
+                im_mask[bbox[1]:bbox[1] + h, bbox[0]:bbox[0] + w] = bbox_mask
+
+            if rcnn_test_cfg.get("no_test_rle"):
+                cls_segms[label - 1].append(im_mask)
+            else:
+                rle = mask_util.encode(
+                    np.array(im_mask[:, :, np.newaxis], order="F"))[0]
+                cls_segms[label - 1].append(rle)
 
         return cls_segms


### PR DESCRIPTION
This PR adds two more options for test config (see the example bellow).

```
test_cfg = dict(
    rpn=dict(
...
    ),
    rcnn=dict(
        score_thr=0.05,
        nms=dict(type="nms", iou_thr=0.5),
        max_per_img=100,
        mask_thr_binary=0.5,
        no_test_rle=True, # (1)
        box_rel_masks=True, # (2)
    ),
)
```

1. Allows one to disable costly RLE when you need raw binary masks for some postprocessing tricks
2. Since `no_test_rle` is applied you'll recieve N(=number of boxes) binary masks in fullres. In order to decrease memory usage option `box_rel_masks` allows you to get mask with the position inside an appropriate bbox.

Both are optional and disabled by default.

