### PR TITLE
save file instead of show image in windows

### DIFF
--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -167,6 +167,9 @@ def show_result(img,
             color_mask = color_masks[labels[i]]
             mask = maskUtils.decode(segms[i]).astype(np.bool)
             img[mask] = img[mask] * 0.5 + color_mask * 0.5
+    # if out_file specified, do not show image in window
+    if out_file is not None:
+        show = False
     # draw bounding boxes
     mmcv.imshow_det_bboxes(
         img,


### PR DESCRIPTION
I notice your comment on the ‘out_file‘ parameter of the show_result function in inference.py: If out_file is specified, the visualization result will be written to the out file instead of shown in a window,  but actually it is shown in windows. (and because I run my python in no gui environment,  even though i specify the out_file, it shows cannot connect to X server, which may be confused to somebody new to this)
So, I add a if statement before show image.