### PR TITLE
Support polygon mask training

### DIFF
--- a/configs/mask_rcnn_r50_fpn_poly_1x.py
+++ b/configs/mask_rcnn_r50_fpn_poly_1x.py
@@ -187,7 +187,7 @@ log_config = dict(
 total_epochs = 12
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
-work_dir = './work_dirs/mask_rcnn_r50_fpn_1x'
+work_dir = './work_dirs/mask_rcnn_r50_fpn_poly_1x'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]

--- a/configs/mask_rcnn_r50_fpn_poly_1x.py
+++ b/configs/mask_rcnn_r50_fpn_poly_1x.py
@@ -1,0 +1,193 @@
+# model settings
+model = dict(
+    type='MaskRCNN',
+    pretrained='torchvision://resnet50',
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=1,
+        style='pytorch'),
+    neck=dict(
+        type='FPN',
+        in_channels=[256, 512, 1024, 2048],
+        out_channels=256,
+        num_outs=5),
+    rpn_head=dict(
+        type='RPNHead',
+        in_channels=256,
+        feat_channels=256,
+        anchor_scales=[8],
+        anchor_ratios=[0.5, 1.0, 2.0],
+        anchor_strides=[4, 8, 16, 32, 64],
+        target_means=[.0, .0, .0, .0],
+        target_stds=[1.0, 1.0, 1.0, 1.0],
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0 / 9.0, loss_weight=1.0)),
+    bbox_roi_extractor=dict(
+        type='SingleRoIExtractor',
+        roi_layer=dict(type='RoIAlign', out_size=7, sample_num=2),
+        out_channels=256,
+        featmap_strides=[4, 8, 16, 32]),
+    bbox_head=dict(
+        type='SharedFCBBoxHead',
+        num_fcs=2,
+        in_channels=256,
+        fc_out_channels=1024,
+        roi_feat_size=7,
+        num_classes=81,
+        target_means=[0., 0., 0., 0.],
+        target_stds=[0.1, 0.1, 0.2, 0.2],
+        reg_class_agnostic=False,
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
+        loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0)),
+    mask_roi_extractor=dict(
+        type='SingleRoIExtractor',
+        roi_layer=dict(type='RoIAlign', out_size=14, sample_num=2),
+        out_channels=256,
+        featmap_strides=[4, 8, 16, 32]),
+    mask_head=dict(
+        type='FCNMaskHead',
+        num_convs=4,
+        in_channels=256,
+        conv_out_channels=256,
+        num_classes=81,
+        loss_mask=dict(
+            type='CrossEntropyLoss', use_mask=True, loss_weight=1.0)))
+# model training and testing settings
+train_cfg = dict(
+    rpn=dict(
+        assigner=dict(
+            type='MaxIoUAssigner',
+            pos_iou_thr=0.7,
+            neg_iou_thr=0.3,
+            min_pos_iou=0.3,
+            ignore_iof_thr=-1),
+        sampler=dict(
+            type='RandomSampler',
+            num=256,
+            pos_fraction=0.5,
+            neg_pos_ub=-1,
+            add_gt_as_proposals=False),
+        allowed_border=0,
+        pos_weight=-1,
+        debug=False),
+    rpn_proposal=dict(
+        nms_across_levels=False,
+        nms_pre=2000,
+        nms_post=2000,
+        max_num=2000,
+        nms_thr=0.7,
+        min_bbox_size=0),
+    rcnn=dict(
+        assigner=dict(
+            type='MaxIoUAssigner',
+            pos_iou_thr=0.5,
+            neg_iou_thr=0.5,
+            min_pos_iou=0.5,
+            ignore_iof_thr=-1),
+        sampler=dict(
+            type='RandomSampler',
+            num=512,
+            pos_fraction=0.25,
+            neg_pos_ub=-1,
+            add_gt_as_proposals=True),
+        mask_size=28,
+        pos_weight=-1,
+        debug=False))
+test_cfg = dict(
+    rpn=dict(
+        nms_across_levels=False,
+        nms_pre=1000,
+        nms_post=1000,
+        max_num=1000,
+        nms_thr=0.7,
+        min_bbox_size=0),
+    rcnn=dict(
+        score_thr=0.05,
+        nms=dict(type='nms', iou_thr=0.5),
+        max_per_img=100,
+        mask_thr_binary=0.5))
+# dataset settings
+dataset_type = 'CocoDataset'
+data_root = 'data/coco/'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='LoadAnnotations',
+        with_bbox=True,
+        with_mask=True,
+        poly2mask=False),
+    dict(type='Resize', img_scale=(1333, 800), keep_ratio=True),
+    dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size_divisor=32),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(1333, 800),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=True),
+            dict(type='RandomFlip'),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    imgs_per_gpu=2,
+    workers_per_gpu=2,
+    train=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_train2017.json',
+        img_prefix=data_root + 'train2017/',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        img_prefix=data_root + 'val2017/',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        img_prefix=data_root + 'val2017/',
+        pipeline=test_pipeline))
+evaluation = dict(interval=1, metric=['bbox', 'segm'])
+# optimizer
+optimizer = dict(type='SGD', lr=0.02, momentum=0.9, weight_decay=0.0001)
+optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
+# learning policy
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=1.0 / 3,
+    step=[8, 11])
+checkpoint_config = dict(interval=1)
+# yapf:disable
+log_config = dict(
+    interval=50,
+    hooks=[
+        dict(type='TextLoggerHook'),
+        # dict(type='TensorboardLoggerHook')
+    ])
+# yapf:enable
+# runtime settings
+total_epochs = 12
+dist_params = dict(backend='nccl')
+log_level = 'INFO'
+work_dir = './work_dirs/mask_rcnn_r50_fpn_1x'
+load_from = None
+resume_from = None
+workflow = [('train', 1)]

