### PR TITLE
Add batched nms

### DIFF
--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -27,40 +27,47 @@ def multiclass_nms(multi_bboxes,
         tuple: (bboxes, labels), tensors of shape (k, 5) and (k, 1). Labels
             are 0-based.
     """
-    num_classes = multi_scores.shape[1]
-    bboxes, labels = [], []
+    num_classes = multi_scores.size(1) - 1
+    # exclude background category
+    if multi_bboxes.shape[1] > 4:
+        bboxes = multi_bboxes.view(multi_scores.size(0), -1, 4)[:, 1:]
+    else:
+        bboxes = multi_bboxes[:, None].expand(-1, num_classes, 4)
+    scores = multi_scores[:, 1:]
+
+    # filter out boxes with low scores
+    valid_mask = scores > score_thr
+    bboxes = bboxes[valid_mask]
+    if score_factors is not None:
+        scores = scores * score_factors[:, None]
+    scores = scores[valid_mask]
+    labels = valid_mask.nonzero()[:, 1]
+
+    if bboxes.numel() == 0:
+        bboxes = multi_bboxes.new_zeros((0, 5))
+        labels = multi_bboxes.new_zeros((0, ), dtype=torch.long)
+        return bboxes, labels
+
+    # Modified from https://github.com/pytorch/vision/blob
+    # /505cd6957711af790211896d32b40291bea1bc21/torchvision/ops/boxes.py#L39.
+    # strategy: in order to perform NMS independently per class.
+    # we add an offset to all the boxes. The offset is dependent
+    # only on the class idx, and is large enough so that boxes
+    # from different classes do not overlap
+    max_coordinate = bboxes.max()
+    offsets = labels.to(bboxes) * (max_coordinate + 1)
+    bboxes_for_nms = bboxes + offsets[:, None]
     nms_cfg_ = nms_cfg.copy()
     nms_type = nms_cfg_.pop('type', 'nms')
     nms_op = getattr(nms_wrapper, nms_type)
-    for i in range(1, num_classes):
-        cls_inds = multi_scores[:, i] > score_thr
-        if not cls_inds.any():
-            continue
-        # get bboxes and scores of this class
-        if multi_bboxes.shape[1] == 4:
-            _bboxes = multi_bboxes[cls_inds, :]
-        else:
-            _bboxes = multi_bboxes[cls_inds, i * 4:(i + 1) * 4]
-        _scores = multi_scores[cls_inds, i]
-        if score_factors is not None:
-            _scores *= score_factors[cls_inds]
-        cls_dets = torch.cat([_bboxes, _scores[:, None]], dim=1)
-        cls_dets, _ = nms_op(cls_dets, **nms_cfg_)
-        cls_labels = multi_bboxes.new_full((cls_dets.shape[0], ),
-                                           i - 1,
-                                           dtype=torch.long)
-        bboxes.append(cls_dets)
-        labels.append(cls_labels)
-    if bboxes:
-        bboxes = torch.cat(bboxes)
-        labels = torch.cat(labels)
-        if bboxes.shape[0] > max_num:
-            _, inds = bboxes[:, -1].sort(descending=True)
-            inds = inds[:max_num]
-            bboxes = bboxes[inds]
-            labels = labels[inds]
-    else:
-        bboxes = multi_bboxes.new_zeros((0, 5))
-        labels = multi_bboxes.new_zeros((0, ), dtype=torch.long)
+    _, keep = nms_op(
+        torch.cat([bboxes_for_nms, scores[:, None]], 1), **nms_cfg_)
 
-    return bboxes, labels
+    if keep.size(0) > max_num:
+        _, inds = scores[keep].sort(descending=True)
+        keep = keep[inds[:max_num]]
+    bboxes = bboxes[keep]
+    scores = scores[keep]
+    labels = labels[keep]
+
+    return torch.cat([bboxes, scores[:, None]], 1), labels


### PR DESCRIPTION
Reimplement multiclass_nms in a batched fashion.

| Model              | Original Inf time (s/iter) | New Inf time (s/iter) |
|--------------------|----------------------------|-----------------------|
| Faster R-CNN R-50  | 13.7                       | 16.0                  |
| Mask R-CNN R-50    | 9.9                        | 10.9                  |
| Cascade R-CNN R-50 | 11.7                       | 13.7                  |
| Retinanet R-50     | 12.2                       | 16                    |
| FCOS GN R-50       | 13                         | 19.1                  |
| Mask Scoring R-50  | 9.8                        | 10.8                  |