### PR TITLE
Uint8 fix

### DIFF
--- a/mmdet/core/anchor/anchor_target.py
+++ b/mmdet/core/anchor/anchor_target.py
@@ -165,13 +165,13 @@ def anchor_inside_flags(flat_anchors,
                         allowed_border=0):
     img_h, img_w = img_shape[:2]
     if allowed_border >= 0:
-        inside_flags = valid_flags & \
-            (flat_anchors[:, 0] >= -allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 1] >= -allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.uint8)
+        inside_flags = valid_flags.type(torch.bool) & \
+            (flat_anchors[:, 0] >= -allowed_border).type(torch.bool) & \
+            (flat_anchors[:, 1] >= -allowed_border).type(torch.bool) & \
+            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.bool) & \
+            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.bool)
     else:
-        inside_flags = valid_flags
+        inside_flags = valid_flags.type(torch.bool)
     return inside_flags
 
 

--- a/mmdet/core/anchor/anchor_target.py
+++ b/mmdet/core/anchor/anchor_target.py
@@ -180,9 +180,9 @@ def unmap(data, count, inds, fill=0):
     size count) """
     if data.dim() == 1:
         ret = data.new_full((count, ), fill)
-        ret[inds] = data
+        ret[inds.type(torch.bool)] = data
     else:
         new_size = (count, ) + data.size()[1:]
         ret = data.new_full(new_size, fill)
-        ret[inds, :] = data
+        ret[inds.type(torch.bool), :] = data
     return ret

--- a/mmdet/core/anchor/anchor_target.py
+++ b/mmdet/core/anchor/anchor_target.py
@@ -109,7 +109,7 @@ def anchor_target_single(flat_anchors,
     if not inside_flags.any():
         return (None, ) * 6
     # assign gt and sample anchors
-    anchors = flat_anchors[inside_flags, :]
+    anchors = flat_anchors[inside_flags.type(torch.bool), :]
 
     if sampling:
         assign_result, sampling_result = assign_and_sample(
@@ -165,13 +165,13 @@ def anchor_inside_flags(flat_anchors,
                         allowed_border=0):
     img_h, img_w = img_shape[:2]
     if allowed_border >= 0:
-        inside_flags = valid_flags.type(torch.bool) & \
-            (flat_anchors[:, 0] >= -allowed_border).type(torch.bool) & \
-            (flat_anchors[:, 1] >= -allowed_border).type(torch.bool) & \
-            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.bool) & \
-            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.bool)
+        inside_flags = valid_flags & \
+            (flat_anchors[:, 0] >= -allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 1] >= -allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.uint8) & \
+            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.uint8)
     else:
-        inside_flags = valid_flags.type(torch.bool)
+        inside_flags = valid_flags
     return inside_flags
 
 


### PR DESCRIPTION
Fix https://github.com/open-mmlab/mmdetection/issues/2017
In PyTorch 1.4, using tensor of type `torch.uint8` will cause a massive warning.
To avoid that, the `inside_flags` is converted to `bool` type. However, ***`Tensor.bool()` is not supported in the PyTorch 1.1, the `and` operation is also invalid for bool tensor, as well as `.any()`***.
Therefore, we use `tensor.type(torch.bool)` here.
The modification has been tested with two environments: PyTorch 1.1 & PyTorch 1.4.