### PR TITLE
Config fix

### DIFF
--- a/configs/albu_example/mask_rcnn_r50_fpn_1x.py
+++ b/configs/albu_example/mask_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/atss/atss_r50_fpn_1x.py
+++ b/configs/atss/atss_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/carafe/faster_rcnn_r50_fpn_carafe_1x.py
+++ b/configs/carafe/faster_rcnn_r50_fpn_carafe_1x.py
@@ -178,7 +178,6 @@ log_config = dict(
         # dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-evaluation = dict(interval=1)
 # runtime settings
 total_epochs = 12
 dist_params = dict(backend='nccl')

--- a/configs/carafe/faster_rcnn_r50_fpn_carafe_1x.py
+++ b/configs/carafe/faster_rcnn_r50_fpn_carafe_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN_CARAFE',

--- a/configs/carafe/mask_rcnn_r50_fpn_carafe_1x.py
+++ b/configs/carafe/mask_rcnn_r50_fpn_carafe_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN_CARAFE',

--- a/configs/carafe/mask_rcnn_r50_fpn_carafe_1x.py
+++ b/configs/carafe/mask_rcnn_r50_fpn_carafe_1x.py
@@ -200,7 +200,6 @@ log_config = dict(
         # dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-evaluation = dict(interval=1)
 # runtime settings
 total_epochs = 12
 dist_params = dict(backend='nccl')

--- a/configs/cascade_mask_rcnn_r101_fpn_1x.py
+++ b/configs/cascade_mask_rcnn_r101_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_mask_rcnn_r50_fpn_1x.py
+++ b/configs/cascade_mask_rcnn_r50_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_mask_rcnn_x101_32x4d_fpn_1x.py
+++ b/configs/cascade_mask_rcnn_x101_32x4d_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_mask_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/cascade_mask_rcnn_x101_64x4d_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_rcnn_r101_fpn_1x.py
+++ b/configs/cascade_rcnn_r101_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_rcnn_r50_fpn_1x.py
+++ b/configs/cascade_rcnn_r50_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_rcnn_x101_32x4d_fpn_1x.py
+++ b/configs/cascade_rcnn_x101_32x4d_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cascade_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/cascade_rcnn_x101_64x4d_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cityscapes/faster_rcnn_r50_fpn_1x_cityscapes.py
+++ b/configs/cityscapes/faster_rcnn_r50_fpn_1x_cityscapes.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py
+++ b/configs/cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/dcn/cascade_mask_rcnn_dconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/cascade_mask_rcnn_dconv_c3-c5_r50_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCN', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/cascade_rcnn_dconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/cascade_rcnn_dconv_c3-c5_r50_fpn_1x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCN', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/faster_rcnn_dconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_dconv_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCN', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/faster_rcnn_dconv_c3-c5_x101_32x4d_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_dconv_c3-c5_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCN', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/faster_rcnn_dpool_r50_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_dpool_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/dcn/faster_rcnn_mdconv_c3-c5_group4_r50_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_mdconv_c3-c5_group4_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCNv2', deformable_groups=4, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/faster_rcnn_mdconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_mdconv_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCNv2', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/faster_rcnn_mdpool_r50_fpn_1x.py
+++ b/configs/dcn/faster_rcnn_mdpool_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/dcn/mask_rcnn_dconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/mask_rcnn_dconv_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCN', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/dcn/mask_rcnn_mdconv_c3-c5_r50_fpn_1x.py
+++ b/configs/dcn/mask_rcnn_mdconv_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(type='DCNv2', deformable_groups=1, fallback_on_stride=False),
         stage_with_dcn=(False, True, True, True)),

--- a/configs/double_heads/dh_faster_rcnn_r50_fpn_1x.py
+++ b/configs/double_heads/dh_faster_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/double_heads/dh_faster_rcnn_r50_fpn_1x.py
+++ b/configs/double_heads/dh_faster_rcnn_r50_fpn_1x.py
@@ -1,7 +1,7 @@
 # model settings
 model = dict(
     type='DoubleHeadRCNN',
-    pretrained='modelzoo://resnet50',
+    pretrained='torchvision://resnet50',
     backbone=dict(
         type='ResNet',
         depth=50,

--- a/configs/empirical_attention/faster_rcnn_r50_fpn_attention_0010_1x.py
+++ b/configs/empirical_attention/faster_rcnn_r50_fpn_attention_0010_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gen_attention=dict(
             spatial_range=-1, num_heads=8, attention_type='0010', kv_stride=2),

--- a/configs/empirical_attention/faster_rcnn_r50_fpn_attention_0010_dcn_1x.py
+++ b/configs/empirical_attention/faster_rcnn_r50_fpn_attention_0010_dcn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gen_attention=dict(
             spatial_range=-1, num_heads=8, attention_type='0010', kv_stride=2),

--- a/configs/empirical_attention/faster_rcnn_r50_fpn_attention_1111_1x.py
+++ b/configs/empirical_attention/faster_rcnn_r50_fpn_attention_1111_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gen_attention=dict(
             spatial_range=-1, num_heads=8, attention_type='1111', kv_stride=2),

--- a/configs/empirical_attention/faster_rcnn_r50_fpn_attention_1111_dcn_1x.py
+++ b/configs/empirical_attention/faster_rcnn_r50_fpn_attention_1111_dcn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gen_attention=dict(
             spatial_range=-1, num_heads=8, attention_type='1111', kv_stride=2),

--- a/configs/fast_mask_rcnn_r101_fpn_1x.py
+++ b/configs/fast_mask_rcnn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fast_mask_rcnn_r50_fpn_1x.py
+++ b/configs/fast_mask_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fast_rcnn_r101_fpn_1x.py
+++ b/configs/fast_rcnn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fast_rcnn_r50_fpn_1x.py
+++ b/configs/fast_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/faster_rcnn_ohem_r50_fpn_1x.py
+++ b/configs/faster_rcnn_ohem_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/faster_rcnn_r101_fpn_1x.py
+++ b/configs/faster_rcnn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/faster_rcnn_r50_fpn_1x.py
+++ b/configs/faster_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/faster_rcnn_x101_32x4d_fpn_1x.py
+++ b/configs/faster_rcnn_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/faster_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/faster_rcnn_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fcos/fcos_mstrain_640_800_x101_64x4d_fpn_gn_2x.py
+++ b/configs/fcos/fcos_mstrain_640_800_x101_64x4d_fpn_gn_2x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/foveabox/fovea_align_gn_ms_r101_fpn_4gpu_2x.py
+++ b/configs/foveabox/fovea_align_gn_ms_r101_fpn_4gpu_2x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/foveabox/fovea_align_gn_ms_r50_fpn_4gpu_2x.py
+++ b/configs/foveabox/fovea_align_gn_ms_r50_fpn_4gpu_2x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/foveabox/fovea_align_gn_r101_fpn_4gpu_2x.py
+++ b/configs/foveabox/fovea_align_gn_r101_fpn_4gpu_2x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/foveabox/fovea_align_gn_r50_fpn_4gpu_2x.py
+++ b/configs/foveabox/fovea_align_gn_r50_fpn_4gpu_2x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/foveabox/fovea_r50_fpn_4gpu_1x.py
+++ b/configs/foveabox/fovea_r50_fpn_4gpu_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fp16/faster_rcnn_r50_fpn_fp16_1x.py
+++ b/configs/fp16/faster_rcnn_r50_fpn_fp16_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fp16/mask_rcnn_r50_fpn_fp16_1x.py
+++ b/configs/fp16/mask_rcnn_r50_fpn_fp16_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/fp16/retinanet_r50_fpn_fp16_1x.py
+++ b/configs/fp16/retinanet_r50_fpn_fp16_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/free_anchor/retinanet_free_anchor_r101_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/free_anchor/retinanet_free_anchor_r101_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_r101_fpn_1x.py
@@ -117,7 +117,6 @@ log_config = dict(
 # yapf:enable
 # runtime settings
 total_epochs = 12
-device_ids = range(8)
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/retinanet_free_anchor_r101_fpn_1x'

--- a/configs/free_anchor/retinanet_free_anchor_r50_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/free_anchor/retinanet_free_anchor_r50_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_r50_fpn_1x.py
@@ -117,7 +117,6 @@ log_config = dict(
 # yapf:enable
 # runtime settings
 total_epochs = 12
-device_ids = range(8)
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/retinanet_free_anchor_r50_fpn_1x'

--- a/configs/free_anchor/retinanet_free_anchor_x101-32x4d_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_x101-32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/free_anchor/retinanet_free_anchor_x101-32x4d_fpn_1x.py
+++ b/configs/free_anchor/retinanet_free_anchor_x101-32x4d_fpn_1x.py
@@ -119,7 +119,6 @@ log_config = dict(
 # yapf:enable
 # runtime settings
 total_epochs = 12
-device_ids = range(8)
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/retinanet_free_anchor_x101-32x4d_fpn_1x'

--- a/configs/gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_1x.py
+++ b/configs/gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gcb=dict(ratio=1. / 16., ),
         stage_with_gcb=(False, True, True, True)),

--- a/configs/gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_syncbn_1x.py
+++ b/configs/gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_syncbn_1x.py
@@ -1,6 +1,4 @@
 # model settings
-norm_cfg = dict(type='SyncBN', requires_grad=True)
-
 model = dict(
     type='MaskRCNN',
     pretrained='torchvision://resnet50',
@@ -10,11 +8,11 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        norm_eval=False,
         style='pytorch',
         gcb=dict(ratio=1. / 16., ),
-        stage_with_gcb=(False, True, True, True),
-        norm_eval=False,
-        norm_cfg=norm_cfg),
+        stage_with_gcb=(False, True, True, True)),
     neck=dict(
         type='FPN',
         in_channels=[256, 512, 1024, 2048],

--- a/configs/gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_1x.py
+++ b/configs/gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         gcb=dict(ratio=1. / 4., ),
         stage_with_gcb=(False, True, True, True)),

--- a/configs/gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_syncbn_1x.py
+++ b/configs/gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_syncbn_1x.py
@@ -1,6 +1,4 @@
 # model settings
-norm_cfg = dict(type='SyncBN', requires_grad=True)
-
 model = dict(
     type='MaskRCNN',
     pretrained='torchvision://resnet50',
@@ -10,11 +8,11 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
+        norm_eval=False,
         style='pytorch',
         gcb=dict(ratio=1. / 4., ),
-        stage_with_gcb=(False, True, True, True),
-        norm_eval=False,
-        norm_cfg=norm_cfg),
+        stage_with_gcb=(False, True, True, True)),
     neck=dict(
         type='FPN',
         in_channels=[256, 512, 1024, 2048],

--- a/configs/gcnet/mask_rcnn_r50_fpn_sbn_1x.py
+++ b/configs/gcnet/mask_rcnn_r50_fpn_sbn_1x.py
@@ -1,6 +1,4 @@
 # model settings
-norm_cfg = dict(type='SyncBN', requires_grad=True)
-
 model = dict(
     type='MaskRCNN',
     pretrained='torchvision://resnet50',
@@ -10,9 +8,9 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
-        style='pytorch',
+        norm_cfg=dict(type='SyncBN', requires_grad=True),
         norm_eval=False,
-        norm_cfg=norm_cfg),
+        style='pytorch'),
     neck=dict(
         type='FPN',
         in_channels=[256, 512, 1024, 2048],

--- a/configs/ghm/retinanet_ghm_r50_fpn_1x.py
+++ b/configs/ghm/retinanet_ghm_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/grid_rcnn/grid_rcnn_gn_head_r50_fpn_2x.py
+++ b/configs/grid_rcnn/grid_rcnn_gn_head_r50_fpn_2x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/grid_rcnn/grid_rcnn_gn_head_x101_32x4d_fpn_2x.py
+++ b/configs/grid_rcnn/grid_rcnn_gn_head_x101_32x4d_fpn_2x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/guided_anchoring/ga_faster_x101_32x4d_fpn_1x.py
+++ b/configs/guided_anchoring/ga_faster_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/guided_anchoring/ga_retinanet_x101_32x4d_fpn_1x.py
+++ b/configs/guided_anchoring/ga_retinanet_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/guided_anchoring/ga_rpn_x101_32x4d_fpn_1x.py
+++ b/configs/guided_anchoring/ga_rpn_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/hrnet/mask_rcnn_hrnetv2p_w32_1x.py
+++ b/configs/hrnet/mask_rcnn_hrnetv2p_w32_1x.py
@@ -56,6 +56,7 @@ model = dict(
         num_classes=81,
         target_means=[0., 0., 0., 0.],
         target_stds=[0.1, 0.1, 0.2, 0.2],
+        reg_class_agnostic=False,
         loss_cls=dict(
             type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
         loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0)),

--- a/configs/htc/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py
+++ b/configs/htc/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py
@@ -13,6 +13,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(
             type='DCN',

--- a/configs/htc/htc_r101_fpn_20e.py
+++ b/configs/htc/htc_r101_fpn_20e.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/htc/htc_r50_fpn_1x.py
+++ b/configs/htc/htc_r50_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/htc/htc_r50_fpn_20e.py
+++ b/configs/htc/htc_r50_fpn_20e.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/htc/htc_without_semantic_r50_fpn_1x.py
+++ b/configs/htc/htc_without_semantic_r50_fpn_1x.py
@@ -11,6 +11,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/htc/htc_x101_32x4d_fpn_20e_16gpu.py
+++ b/configs/htc/htc_x101_32x4d_fpn_20e_16gpu.py
@@ -13,6 +13,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/htc/htc_x101_64x4d_fpn_20e_16gpu.py
+++ b/configs/htc/htc_x101_64x4d_fpn_20e_16gpu.py
@@ -13,6 +13,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/instaboost/cascade_mask_rcnn_r50_fpn_instaboost_4x.py
+++ b/configs/instaboost/cascade_mask_rcnn_r50_fpn_instaboost_4x.py
@@ -9,6 +9,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/instaboost/mask_rcnn_r50_fpn_instaboost_4x.py
+++ b/configs/instaboost/mask_rcnn_r50_fpn_instaboost_4x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/libra_rcnn/libra_fast_rcnn_r50_fpn_1x.py
+++ b/configs/libra_rcnn/libra_fast_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=[
         dict(

--- a/configs/libra_rcnn/libra_faster_rcnn_r101_fpn_1x.py
+++ b/configs/libra_rcnn/libra_faster_rcnn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=[
         dict(

--- a/configs/libra_rcnn/libra_faster_rcnn_r50_fpn_1x.py
+++ b/configs/libra_rcnn/libra_faster_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=[
         dict(

--- a/configs/libra_rcnn/libra_faster_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/libra_rcnn/libra_faster_rcnn_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=[
         dict(

--- a/configs/libra_rcnn/libra_retinanet_r50_fpn_1x.py
+++ b/configs/libra_rcnn/libra_retinanet_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=[
         dict(

--- a/configs/mask_rcnn_r101_fpn_1x.py
+++ b/configs/mask_rcnn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/mask_rcnn_r50_fpn_1x.py
+++ b/configs/mask_rcnn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/mask_rcnn_x101_32x4d_fpn_1x.py
+++ b/configs/mask_rcnn_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/mask_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/mask_rcnn_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/ms_rcnn/ms_rcnn_x101_64x4d_fpn_1x.py
+++ b/configs/ms_rcnn/ms_rcnn_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/nas_fpn/retinanet_crop640_r50_fpn_50e.py
+++ b/configs/nas_fpn/retinanet_crop640_r50_fpn_50e.py
@@ -141,7 +141,6 @@ log_config = dict(
 # yapf:enable
 # runtime settings
 total_epochs = 50
-device_ids = range(8)
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/retinanet_crop640_r50_fpn_50e'

--- a/configs/nas_fpn/retinanet_crop640_r50_nasfpn_50e.py
+++ b/configs/nas_fpn/retinanet_crop640_r50_nasfpn_50e.py
@@ -140,7 +140,6 @@ log_config = dict(
 # yapf:enable
 # runtime settings
 total_epochs = 50
-device_ids = range(8)
 dist_params = dict(backend='nccl')
 log_level = 'INFO'
 work_dir = './work_dirs/retinanet_crop640_r50_nasfpn_50e'

--- a/configs/pascal_voc/faster_rcnn_r50_fpn_1x_voc0712.py
+++ b/configs/pascal_voc/faster_rcnn_r50_fpn_1x_voc0712.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/bbox_r50_grid_center_fpn_1x.py
+++ b/configs/reppoints/bbox_r50_grid_center_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/bbox_r50_grid_center_fpn_1x.py
+++ b/configs/reppoints/bbox_r50_grid_center_fpn_1x.py
@@ -140,5 +140,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/bbox_r50_grid_center_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/bbox_r50_grid_fpn_1x.py
+++ b/configs/reppoints/bbox_r50_grid_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/bbox_r50_grid_fpn_1x.py
+++ b/configs/reppoints/bbox_r50_grid_fpn_1x.py
@@ -145,5 +145,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/bbox_r50_grid_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_minmax_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_minmax_r50_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_minmax_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_minmax_r50_fpn_1x.py
@@ -139,5 +139,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_minmax_r50_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(
             modulated=False, deformable_groups=1, fallback_on_stride=False),

--- a/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x.py
@@ -142,5 +142,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r101_dcn_fpn_2x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x_mt.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(
             modulated=False, deformable_groups=1, fallback_on_stride=False),

--- a/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r101_dcn_fpn_2x_mt.py
@@ -146,5 +146,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r101_dcn_fpn_2x_mt'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r101_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r101_fpn_2x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r101_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r101_fpn_2x.py
@@ -139,5 +139,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r101_fpn_2x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r101_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r101_fpn_2x_mt.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r101_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r101_fpn_2x_mt.py
@@ -143,5 +143,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r101_fpn_2x_mt'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_1x.py
@@ -139,5 +139,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r50_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r50_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_2x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r50_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_2x.py
@@ -139,5 +139,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r50_fpn_2x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r50_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_2x_mt.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r50_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_r50_fpn_2x_mt.py
@@ -143,5 +143,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r50_fpn_2x_mt'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_r50_no_gn_fpn_1x.py
+++ b/configs/reppoints/reppoints_moment_r50_no_gn_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_moment_r50_no_gn_fpn_1x.py
+++ b/configs/reppoints/reppoints_moment_r50_no_gn_fpn_1x.py
@@ -108,6 +108,7 @@ data = dict(
         ann_file=data_root + 'annotations/instances_val2017.json',
         img_prefix=data_root + 'val2017/',
         pipeline=test_pipeline))
+evaluation = dict(interval=1, metric='bbox')
 # optimizer
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
 optimizer_config = dict(grad_clip=dict(max_norm=35, norm_type=2))
@@ -134,5 +135,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_r50_no_gn_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x.py
@@ -147,5 +147,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_x101_dcn_fpn_2x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x.py
+++ b/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x.py
@@ -12,6 +12,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(
             modulated=False,

--- a/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py
@@ -12,6 +12,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch',
         dcn=dict(
             modulated=False,

--- a/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py
+++ b/configs/reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py
@@ -151,5 +151,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_moment_x101_dcn_fpn_2x_mt'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/reppoints/reppoints_partial_minmax_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_partial_minmax_r50_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/reppoints/reppoints_partial_minmax_r50_fpn_1x.py
+++ b/configs/reppoints/reppoints_partial_minmax_r50_fpn_1x.py
@@ -139,5 +139,4 @@ log_level = 'INFO'
 work_dir = './work_dirs/reppoints_partial_minmax_r50_fpn_1x'
 load_from = None
 resume_from = None
-auto_resume = True
 workflow = [('train', 1)]

--- a/configs/retinanet_r101_fpn_1x.py
+++ b/configs/retinanet_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/retinanet_r50_fpn_1x.py
+++ b/configs/retinanet_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/retinanet_x101_32x4d_fpn_1x.py
+++ b/configs/retinanet_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/retinanet_x101_64x4d_fpn_1x.py
+++ b/configs/retinanet_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/rpn_r101_fpn_1x.py
+++ b/configs/rpn_r101_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/rpn_r50_fpn_1x.py
+++ b/configs/rpn_r50_fpn_1x.py
@@ -8,6 +8,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/rpn_x101_32x4d_fpn_1x.py
+++ b/configs/rpn_x101_32x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',

--- a/configs/rpn_x101_64x4d_fpn_1x.py
+++ b/configs/rpn_x101_64x4d_fpn_1x.py
@@ -10,6 +10,7 @@ model = dict(
         num_stages=4,
         out_indices=(0, 1, 2, 3),
         frozen_stages=1,
+        norm_cfg=dict(type='BN', requires_grad=True),
         style='pytorch'),
     neck=dict(
         type='FPN',


### PR DESCRIPTION
This PR added `norm_cfg` for ResNet PyTorch style models. 
It also deleted redundant fields like `device_id` in FreeAnchor, `auto_resume` in RepPoints,  `evaluation` in CARAFE, `pretrained` in DoubleHeads. 