### PR TITLE
Fix IOU assigners when ignore_of_thr > 0 and no pred boxes

### DIFF
--- a/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
@@ -118,8 +118,8 @@ class ApproxMaxIoUAssigner(MaxIoUAssigner):
 
         bboxes = squares[:, :4]
 
-        if (self.ignore_iof_thr > 0) and (gt_bboxes_ignore is not None) and (
-                gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
+        if (self.ignore_iof_thr > 0 and gt_bboxes_ignore is not None
+                and gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
             if self.ignore_wrt_candidates:
                 ignore_overlaps = bbox_overlaps(
                     bboxes, gt_bboxes_ignore, mode='iof')

--- a/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
@@ -119,7 +119,7 @@ class ApproxMaxIoUAssigner(MaxIoUAssigner):
         bboxes = squares[:, :4]
 
         if (self.ignore_iof_thr > 0) and (gt_bboxes_ignore is not None) and (
-                gt_bboxes_ignore.numel() > 0):
+                gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
             if self.ignore_wrt_candidates:
                 ignore_overlaps = bbox_overlaps(
                     bboxes, gt_bboxes_ignore, mode='iof')

--- a/mmdet/core/bbox/assigners/max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/max_iou_assigner.py
@@ -98,8 +98,8 @@ class MaxIoUAssigner(BaseAssigner):
         bboxes = bboxes[:, :4]
         overlaps = bbox_overlaps(gt_bboxes, bboxes)
 
-        if (self.ignore_iof_thr > 0) and (gt_bboxes_ignore is not None) and (
-                gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
+        if (self.ignore_iof_thr > 0 and gt_bboxes_ignore is not None
+                and gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
             if self.ignore_wrt_candidates:
                 ignore_overlaps = bbox_overlaps(
                     bboxes, gt_bboxes_ignore, mode='iof')

--- a/mmdet/core/bbox/assigners/max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/max_iou_assigner.py
@@ -99,7 +99,7 @@ class MaxIoUAssigner(BaseAssigner):
         overlaps = bbox_overlaps(gt_bboxes, bboxes)
 
         if (self.ignore_iof_thr > 0) and (gt_bboxes_ignore is not None) and (
-                gt_bboxes_ignore.numel() > 0):
+                gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
             if self.ignore_wrt_candidates:
                 ignore_overlaps = bbox_overlaps(
                     bboxes, gt_bboxes_ignore, mode='iof')

--- a/tests/test_assigner.py
+++ b/tests/test_assigner.py
@@ -133,14 +133,17 @@ def test_max_iou_assigner_with_empty_boxes_and_ignore():
     gt_labels = torch.LongTensor([2, 3])
 
     # Test with gt_labels
-    assign_result = self.assign(bboxes, gt_bboxes, gt_labels=gt_labels,
-                                gt_bboxes_ignore=gt_bboxes_ignore)
+    assign_result = self.assign(
+        bboxes,
+        gt_bboxes,
+        gt_labels=gt_labels,
+        gt_bboxes_ignore=gt_bboxes_ignore)
     assert len(assign_result.gt_inds) == 0
     assert tuple(assign_result.labels.shape) == (0, )
 
     # Test without gt_labels
-    assign_result = self.assign(bboxes, gt_bboxes, gt_labels=None,
-                                gt_bboxes_ignore=gt_bboxes_ignore)
+    assign_result = self.assign(
+        bboxes, gt_bboxes, gt_labels=None, gt_bboxes_ignore=gt_bboxes_ignore)
     assert len(assign_result.gt_inds) == 0
     assert assign_result.labels is None
 

--- a/tests/test_assigner.py
+++ b/tests/test_assigner.py
@@ -112,6 +112,39 @@ def test_max_iou_assigner_with_empty_boxes():
     assert assign_result.labels is None
 
 
+def test_max_iou_assigner_with_empty_boxes_and_ignore():
+    """
+    Test corner case where an network might predict no boxes and ignore_iof_thr
+    is on
+    """
+    self = MaxIoUAssigner(
+        pos_iou_thr=0.5,
+        neg_iou_thr=0.5,
+        ignore_iof_thr=0.5,
+    )
+    bboxes = torch.empty((0, 4))
+    gt_bboxes = torch.FloatTensor([
+        [0, 0, 10, 9],
+        [0, 10, 10, 19],
+    ])
+    gt_bboxes_ignore = torch.Tensor([
+        [30, 30, 40, 40],
+    ])
+    gt_labels = torch.LongTensor([2, 3])
+
+    # Test with gt_labels
+    assign_result = self.assign(bboxes, gt_bboxes, gt_labels=gt_labels,
+                                gt_bboxes_ignore=gt_bboxes_ignore)
+    assert len(assign_result.gt_inds) == 0
+    assert tuple(assign_result.labels.shape) == (0, )
+
+    # Test without gt_labels
+    assign_result = self.assign(bboxes, gt_bboxes, gt_labels=None,
+                                gt_bboxes_ignore=gt_bboxes_ignore)
+    assert len(assign_result.gt_inds) == 0
+    assert assign_result.labels is None
+
+
 def test_max_iou_assigner_with_empty_boxes_and_gt():
     """
     Test corner case where an network might predict no boxes and no gt


### PR DESCRIPTION
When ignore_of_thr is enabled and there are no predicted bboxes, the `.max` function fails because the `ignore_overlaps` tensor is empty. The error is as follows:

```
~/code/mmdetection/mmdet/core/bbox/assigners/max_iou_assigner.py in assign(self, bboxes, gt_bboxes, gt_bboxes_ignore, gt_labels)
    104                 ignore_overlaps = bbox_overlaps(
    105                     bboxes, gt_bboxes_ignore, mode='iof')
--> 106                 ignore_max_overlaps, _ = ignore_overlaps.max(dim=1)
    107             else:
    108                 ignore_overlaps = bbox_overlaps(

RuntimeError: cannot perform reduction function max on tensor with no elements because the operation does not have an identity
```

This can be fixed by simply checking that bboxes isn't empty before running the code. I've added this fix for both approx and max iou assigners. I've also added a test, which currently passes, but will fail if the patch is removed. 