### PR TITLE
Fix FPN upscale

### DIFF
--- a/mmdet/models/necks/fpn.py
+++ b/mmdet/models/necks/fpn.py
@@ -9,6 +9,43 @@ from ..utils import ConvModule
 
 @NECKS.register_module
 class FPN(nn.Module):
+    """
+    Feature Pyramid Network.
+
+    This is an implementation of - Feature Pyramid Networks for Object
+    Detection (https://arxiv.org/abs/1612.03144)
+
+    Args:
+        in_channels (List[int]):
+            number of input channels per scale
+
+        out_channels (int):
+            number of output channels (used at each scale)
+
+        num_outs (int):
+            number of output scales
+
+        start_level (int):
+            index of the first input scale to use as an output scale
+
+        end_level (int, default=-1):
+            index of the last input scale to use as an output scale
+
+    Example:
+        >>> import torch
+        >>> in_channels = [2, 3, 5, 7]
+        >>> scales = [340, 170, 84, 43]
+        >>> inputs = [torch.rand(1, c, s, s)
+        ...           for c, s in zip(in_channels, scales)]
+        >>> self = FPN(in_channels, 11, len(in_channels)).eval()
+        >>> outputs = self.forward(inputs)
+        >>> for i in range(len(outputs)):
+        ...     print('outputs[{}].shape = {!r}'.format(i, outputs[i].shape))
+        outputs[0].shape = torch.Size([1, 11, 340, 340])
+        outputs[1].shape = torch.Size([1, 11, 170, 170])
+        outputs[2].shape = torch.Size([1, 11, 84, 84])
+        outputs[3].shape = torch.Size([1, 11, 43, 43])
+    """
 
     def __init__(self,
                  in_channels,
@@ -111,8 +148,9 @@ class FPN(nn.Module):
         # build top-down path
         used_backbone_levels = len(laterals)
         for i in range(used_backbone_levels - 1, 0, -1):
+            prev_shape = laterals[i - 1].shape[2:]
             laterals[i - 1] += F.interpolate(
-                laterals[i], scale_factor=2, mode='nearest')
+                laterals[i], size=prev_shape, mode='nearest')
 
         # build outputs
         # part 1: from original levels


### PR DESCRIPTION
Currently the FPN module is broken for certain input sizes due to the assumption that each previous scale will always be 2x as large as the current scale. This is not always the case. In a cascade rcnn model I'm working with the size of each layer in the feature pyramid is: 

```
laterals[0].shape = torch.Size([1, 256, 256, 340])
laterals[1].shape = torch.Size([1, 256, 128, 170])
laterals[2].shape = torch.Size([1, 256, 64, 85])
laterals[3].shape = torch.Size([1, 256, 32, 43])
```

The key difference is that 43 * 2 is not equal to 85. This causes an error:

```python
~/code/mmdetection/mmdet/models/necks/fpn.py in forward(self, inputs)
    112         used_backbone_levels = len(laterals)
    113         for i in range(used_backbone_levels - 1, 0, -1):
--> 114             laterals[i - 1] += F.interpolate(
    115                 laterals[i], scale_factor=2, mode='nearest')
    116 

RuntimeError: The size of tensor a (85) must match the size of tensor b (86) at non-singleton dimension 3
```

However, this can be fixed by replacing the `scale_factor` in `F.interpolate` with the `size` parameter and explicitly passing it the correct size of the previous layer: 

```python
            target_shape = laterals[i - 1].shape[2:]
            laterals[i - 1] += F.interpolate(
                laterals[i], size=target_shape, mode='nearest')
```

That change does fix my use-case, but I also want to make sure it won't break existing pretrained models. To verify this I came up the the following code: 

```python
        >>> from mmdet.models.necks.fpn import *  # NOQA
        >>> import torch
        >>> in_channels = [2, 3, 5, 7]
        >>> scales = [16, 8, 4, 2]
        >>> inputs = [torch.rand(1, c, s, s)
        ...           for c, s in zip(in_channels, scales)]
        >>> self = FPN(in_channels, 11, len(in_channels)).eval()
        >>> # Force inputs and parameters to be deterministic
        >>> for x in inputs:
        ...     x.view(-1)[:] = torch.linspace(0, 1, x.numel())
        >>> for p in self.parameters():
        ...     p.view(-1)[:] = torch.linspace(0, 1, p.numel())
        >>> outputs = self.forward(inputs)
        >>> for i in range(len(outputs)):
        ...     print('outputs[{}].mean() = {!r}'.format(i, outputs[i].mean()))
```

This produces an FPN with the exact same weights each time. I ran the code and inspected the outputs once with the original interpolate code, and once with my patch. Both of them returned outputs with the same mean values (which I'm using as evidence that the computation is indeed the same as the 2x upsample case). 

```
outputs[0].mean() = tensor(299.2685, grad_fn=<MeanBackward0>)
outputs[1].mean() = tensor(230.4240, grad_fn=<MeanBackward0>)
outputs[2].mean() = tensor(145.4662, grad_fn=<MeanBackward0>)
outputs[3].mean() = tensor(52.7472, grad_fn=<MeanBackward0>)
```

You should be able to verify this by running above code on an unpatched version of mmdetection. It should produce the same result. 

