### PR TITLE
Bug fix: Soft limit cannot exceed hard limit

### DIFF
--- a/mmdet/datasets/loader/build_loader.py
+++ b/mmdet/datasets/loader/build_loader.py
@@ -13,7 +13,9 @@ if platform.system() != 'Windows':
     # https://github.com/pytorch/pytorch/issues/973
     import resource
     rlimit = resource.getrlimit(resource.RLIMIT_NOFILE)
-    resource.setrlimit(resource.RLIMIT_NOFILE, (4096, rlimit[1]))
+    hard_limit = rlimit[1]
+    soft_limit = min(4096, hard_limit)
+    resource.setrlimit(resource.RLIMIT_NOFILE, (soft_limit, hard_limit))
 
 
 def build_dataloader(dataset,


### PR DESCRIPTION
`resource.setrlimit` soft limit cannot exceed hard limit.
See https://docs.python.org/3/library/resource.html#resource.setrlimit

On my system the master branch raises a `ValueError` as the hard limit is lower than 4096.