### PR TITLE
Fix datasets builder

### DIFF
--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -33,7 +33,7 @@ def build_dataset(cfg, default_args=None):
     elif cfg['type'] == 'RepeatDataset':
         dataset = RepeatDataset(
             build_dataset(cfg['dataset'], default_args), cfg['times'])
-    elif isinstance(cfg['ann_file'], (list, tuple)):
+    elif isinstance(cfg.get('ann_file'), (list, tuple)):
         dataset = _concat_dataset(cfg, default_args)
     else:
         dataset = build_from_cfg(cfg, DATASETS, default_args)


### PR DESCRIPTION
Tools such as `tools/train.py` that rely on the dataset builder may fail if the Dataset doesn't require an `ann_file` argument. This can be the case with newly defined Dataset types.