--- a/mmdet/core/mask/mask_target.py
+++ b/mmdet/core/mask/mask_target.py
@@ -1,19 +1,30 @@
+import copy
+
 import mmcv
 import numpy as np
+import pycocotools.mask as mask_utils
 import torch
 from torch.nn.modules.utils import _pair
 
 
 def mask_target(pos_proposals_list, pos_assigned_gt_inds_list, gt_masks_list,
-                cfg):
+                cfg, img_meta_list):
     cfg_list = [cfg for _ in range(len(pos_proposals_list))]
+    if isinstance(gt_masks_list[0], np.ndarray):
+        mask_target_single = mask_target_single_bitmaps
+    elif isinstance(gt_masks_list[0], list):
+        mask_target_single = mask_target_single_polygons
+    else:
+        raise NotImplementedError
     mask_targets = map(mask_target_single, pos_proposals_list,
-                       pos_assigned_gt_inds_list, gt_masks_list, cfg_list)
+                       pos_assigned_gt_inds_list, gt_masks_list, cfg_list,
+                       img_meta_list)
     mask_targets = torch.cat(list(mask_targets))
     return mask_targets
 
 
-def mask_target_single(pos_proposals, pos_assigned_gt_inds, gt_masks, cfg):
+def mask_target_single_bitmaps(pos_proposals, pos_assigned_gt_inds, gt_masks,
+                               cfg, img_meta):
     mask_size = _pair(cfg.mask_size)
     num_pos = pos_proposals.size(0)
     mask_targets = []
@@ -38,4 +49,49 @@ def mask_target_single(pos_proposals, pos_assigned_gt_inds, gt_masks, cfg):
             pos_proposals.device)
     else:
         mask_targets = pos_proposals.new_zeros((0, ) + mask_size)
+    return mask_targets
+
+
+def mask_target_single_polygons(pos_proposals, pos_assigned_gt_inds, gt_masks,
+                                cfg, img_meta):
+    mask_size = cfg.mask_size
+    num_pos = pos_proposals.size(0)
+    mask_targets = []
+    if num_pos > 0:
+        proposals_np = pos_proposals.cpu().numpy()
+        maxh, maxw = img_meta['pad_shape'][:2]
+        proposals_np[:, [0, 2]] = np.clip(proposals_np[:, [0, 2]], 0, maxw - 1)
+        proposals_np[:, [1, 3]] = np.clip(proposals_np[:, [1, 3]], 0, maxh - 1)
+        for i in range(num_pos):
+            polygons = gt_masks[pos_assigned_gt_inds[i]]
+            bbox = proposals_np[i, :].astype(np.int32)
+
+            # shift
+            polygons = copy.deepcopy(polygons)
+            for p in polygons:
+                p[0::2] = p[0::2] - bbox[0]
+                p[1::2] = p[1::2] - bbox[1]
+
+            # rescale
+            w = bbox[2] - bbox[0] + 1
+            h = bbox[3] - bbox[1] + 1
+            ratio_h = mask_size / h
+            ratio_w = mask_size / w
+            if ratio_h == ratio_w:
+                for p in polygons:
+                    p *= ratio_h
+            else:
+                for p in polygons:
+                    p[0::2] *= ratio_w
+                    p[1::2] *= ratio_h
+
+            # convert to bitmap
+            rles = mask_utils.frPyObjects(polygons, mask_size, mask_size)
+            rle = mask_utils.merge(rles)
+            mask = mask_utils.decode(rle).astype(np.bool)
+            mask_targets.append(torch.from_numpy(mask))
+        mask_targets = torch.stack(mask_targets).to(
+            device=pos_proposals.device).float()
+    else:
+        mask_targets = pos_proposals.new_zeros((0, mask_size, mask_size))
     return mask_targets

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -84,6 +84,11 @@ class LoadAnnotations(object):
         gt_masks = results['ann_info']['masks']
         if self.poly2mask:
             gt_masks = [self._poly2mask(mask, h, w) for mask in gt_masks]
+        else:
+            gt_masks = [
+                self.process_polygons(polygons) for polygons in gt_masks
+            ]
+        results['poly2mask'] = self.poly2mask
         results['gt_masks'] = gt_masks
         results['mask_fields'].append('gt_masks')
         return results
@@ -114,6 +119,21 @@ class LoadAnnotations(object):
                      ' with_seg={})').format(self.with_bbox, self.with_label,
                                              self.with_mask, self.with_seg)
         return repr_str
