### PR TITLE
Fix the incompatibility of the latest numpy and pycocotools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ before_install:
 install:
   - pip install Pillow==6.2.2  # remove this line when torchvision>=0.5
   - pip install Cython torch==1.2 torchvision==0.4.0  # TODO: fix CI for pytorch>1.2
+  - pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
   - pip install -r requirements.txt
 
 before_script:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -40,9 +40,11 @@ cd mmdetection
 ```
 
 d. Install build requirements and then install mmdetection.
+(We install pycocotools via the github repo instead of pypi because the pypi version is old and not compatible with the latest numpy.)
 
 ```shell
 pip install -r requirements/build.txt
+pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
 pip install -v -e .  # or "python setup.py develop"
 ```
 
@@ -102,7 +104,7 @@ mv train/*/* train/
 
 ### A from-scratch setup script
 
-Here is a full script for setting up mmdetection with conda and link the dataset path.
+Here is a full script for setting up mmdetection with conda and link the dataset path (supposing that your COCO dataset path is $COCO_ROOT).
 
 ```shell
 conda create -n open-mmlab python=3.7 -y
@@ -112,6 +114,8 @@ conda install -c pytorch pytorch torchvision -y
 conda install cython -y
 git clone https://github.com/open-mmlab/mmdetection.git
 cd mmdetection
+pip install -r requirements/build.txt
+pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
 pip install -v -e .
 
 mkdir data

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,11 +1,9 @@
-git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
 matplotlib
 mmcv>=0.2.15
 numpy
+# need older pillow until torchvision is fixed
+Pillow<=6.2.2
 six
 terminaltables
 torch>=1.1
 torchvision
-
-# need older pillow until torchvision is fixed
-Pillow<=6.2.2

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,7 +1,7 @@
+git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI
 matplotlib
 mmcv>=0.2.15
 numpy
-pycocotools
 six
 terminaltables
 torch>=1.1


### PR DESCRIPTION
```python
np.linspace(.5, 0.95, np.round((0.95 - .5) / .05) + 1, endpoint=True)
```
will raise a TypeError.