### PR TITLE
Add .git to avoid 404 error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://gitlab.com/pycqa/flake8.git
     rev: 3.7.9
     hooks:
       - id: flake8


### PR DESCRIPTION
In the .pre-commit-config.yaml, the path for flake8 could cause 404 error in some machines, add `.git` could avoid this bug.