### PR TITLE
Unify regression loss

### DIFF
--- a/mmdet/core/bbox/samplers/ohem_sampler.py
+++ b/mmdet/core/bbox/samplers/ohem_sampler.py
@@ -40,6 +40,7 @@ class OHEMSampler(BaseSampler):
             loss = self.bbox_head.loss(
                 cls_score=cls_score,
                 bbox_pred=None,
+                rois=rois,
                 labels=labels,
                 label_weights=cls_score.new_ones(cls_score.size(0)),
                 bbox_targets=None,

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -309,7 +309,7 @@ class AnchorHead(nn.Module):
 
         # anchor number of multi levels
         num_level_anchors = [anchors.size(0) for anchors in anchor_list[0]]
-        # concat all level anchors and flags to a single tensor
+        # concat all level anchors to a single tensor
         concat_anchor_list = []
         concat_valid_flag_list = []
         for i in range(num_imgs):

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -48,6 +48,7 @@ class AnchorHead(nn.Module):
                      type='DeltaXYWHBBoxCoder',
                      target_means=(.0, .0, .0, .0),
                      target_stds=(1.0, 1.0, 1.0, 1.0)),
+                 reg_decoded_bbox=False,
                  background_label=None,
                  loss_cls=dict(
                      type='CrossEntropyLoss',
@@ -77,6 +78,7 @@ class AnchorHead(nn.Module):
 
         if self.cls_out_channels <= 0:
             raise ValueError('num_classes={} is too small'.format(num_classes))
+        self.reg_decoded_bbox = reg_decoded_bbox
 
         self.background_label = (
             num_classes if background_label is None else background_label)
@@ -231,8 +233,11 @@ class AnchorHead(nn.Module):
         pos_inds = sampling_result.pos_inds
         neg_inds = sampling_result.neg_inds
         if len(pos_inds) > 0:
-            pos_bbox_targets = self.bbox_coder.encode(
-                sampling_result.pos_bboxes, sampling_result.pos_gt_bboxes)
+            if not self.reg_decoded_bbox:
+                pos_bbox_targets = self.bbox_coder.encode(
+                    sampling_result.pos_bboxes, sampling_result.pos_gt_bboxes)
+            else:
+                pos_bbox_targets = sampling_result.pos_gt_bboxes
             bbox_targets[pos_inds, :] = pos_bbox_targets
             bbox_weights[pos_inds, :] = 1.0
             if gt_labels is None:
@@ -305,10 +310,12 @@ class AnchorHead(nn.Module):
         # anchor number of multi levels
         num_level_anchors = [anchors.size(0) for anchors in anchor_list[0]]
         # concat all level anchors and flags to a single tensor
+        concat_anchor_list = []
+        concat_valid_flag_list = []
         for i in range(num_imgs):
             assert len(anchor_list[i]) == len(valid_flag_list[i])
-            anchor_list[i] = torch.cat(anchor_list[i])
-            valid_flag_list[i] = torch.cat(valid_flag_list[i])
+            concat_anchor_list.append(torch.cat(anchor_list[i]))
+            concat_valid_flag_list.append(torch.cat(valid_flag_list[i]))
 
         # compute targets for each image
         if gt_bboxes_ignore_list is None:
@@ -318,8 +325,8 @@ class AnchorHead(nn.Module):
         (all_labels, all_label_weights, all_bbox_targets, all_bbox_weights,
          pos_inds_list, neg_inds_list) = multi_apply(
              self._get_targets_single,
-             anchor_list,
-             valid_flag_list,
+             concat_anchor_list,
+             concat_valid_flag_list,
              gt_bboxes_list,
              gt_bboxes_ignore_list,
              gt_labels_list,
@@ -343,7 +350,7 @@ class AnchorHead(nn.Module):
         return (labels_list, label_weights_list, bbox_targets_list,
                 bbox_weights_list, num_total_pos, num_total_neg)
 
-    def loss_single(self, cls_score, bbox_pred, labels, label_weights,
+    def loss_single(self, cls_score, bbox_pred, anchors, labels, label_weights,
                     bbox_targets, bbox_weights, num_total_samples):
         # classification loss
         labels = labels.reshape(-1)
@@ -356,6 +363,9 @@ class AnchorHead(nn.Module):
         bbox_targets = bbox_targets.reshape(-1, 4)
         bbox_weights = bbox_weights.reshape(-1, 4)
         bbox_pred = bbox_pred.permute(0, 2, 3, 1).reshape(-1, 4)
+        if self.reg_decoded_bbox:
+            anchors = anchors.reshape(-1, 4)
+            bbox_pred = self.bbox_coder.decode(anchors, bbox_pred)
         loss_bbox = self.loss_bbox(
             bbox_pred,
             bbox_targets,
@@ -393,10 +403,21 @@ class AnchorHead(nn.Module):
          num_total_pos, num_total_neg) = cls_reg_targets
         num_total_samples = (
             num_total_pos + num_total_neg if self.sampling else num_total_pos)
+
+        # anchor number of multi levels
+        num_level_anchors = [anchors.size(0) for anchors in anchor_list[0]]
+        # concat all level anchors and flags to a single tensor
+        concat_anchor_list = []
+        for i in range(len(anchor_list)):
+            concat_anchor_list.append(torch.cat(anchor_list[i]))
+        all_anchor_list = images_to_levels(concat_anchor_list,
+                                           num_level_anchors)
+
         losses_cls, losses_bbox = multi_apply(
             self.loss_single,
             cls_scores,
             bbox_preds,
+            all_anchor_list,
             labels_list,
             label_weights_list,
             bbox_targets_list,

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -25,8 +25,9 @@ class AnchorHead(nn.Module):
         anchor_ratios (Iterable): Anchor aspect ratios.
         anchor_strides (Iterable): Anchor strides.
         anchor_base_sizes (Iterable): Anchor base sizes.
-        target_means (Iterable): Mean values of regression targets.
-        target_stds (Iterable): Std values of regression targets.
+        bbox_coder (dict): Config of bounding box coder.
+        reg_decoded_bbox (bool): If true, the regression loss would be
+            applied on decoded bounding boxes. Default: False
         background_label (int | None): Label ID of background, set as 0 for
             RPN and num_classes for other heads. It will automatically set as
             num_classes if None is given.

--- a/mmdet/models/anchor_heads/atss_head.py
+++ b/mmdet/models/anchor_heads/atss_head.py
@@ -363,7 +363,6 @@ class ATSSHead(AnchorHead):
                     valid_flag_list,
                     gt_bboxes_list,
                     img_metas,
-                    cfg,
                     gt_bboxes_ignore_list=None,
                     gt_labels_list=None,
                     label_channels=1,
@@ -402,9 +401,7 @@ class ATSSHead(AnchorHead):
              gt_bboxes_ignore_list,
              gt_labels_list,
              img_metas,
-             cfg=cfg,
              label_channels=label_channels,
-             background_label=self.background_label,
              unmap_outputs=unmap_outputs)
         # no valid anchors
         if any([labels is None for labels in all_labels]):
@@ -433,13 +430,11 @@ class ATSSHead(AnchorHead):
                            gt_bboxes_ignore,
                            gt_labels,
                            img_meta,
-                           cfg,
                            label_channels=1,
-                           background_label=80,
                            unmap_outputs=True):
         inside_flags = anchor_inside_flags(flat_anchors, valid_flags,
                                            img_meta['img_shape'][:2],
-                                           cfg.allowed_border)
+                                           self.train_cfg.allowed_border)
         if not inside_flags.any():
             return (None, ) * 6
         # assign gt and sample anchors
@@ -458,7 +453,7 @@ class ATSSHead(AnchorHead):
         bbox_targets = torch.zeros_like(anchors)
         bbox_weights = torch.zeros_like(anchors)
         labels = anchors.new_full((num_valid_anchors, ),
-                                  background_label,
+                                  self.background_label,
                                   dtype=torch.long)
         label_weights = anchors.new_zeros(num_valid_anchors, dtype=torch.float)
 
@@ -474,10 +469,10 @@ class ATSSHead(AnchorHead):
             else:
                 labels[pos_inds] = gt_labels[
                     sampling_result.pos_assigned_gt_inds]
-            if cfg.pos_weight <= 0:
+            if self.train_cfg.pos_weight <= 0:
                 label_weights[pos_inds] = 1.0
             else:
-                label_weights[pos_inds] = cfg.pos_weight
+                label_weights[pos_inds] = self.train_cfg.pos_weight
         if len(neg_inds) > 0:
             label_weights[neg_inds] = 1.0
 

--- a/mmdet/models/anchor_heads/atss_head.py
+++ b/mmdet/models/anchor_heads/atss_head.py
@@ -46,30 +46,24 @@ class ATSSHead(AnchorHead):
                      type='CrossEntropyLoss',
                      use_sigmoid=True,
                      loss_weight=1.0),
