### PR TITLE
Set initial values for default meta keys when loading images

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -27,6 +27,12 @@ class LoadImageFromFile(object):
         results['img'] = img
         results['img_shape'] = img.shape
         results['ori_shape'] = img.shape
+        # Set initial values for default meta_keys
+        results['pad_shape'] = img.shape
+        results['flip'] = False
+        results['scale_factor'] = 1.0
+        cnum = 1 if len(img.shape) < 3 else img.shape[2]
+        results['img_norm_cfg'] = [[0.0] * cnum, [1.0] * cnum, False]
         return results
 
     def __repr__(self):

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -31,8 +31,9 @@ class LoadImageFromFile(object):
         results['pad_shape'] = img.shape
         results['flip'] = False
         results['scale_factor'] = 1.0
-        cnum = 1 if len(img.shape) < 3 else img.shape[2]
-        results['img_norm_cfg'] = [[0.0] * cnum, [1.0] * cnum, False]
+        num_channels = 1 if len(img.shape) < 3 else img.shape[2]
+        results['img_norm_cfg'] = [[0.0] * num_channels, [1.0] * num_channels,
+                                   False]
         return results
 
     def __repr__(self):


### PR DESCRIPTION
The aim of this change is to simplify use of pipelines that do not require image
scaling, normalization, flipping or padding

On branch set_default_metakeys
Changes to be committed:
modified:   mmdet/datasets/pipelines/loading.py