### PR TITLE
Allow find_unused_parameters to be set in config

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -129,7 +129,7 @@ def _dist_train(model,
             seed=cfg.seed) for ds in dataset
     ]
     # put model on gpus
-    find_unused_parameters = cfg.get('find_unused_paramaters', False)
+    find_unused_parameters = cfg.get('find_unused_parameters', False)
     # Sets the `find_unused_parameters` parameter in
     # torch.nn.parallel.DistributedDataParallel
     model = MMDistributedDataParallel(

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -129,10 +129,14 @@ def _dist_train(model,
             seed=cfg.seed) for ds in dataset
     ]
     # put model on gpus
+    find_unused_parameters = cfg.get('find_unused_paramaters', False)
+    # Sets the `find_unused_parameters` parameter in
+    # torch.nn.parallel.DistributedDataParallel
     model = MMDistributedDataParallel(
         model.cuda(),
         device_ids=[torch.cuda.current_device()],
-        broadcast_buffers=False)
+        broadcast_buffers=False,
+        find_unused_parameters=find_unused_parameters)
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)


### PR DESCRIPTION
Allow `find_unused_parameters` to be set in the configuration file. If not present it defaults to the pytorch default of `False`.

This comes in handy when the underlying reason for the unused parameters is hard to find or not resolved well by pytorch. Current way to overcome this is to change `apis/train.py` in a user maintained fork which is not ideal.

This would also be useful for users affected by https://github.com/open-mmlab/mmdetection/issues/2153 