-                 train_cfg=None,
-                 test_cfg=None,
                  **kwargs):
         self.stacked_convs = stacked_convs
         self.octave_base_scale = octave_base_scale
         self.scales_per_octave = scales_per_octave
         self.conv_cfg = conv_cfg
         self.norm_cfg = norm_cfg
-        self.sampling = False
-        self.train_cfg = train_cfg
-        self.test_cfg = test_cfg
-
-        if self.train_cfg:
-            self.assigner = build_assigner(self.train_cfg.assigner)
-            # SSD sampling=False so use PseudoSampler
-            sampler_cfg = dict(type='PseudoSampler')
-            self.sampler = build_sampler(sampler_cfg, context=self)
-
         octave_scales = np.array(
             [2**(i / scales_per_octave) for i in range(scales_per_octave)])
         anchor_scales = octave_scales * octave_base_scale
         super(ATSSHead, self).__init__(
             num_classes, in_channels, anchor_scales=anchor_scales, **kwargs)
 
+        self.sampling = False
+        if self.train_cfg:
+            self.assigner = build_assigner(self.train_cfg.assigner)
+            # SSD sampling=False so use PseudoSampler
+            sampler_cfg = dict(type='PseudoSampler')
+            self.sampler = build_sampler(sampler_cfg, context=self)
         self.loss_centerness = build_loss(loss_centerness)
 
     def _init_layers(self):

