### PR TITLE
Add SSDLite

### DIFF
--- a/configs/ssdlite_vgg16_300_coco.py
+++ b/configs/ssdlite_vgg16_300_coco.py
@@ -23,7 +23,7 @@ model = dict(
         anchor_ratios=([2], [2, 3], [2, 3], [2, 3], [2], [2]),
         target_means=(.0, .0, .0, .0),
         target_stds=(0.1, 0.1, 0.2, 0.2),
-        use_depthwise=False))
+        use_depthwise=True))
 cudnn_benchmark = True
 train_cfg = dict(
     assigner=dict(
@@ -130,7 +130,7 @@ log_config = dict(
 total_epochs = 24
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
-work_dir = './work_dirs/ssd300_coco'
+work_dir = './work_dirs/ssdlite_vgg16_300_coco'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]

--- a/mmdet/models/utils/__init__.py
+++ b/mmdet/models/utils/__init__.py
@@ -1,5 +1,6 @@
 from .conv_module import ConvModule, build_conv_layer
 from .conv_ws import ConvWS2d, conv_ws_2d
+from .depthwise_separable_conv import DepthwiseSeparableConv2d
 from .norm import build_norm_layer
 from .scale import Scale
 from .upsample import build_upsample_layer
@@ -9,5 +10,6 @@ from .weight_init import (bias_init_with_prob, kaiming_init, normal_init,
 __all__ = [
     'conv_ws_2d', 'ConvWS2d', 'build_conv_layer', 'ConvModule',
     'build_norm_layer', 'build_upsample_layer', 'xavier_init', 'normal_init',
-    'uniform_init', 'kaiming_init', 'bias_init_with_prob', 'Scale'
+    'uniform_init', 'kaiming_init', 'bias_init_with_prob', 'Scale',
+    'DepthwiseSeparableConv2d'
 ]

--- a/mmdet/models/utils/depthwise_separable_conv.py
+++ b/mmdet/models/utils/depthwise_separable_conv.py
@@ -1,0 +1,40 @@
+import torch.nn as nn
+
+
+class DepthwiseSeparableConv2d(nn.Module):
+
+    def __init__(self,
+                 in_channels,
+                 out_channels,
+                 kernel_size,
+                 stride=1,
+                 padding=0,
+                 dilation=1,
+                 bias=True,
+                 padding_mode='zeros'):
+        super(DepthwiseSeparableConv2d, self).__init__()
+        self.depthwise_conv = nn.Conv2d(
+            in_channels,
+            in_channels,
+            kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            groups=in_channels,
+            bias=bias,
+            padding_mode=padding_mode)
+        self.pointwise_conv = nn.Conv2d(
+            in_channels,
+            out_channels,
+            1,
+            stride=stride,
+            padding=0,
+            dilation=1,
+            groups=1,
+            bias=bias,
+            padding_mode=padding_mode)
+
+    def forward(self, x):
+        x = self.depthwise_conv(x)
+        x = self.pointwise_conv(x)
+        return x


### PR DESCRIPTION
Added an option to use depthwise separable convolutions in the SSDHEAD, which results in what is called **SSDLite** [MobileNetV2: Inverted Residuals and Linear Bottlenecks](https://arxiv.org/abs/1801.04381).

Currently running the added config, but so far (10/24 epochs in) the loss is nearly identical to the baseline.

I plan on implementing the full mobilenetv2-ssdlite, and maybe do some refactoring of the SSDHEAD module to easily support more backbones (e.g. get rid of the hard coded coco and voc 300/512 parameters), but that's for a future pull-request.