### PR TITLE
Add class to wrap result fields into lists for evaluation

### DIFF
--- a/mmdet/datasets/pipelines/formating.py
+++ b/mmdet/datasets/pipelines/formating.py
@@ -194,6 +194,21 @@ class Collect(object):
 
 @PIPELINES.register_module
 class WrapFieldsToLists(object):
+    """
+    Wrap fields of the data dictionary into lists for evaluation.
+
+    This class can be used as a last step of a test or validation
+    pipeline for single image evaluation or inference.
+    Example:
+        >>> test_pipeline = [
+        >>>    dict(type='LoadImageFromFile'),
+        >>>    dict(type='Normalize', **img_norm_cfg),
+        >>>    dict(type='Pad', size_divisor=32),
+        >>>    dict(type='ImageToTensor', keys=['img']),
+        >>>    dict(type='Collect', keys=['img']),
+        >>>    dict(type='WrapIntoLists')
+        >>> ]
+    """
 
     def __call__(self, results):
         # Wrap dict fields into lists

--- a/mmdet/datasets/pipelines/formating.py
+++ b/mmdet/datasets/pipelines/formating.py
@@ -190,3 +190,16 @@ class Collect(object):
     def __repr__(self):
         return self.__class__.__name__ + '(keys={}, meta_keys={})'.format(
             self.keys, self.meta_keys)
+
+
+@PIPELINES.register_module
+class WrapFieldsToLists(object):
+
+    def __call__(self, results):
+        # Wrap dict fields into lists
+        for key, val in results.items():
+            results[key] = [val]
+        return results
+
+    def __repr__(self):
+        return '{}()'.format(self.__class__.__name__)

--- a/mmdet/datasets/pipelines/formating.py
+++ b/mmdet/datasets/pipelines/formating.py
@@ -199,10 +199,14 @@ class WrapFieldsToLists(object):
 
     This class can be used as a last step of a test or validation
     pipeline for single image evaluation or inference.
+
     Example:
         >>> test_pipeline = [
         >>>    dict(type='LoadImageFromFile'),
-        >>>    dict(type='Normalize', **img_norm_cfg),
+        >>>    dict(type='Normalize',
+                    mean=[123.675, 116.28, 103.53],
+                    std=[58.395, 57.12, 57.375],
+                    to_rgb=True),
         >>>    dict(type='Pad', size_divisor=32),
         >>>    dict(type='ImageToTensor', keys=['img']),
         >>>    dict(type='Collect', keys=['img']),


### PR DESCRIPTION
This class is useful to create an evaluation pipeline that does not rely on 
MultiScaleFlipAugmentation 

On branch wrap_into_lists
Changes to be committed:
modified:   mmdet/datasets/pipelines/formating.py