--- a/mmdet/models/anchor_heads/guided_anchor_head.py
+++ b/mmdet/models/anchor_heads/guided_anchor_head.py
@@ -719,7 +719,7 @@ class GuidedAnchorHead(AnchorHead):
         num_level_anchors = [
             anchors.size(0) for anchors in guided_anchors_list[0]
         ]
-        # concat all level anchors and flags to a single tensor
+        # concat all level anchors to a single tensor
         concat_anchor_list = []
         for i in range(len(guided_anchors_list)):
             concat_anchor_list.append(torch.cat(guided_anchors_list[i]))

--- a/mmdet/models/anchor_heads/guided_anchor_head.py
+++ b/mmdet/models/anchor_heads/guided_anchor_head.py
@@ -117,6 +117,7 @@ class GuidedAnchorHead(AnchorHead):
             target_means=[.0, .0, .0, .0],
             target_stds=[1.0, 1.0, 1.0, 1.0]
         ),
+        reg_decoded_bbox=False,
         deformable_groups=4,
         loc_filter_thr=0.01,
         background_label=None,
@@ -158,6 +159,8 @@ class GuidedAnchorHead(AnchorHead):
             # Generators for squares
             self.square_generators.append(
                 AnchorGenerator(anchor_base, [self.octave_base_scale], [1.0]))
+
+        self.reg_decoded_bbox = reg_decoded_bbox
 
         self.background_label = (
             num_classes if background_label is None else background_label)
@@ -712,11 +715,23 @@ class GuidedAnchorHead(AnchorHead):
         num_total_samples = (
             num_total_pos + num_total_neg if self.sampling else num_total_pos)
 
+        # anchor number of multi levels
+        num_level_anchors = [
+            anchors.size(0) for anchors in guided_anchors_list[0]
+        ]
+        # concat all level anchors and flags to a single tensor
+        concat_anchor_list = []
+        for i in range(len(guided_anchors_list)):
+            concat_anchor_list.append(torch.cat(guided_anchors_list[i]))
+        all_anchor_list = images_to_levels(concat_anchor_list,
+                                           num_level_anchors)
+
         # get classification and bbox regression losses
         losses_cls, losses_bbox = multi_apply(
             self.loss_single,
             cls_scores,
             bbox_preds,
+            all_anchor_list,
             labels_list,
             label_weights_list,
             bbox_targets_list,

--- a/mmdet/models/anchor_heads/ssd_head.py
+++ b/mmdet/models/anchor_heads/ssd_head.py
@@ -206,7 +206,7 @@ class SSDHead(AnchorHead):
         all_bbox_weights = torch.cat(bbox_weights_list,
                                      -2).view(num_images, -1, 4)
 
-        # concat all level anchors and flags to a single tensor
+        # concat all level anchors to a single tensor
         all_anchors = []
         for i in range(num_images):
             all_anchors.append(torch.cat(anchor_list[i]))

--- a/mmdet/models/anchor_heads/ssd_head.py
+++ b/mmdet/models/anchor_heads/ssd_head.py
@@ -28,6 +28,7 @@ class SSDHead(AnchorHead):
                      target_means=[.0, .0, .0, .0],
                      target_stds=[1.0, 1.0, 1.0, 1.0],
                  ),
+                 reg_decoded_bbox=False,
                  train_cfg=None,
                  test_cfg=None):
         super(AnchorHead, self).__init__()
