### PR TITLE
Add class to load multi-channel images from a list of files

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -35,6 +35,39 @@ class LoadImageFromFile(object):
 
 
 @PIPELINES.register_module
+class LoadMultiChannelImageFromFiles(object):
+    """ Load multi channel images from a list of separate channel files.
+    Expects results['filename'] to be a list of filenames
+    """
+
+    def __init__(self, to_float32=True, color_type='unchanged'):
+        self.to_float32 = to_float32
+        self.color_type = color_type
+
+    def __call__(self, results):
+        if results['img_prefix'] is not None:
+            filename = [
+                osp.join(results['img_prefix'], fname)
+                for fname in results['img_info']['filename']
+            ]
+        else:
+            filename = results['img_info']['filename']
+        img = np.stack(
+            [mmcv.imread(name, self.color_type) for name in filename], axis=-1)
+        if self.to_float32:
+            img = img.astype(np.float32)
+        results['filename'] = filename
+        results['img'] = img
+        results['img_shape'] = img.shape
+        results['ori_shape'] = img.shape
+        return results
+
+    def __repr__(self):
+        return '{} (to_float32={}, color_type={})'.format(
+            self.__class__.__name__, self.to_float32, self.color_type)
+
+
+@PIPELINES.register_module
 class LoadAnnotations(object):
 
     def __init__(self,


### PR DESCRIPTION
This class will be usefull for loading a multi-channel image from a list of separate images. This
is often necessary for medical and scientific images, since OpenCV or PIL do not handle correctly
many specialized medical or scientific file formats.

On branch load_multichannel
Changes to be committed:
modified:   mmdet/datasets/pipelines/loading.py