### PR TITLE
Speed up sampler

### DIFF
--- a/mmdet/core/bbox/samplers/random_sampler.py
+++ b/mmdet/core/bbox/samplers/random_sampler.py
@@ -1,4 +1,3 @@
-import numpy as np
 import torch
 
 from .base_sampler import BaseSampler

--- a/mmdet/core/bbox/samplers/random_sampler.py
+++ b/mmdet/core/bbox/samplers/random_sampler.py
@@ -18,20 +18,18 @@ class RandomSampler(BaseSampler):
         self.rng = demodata.ensure_rng(kwargs.get('rng', None))
 
     def random_choice(self, gallery, num):
-        """Random select some elements from the gallery.
-
-        It seems that Pytorch's implementation is slower than numpy so we use
-        numpy to randperm the indices.
-        """
+        """Random select some elements from the gallery. """
         assert len(gallery) >= num
-        if isinstance(gallery, list):
-            gallery = np.array(gallery)
-        cands = np.arange(len(gallery))
-        self.rng.shuffle(cands)
-        rand_inds = cands[:num]
-        if not isinstance(gallery, np.ndarray):
-            rand_inds = torch.from_numpy(rand_inds).long().to(gallery.device)
-        return gallery[rand_inds]
+
+        is_tensor = isinstance(gallery, torch.Tensor)
+        if not is_tensor:
+            gallery = torch.tensor(
+                gallery, dtype=torch.long, device=torch.cuda.current_device())
+        perm = torch.randperm(gallery.numel(), device=gallery.device)[:num]
+        rand_inds = gallery[perm]
+        if not is_tensor:
+            rand_inds = rand_inds.cpu().numpy()
+        return rand_inds
 
     def _sample_pos(self, assign_result, num_expected, **kwargs):
         """Randomly sample some positive samples."""

--- a/mmdet/core/bbox/samplers/random_sampler.py
+++ b/mmdet/core/bbox/samplers/random_sampler.py
@@ -17,7 +17,19 @@ class RandomSampler(BaseSampler):
         self.rng = demodata.ensure_rng(kwargs.get('rng', None))
 
     def random_choice(self, gallery, num):
-        """Random select some elements from the gallery. """
+        """Random select some elements from the gallery.
+
+        If `gallery` is a Tensor, the returned indices will be a Tensor;
+        If `gallery` is a ndarray or list, the returned indices will be a
+        ndarray.
+
+        Args:
+            gallery (Tensor | ndarray | list): indices pool.
+            num (int): expected sample num.
+
+        Returns:
+            Tensor or ndarray: sampled indices.
+        """
         assert len(gallery) >= num
 
         is_tensor = isinstance(gallery, torch.Tensor)


### PR DESCRIPTION
This pr reimplements `random_choice` with `torch.randperm`. 
It speeds up [libra faster r50](https://github.com/open-mmlab/mmdetection/blob/master/configs/libra_rcnn/libra_faster_rcnn_r50_fpn_1x.py) by around 0.02s\iter on TITAN XP.