@@ -95,6 +96,8 @@ class SSDHead(AnchorHead):
                 anchor_generator.base_anchors, 0, torch.LongTensor(indices))
             self.anchor_generators.append(anchor_generator)
 
+        self.reg_decoded_bbox = reg_decoded_bbox
+
         self.background_label = (
             num_classes if background_label is None else background_label)
         # background_label should be either 0 or num_classes
@@ -129,7 +132,7 @@ class SSDHead(AnchorHead):
             bbox_preds.append(reg_conv(feat))
         return cls_scores, bbox_preds
 
-    def loss_single(self, cls_score, bbox_pred, labels, label_weights,
+    def loss_single(self, cls_score, bbox_pred, anchor, labels, label_weights,
                     bbox_targets, bbox_weights, num_total_samples):
         loss_cls_all = F.cross_entropy(
             cls_score, labels, reduction='none') * label_weights
@@ -146,6 +149,9 @@ class SSDHead(AnchorHead):
         loss_cls_pos = loss_cls_all[pos_inds].sum()
         loss_cls_neg = topk_loss_cls_neg.sum()
         loss_cls = (loss_cls_pos + loss_cls_neg) / num_total_samples
+
+        if self.reg_decoded_bbox:
+            bbox_pred = self.bbox_coder.decode(anchor, bbox_pred)
 
         loss_bbox = smooth_l1_loss(
             bbox_pred,
@@ -200,6 +206,11 @@ class SSDHead(AnchorHead):
         all_bbox_weights = torch.cat(bbox_weights_list,
                                      -2).view(num_images, -1, 4)
 
+        # concat all level anchors and flags to a single tensor
+        all_anchors = []
+        for i in range(num_images):
+            all_anchors.append(torch.cat(anchor_list[i]))
+
         # check NaN and Inf
         assert torch.isfinite(all_cls_scores).all().item(), \
             'classification scores become infinite or NaN!'
@@ -210,6 +221,7 @@ class SSDHead(AnchorHead):
             self.loss_single,
             all_cls_scores,
             all_bbox_preds,
+            all_anchors,
             all_labels,
             all_label_weights,
             all_bbox_targets,

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -23,7 +23,7 @@ def iou_loss(pred, target, eps=1e-6):
         Tensor: Loss tensor.
     """
     ious = bbox_overlaps(pred, target, is_aligned=True).clamp(min=eps)
-    loss = -ious.log()
+    loss = -ious.log().unsqueeze(dim=1)
     return loss
 
 

--- a/mmdet/models/roi_heads/cascade_roi_head.py
+++ b/mmdet/models/roi_heads/cascade_roi_head.py
@@ -137,7 +137,7 @@ class CascadeRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         bbox_targets = self.bbox_head[stage].get_targets(
             sampling_results, gt_bboxes, gt_labels, rcnn_train_cfg)
         loss_bbox = self.bbox_head[stage].loss(bbox_results['cls_score'],
-                                               bbox_results['bbox_pred'],
+                                               bbox_results['bbox_pred'], rois,
                                                *bbox_targets)
 
         bbox_results.update(

--- a/mmdet/models/roi_heads/htc_roi_head.py
+++ b/mmdet/models/roi_heads/htc_roi_head.py
@@ -100,7 +100,8 @@ class HybridTaskCascadeRoIHead(CascadeRoIHead):
         bbox_targets = bbox_head.get_targets(sampling_results, gt_bboxes,
                                              gt_labels, rcnn_train_cfg)
         loss_bbox = bbox_head.loss(bbox_results['cls_score'],
-                                   bbox_results['bbox_pred'], *bbox_targets)
+                                   bbox_results['bbox_pred'], rois,
+                                   *bbox_targets)
 
         bbox_results.update(
             loss_bbox=loss_bbox,

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -152,7 +152,7 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         bbox_targets = self.bbox_head.get_targets(sampling_results, gt_bboxes,
                                                   gt_labels, self.train_cfg)
         loss_bbox = self.bbox_head.loss(bbox_results['cls_score'],
-                                        bbox_results['bbox_pred'],
+                                        bbox_results['bbox_pred'], rois,
                                         *bbox_targets)
 
         bbox_results.update(loss_bbox=loss_bbox)


### PR DESCRIPTION
This PR unified the regression loss in `bbox_head`. 
Attribute `reg_delta_target = True` indicates the regression target is the delta between prediction and target, otherwise regression target is the ground truth bounding box.
Fixed https://github.com/open-mmlab/mmdetection/issues/2143 so that `IoULoss` could be applied directly in `bbox_head`. 