+
+    def process_polygons(self, polygons):
+        """ Convert polygons to ndarray and filter invalid polygons.
+        Args:
+            polygons (list of list): polygons of one instance.
+
+        Returns:
+            polygons (list of ndarray).
+        """
+        polygons = [np.array(p) for p in polygons]
+        valid_polygons = []
+        for polygon in polygons:
+            if len(polygon) % 2 == 0 and len(polygon) >= 6:
+                valid_polygons.append(polygon)
+        return valid_polygons
 
 
 @PIPELINES.register_module

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -261,23 +261,18 @@ class RandomFlip(object):
         else:
             flipped_masks = []
             if direction == 'horizontal':
-                w = img_shape[1]
-                for poly_per_instance in masks:
-                    flipped_poly_per_instance = []
-                    for p in poly_per_instance:
-                        p = p.copy()
-                        p[0::2] = w - p[0::2] - 1
-                        flipped_poly_per_instance.append(p)
-                    flipped_masks.append(flipped_poly_per_instance)
+                dim = img_shape[1]
+                idx = 0
             elif direction == 'vertical':
-                h = img_shape[0]
-                for poly_per_instance in masks:
-                    flipped_poly_per_instance = []
-                    for p in poly_per_instance:
-                        p = p.copy()
-                        p[1::2] = h - p[1::2] - 1
-                        flipped_poly_per_instance.append(p)
-                    flipped_masks.append(flipped_poly_per_instance)
+                dim = img_shape[0]
+                idx = 1
+            for poly_per_instance in masks:
+                flipped_poly_per_instance = []
+                for p in poly_per_instance:
+                    p = p.copy()
+                    p[idx::2] = dim - p[idx::2] - 1
+                    flipped_poly_per_instance.append(p)
+                flipped_masks.append(flipped_poly_per_instance)
         return flipped_masks
 
     def __call__(self, results):
@@ -345,10 +340,7 @@ class Pad(object):
         results['pad_size_divisor'] = self.size_divisor
 
     def _pad_masks(self, results):
-        if 'poly2mask' not in results:
-            return
-        # polygons no need pad
-        if not results['poly2mask']:
+        if 'poly2mask' not in results or not results['poly2mask']:
             return
         pad_shape = results['pad_shape'][:2]
         for key in results.get('mask_fields', []):
@@ -911,8 +903,6 @@ class Albu(object):
                     results[label] = np.array(
                         [results[label][i] for i in results['idx_mapper']])
                 if 'masks' in results:
-                    # TODO: support polygons
-                    assert results['poly2mask']
                     results['masks'] = np.array(
                         [results['masks'][i] for i in results['idx_mapper']])
 

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -251,7 +251,7 @@ class TwoStageDetector(BaseDetector, RPNTestMixin, BBoxTestMixin,
             if mask_feats.shape[0] > 0:
                 mask_pred = self.mask_head(mask_feats)
                 mask_targets = self.mask_head.get_target(
-                    sampling_results, gt_masks, self.train_cfg.rcnn)
+                    sampling_results, gt_masks, self.train_cfg.rcnn, img_meta)
                 pos_labels = torch.cat(
                     [res.pos_gt_labels for res in sampling_results])
                 loss_mask = self.mask_head.loss(mask_pred, mask_targets,

--- a/mmdet/models/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/mask_heads/fcn_mask_head.py
@@ -119,13 +119,14 @@ class FCNMaskHead(nn.Module):
         mask_pred = self.conv_logits(x)
         return mask_pred
 
-    def get_target(self, sampling_results, gt_masks, rcnn_train_cfg):
+    def get_target(self, sampling_results, gt_masks, rcnn_train_cfg,
+                   img_metas):
         pos_proposals = [res.pos_bboxes for res in sampling_results]
         pos_assigned_gt_inds = [
             res.pos_assigned_gt_inds for res in sampling_results
         ]
         mask_targets = mask_target(pos_proposals, pos_assigned_gt_inds,
-                                   gt_masks, rcnn_train_cfg)
+                                   gt_masks, rcnn_train_cfg, img_metas)
         return mask_targets
 
     @force_fp32(apply_to=('mask_pred', ))


### PR DESCRIPTION
Add polygon mask training support for some models (not all). 
Replacing bitmap mask with polygon can speed up the training process, mainly on data preprocessing and mask target computation. 
The performance may slightly drop like 0.1~0.2.

| Model            | Mask format | Mem (MB) | Train time (s/iter) | AP bbox | AP mask| training log |
 | ---------------- | --- | -------- | ------------------- | -- | --| -- |
| Mask R-CNN R50 | BitMap | 4.1        |  0.636                   |  37.1  | 34.1| [mask_r50_bit.log](https://github.com/open-mmlab/mmdetection/files/4254260/mask_r50_bit.log)|
| Mask R-CNN R50 | Polygon |  4.1     | 0.546                    | 37.1   | 34.1| [mask_r50_poly.log](https://github.com/open-mmlab/mmdetection/files/4254263/mask_r50_poly.log) |



