### PR TITLE
Fix (transforms): fix bugs in transforms when the gt is empty

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -156,7 +156,11 @@ class Resize(object):
                     mmcv.imresize(mask, mask_size, interpolation='nearest')
                     for mask in results[key]
                 ]
-            results[key] = np.stack(masks)
+            if masks:
+                results[key] = np.stack(masks)
+            else:
+                results[key] = np.empty(
+                    (0, ) + results['img_shape'], dtype=np.uint8)
 
     def _resize_seg(self, results):
         for key in results.get('seg_fields', []):
@@ -245,10 +249,15 @@ class RandomFlip(object):
                                               results['flip_direction'])
             # flip masks
             for key in results.get('mask_fields', []):
-                results[key] = np.stack([
+                masks = [
                     mmcv.imflip(mask, direction=results['flip_direction'])
                     for mask in results[key]
-                ])
+                ]
+                if masks:
+                    results[key] = np.stack(masks)
+                else:
+                    results[key] = np.empty(
+                        (0, ) + results['img_shape'], dtype=np.uint8)
 
             # flip segs
             for key in results.get('seg_fields', []):

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -419,7 +419,12 @@ class RandomCrop(object):
                     gt_mask = results['gt_masks'][i][crop_y1:crop_y2,
                                                      crop_x1:crop_x2]
                     valid_gt_masks.append(gt_mask)
-                results['gt_masks'] = np.stack(valid_gt_masks)
+
+                if valid_gt_masks:
+                    results['gt_masks'] = np.stack(valid_gt_masks)
+                else:
+                    results['gt_masks'] = np.empty(
+                        (0, ) + results['img_shape'], dtype=np.uint8)
 
         return results
 
@@ -537,7 +542,8 @@ class PhotoMetricDistortion(object):
                      'saturation_range={}, hue_delta={})').format(
                          self.brightness_delta,
                          (self.contrast_lower, self.contrast_upper),
-                         self.saturation_range, self.hue_delta)
+                         (self.saturation_lower, self.saturation_upper),
+                         self.hue_delta)
         return repr_str
 
 
@@ -596,7 +602,12 @@ class Expand(object):
                                       0).astype(mask.dtype)
                 expand_mask[top:top + h, left:left + w] = mask
                 expand_gt_masks.append(expand_mask)
-            results['gt_masks'] = np.stack(expand_gt_masks)
+
+            if expand_gt_masks:
+                results['gt_masks'] = np.stack(expand_gt_masks)
+            else:
+                results['gt_masks'] = np.empty(
+                    (0, ) + results['img_shape'], dtype=np.uint8)
 
         # not tested
         if 'gt_semantic_seg' in results:
@@ -632,6 +643,7 @@ class MinIoURandomCrop(object):
 
     def __init__(self, min_ious=(0.1, 0.3, 0.5, 0.7, 0.9), min_crop_size=0.3):
         # 1: return ori img
+        self.min_ious = min_ious
         self.sample_mode = (1, *min_ious, 0)
         self.min_crop_size = min_crop_size
 
@@ -661,37 +673,45 @@ class MinIoURandomCrop(object):
                     (int(left), int(top), int(left + new_w), int(top + new_h)))
                 overlaps = bbox_overlaps(
                     patch.reshape(-1, 4), boxes.reshape(-1, 4)).reshape(-1)
-                if overlaps.min() < min_iou:
+                if len(overlaps) > 0 and overlaps.min() < min_iou:
                     continue
 
                 # center of boxes should inside the crop img
-                center = (boxes[:, :2] + boxes[:, 2:]) / 2
-                mask = ((center[:, 0] > patch[0]) * (center[:, 1] > patch[1]) *
-                        (center[:, 0] < patch[2]) * (center[:, 1] < patch[3]))
-                if not mask.any():
-                    continue
-                boxes = boxes[mask]
-                labels = labels[mask]
+                # only adjust boxes and instance masks when the gt is not empty
+                if len(overlaps) > 0:
+                    # adjust boxes
+                    center = (boxes[:, :2] + boxes[:, 2:]) / 2
+                    mask = ((center[:, 0] > patch[0]) *
+                            (center[:, 1] > patch[1]) *
+                            (center[:, 0] < patch[2]) *
+                            (center[:, 1] < patch[3]))
+                    if not mask.any():
+                        continue
 
-                # adjust boxes
+                    boxes = boxes[mask]
+                    labels = labels[mask]
+
+                    boxes[:, 2:] = boxes[:, 2:].clip(max=patch[2:])
+                    boxes[:, :2] = boxes[:, :2].clip(min=patch[:2])
+                    boxes -= np.tile(patch[:2], 2)
+
+                    results['gt_bboxes'] = boxes
+                    results['gt_labels'] = labels
+
+                    if 'gt_masks' in results:
+                        valid_masks = [
+                            results['gt_masks'][i] for i in range(len(mask))
+                            if mask[i]
+                        ]
+                        # here the valid_masks is not empty
+                        results['gt_masks'] = np.stack([
+                            gt_mask[patch[1]:patch[3], patch[0]:patch[2]]
+                            for gt_mask in valid_masks
+                        ])
+
+                # adjust the img no matter whether the gt is empty before crop
                 img = img[patch[1]:patch[3], patch[0]:patch[2]]
-                boxes[:, 2:] = boxes[:, 2:].clip(max=patch[2:])
-                boxes[:, :2] = boxes[:, :2].clip(min=patch[:2])
-                boxes -= np.tile(patch[:2], 2)
-
                 results['img'] = img
-                results['gt_bboxes'] = boxes
-                results['gt_labels'] = labels
-
-                if 'gt_masks' in results:
-                    valid_masks = [
-                        results['gt_masks'][i] for i in range(len(mask))
-                        if mask[i]
-                    ]
-                    results['gt_masks'] = np.stack([
-                        gt_mask[patch[1]:patch[3], patch[0]:patch[2]]
-                        for gt_mask in valid_masks
-                    ])
 
                 # not tested
                 if 'gt_semantic_seg' in results:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,7 +190,7 @@ def test_config_data_pipeline():
     # config_names = [relpath(p, config_dpath) for p in config_fpaths]
 
     # Only tests a representative subset of configurations
-    # TODO: test pipelines using Albu
+    # TODO: test pipelines using Albu, current Albu throw None given empty GT
     config_names = [
         'wider_face/ssd300_wider_face.py',
         'pascal_voc/ssd300_voc.py',
@@ -215,9 +215,8 @@ def test_config_data_pipeline():
 
         print(
             'Building data pipeline, config_fpath = {!r}'.format(config_fpath))
-        print('Test training data pipeline: \n{!r}'.format(train_pipeline))
-        print('Test testing data pipeline: \n{!r}'.format(test_pipeline))
 
+        print('Test training data pipeline: \n{!r}'.format(train_pipeline))
         img = np.random.randint(0, 255, size=(888, 666, 3), dtype=np.uint8)
         if loading_pipeline.get('to_float32', False):
             img = img.astype(np.float32)
@@ -235,6 +234,7 @@ def test_config_data_pipeline():
         output_results = train_pipeline(results)
         assert output_results is not None
 
+        print('Test testing data pipeline: \n{!r}'.format(test_pipeline))
         results = dict(
             filename='test_img.png',
             img=img,
@@ -250,6 +250,8 @@ def test_config_data_pipeline():
         assert output_results is not None
 
         # test empty GT
+        print('Test empty GT with training data pipeline: \n{!r}'.format(
+            train_pipeline))
         results = dict(
             filename='test_img.png',
             img=img,
@@ -264,6 +266,8 @@ def test_config_data_pipeline():
         output_results = train_pipeline(results)
         assert output_results is not None
 
+        print('Test empty GT with testing data pipeline: \n{!r}'.format(
+            test_pipeline))
         results = dict(
             filename='test_img.png',
             img=img,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -185,10 +185,6 @@ def test_config_data_pipeline():
     config_dpath = _get_config_directory()
     print('Found config_dpath = {!r}'.format(config_dpath))
 
-    # import glob
-    # config_fpaths = list(glob.glob(join(config_dpath, '**', '*.py')))
-    # config_names = [relpath(p, config_dpath) for p in config_fpaths]
-
     # Only tests a representative subset of configurations
     # TODO: test pipelines using Albu, current Albu throw None given empty GT
     config_names = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -170,3 +170,210 @@ def test_config_build_detector():
             train_cfg=config_mod.train_cfg,
             test_cfg=config_mod.test_cfg)
         assert detector is not None
+
+
+def test_config_data_pipeline():
+    """
+    Test whether the data pipeline is valid and can process corner cases.
+    CommandLine:
+        xdoctest -m tests/test_config.py test_config_build_data_pipeline
+    """
+    from xdoctest.utils import import_module_from_path
+    from mmdet.datasets.pipelines import Compose
+    import numpy as np
+
+    config_dpath = _get_config_directory()
+    print('Found config_dpath = {!r}'.format(config_dpath))
+
+    # import glob
+    # config_fpaths = list(glob.glob(join(config_dpath, '**', '*.py')))
+    # config_names = [relpath(p, config_dpath) for p in config_fpaths]
+
+    # Only tests a representative subset of configurations
+
+    config_names = [
+        # 'dcn/faster_rcnn_dconv_c3-c5_r50_fpn_1x.py',
+        # 'dcn/cascade_mask_rcnn_dconv_c3-c5_r50_fpn_1x.py',
+        # 'dcn/faster_rcnn_dpool_r50_fpn_1x.py',
+        # 'dcn/mask_rcnn_dconv_c3-c5_r50_fpn_1x.py',
+        # 'dcn/faster_rcnn_dconv_c3-c5_x101_32x4d_fpn_1x.py',
+        # 'dcn/cascade_rcnn_dconv_c3-c5_r50_fpn_1x.py',
+        # 'dcn/faster_rcnn_mdpool_r50_fpn_1x.py',
+        # 'dcn/faster_rcnn_mdconv_c3-c5_group4_r50_fpn_1x.py',
+        # 'dcn/faster_rcnn_mdconv_c3-c5_r50_fpn_1x.py',
+        # ---
+        # 'htc/htc_x101_32x4d_fpn_20e_16gpu.py',
+        # 'htc/htc_without_semantic_r50_fpn_1x.py',
+        # 'htc/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py',
+        # 'htc/htc_x101_64x4d_fpn_20e_16gpu.py',
+        # 'htc/htc_r50_fpn_1x.py',
+        # 'htc/htc_r101_fpn_20e.py',
+        # 'htc/htc_r50_fpn_20e.py',
+        # ---
+        # 'cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py',
+        # 'cityscapes/faster_rcnn_r50_fpn_1x_cityscapes.py',
+        # ---
+        # 'scratch/scratch_faster_rcnn_r50_fpn_gn_6x.py',
+        # 'scratch/scratch_mask_rcnn_r50_fpn_gn_6x.py',
+        # ---
+        # 'grid_rcnn/grid_rcnn_gn_head_x101_32x4d_fpn_2x.py',
+        # 'grid_rcnn/grid_rcnn_gn_head_r50_fpn_2x.py',
+        # ---
+        # 'double_heads/dh_faster_rcnn_r50_fpn_1x.py',
+        # ---
+        # 'empirical_attention/faster_rcnn_r50_fpn_attention_0010_dcn_1x.py',
+        # 'empirical_attention/faster_rcnn_r50_fpn_attention_1111_1x.py',
+        # 'empirical_attention/faster_rcnn_r50_fpn_attention_0010_1x.py',
+        # 'empirical_attention/faster_rcnn_r50_fpn_attention_1111_dcn_1x.py',
+        # ---
+        # 'ms_rcnn/ms_rcnn_r101_caffe_fpn_1x.py',
+        # 'ms_rcnn/ms_rcnn_x101_64x4d_fpn_1x.py',
+        # 'ms_rcnn/ms_rcnn_r50_caffe_fpn_1x.py',
+        # ---
+        # 'guided_anchoring/ga_faster_x101_32x4d_fpn_1x.py',
+        # 'guided_anchoring/ga_rpn_x101_32x4d_fpn_1x.py',
+        # 'guided_anchoring/ga_retinanet_r50_caffe_fpn_1x.py',
+        # 'guided_anchoring/ga_fast_r50_caffe_fpn_1x.py',
+        # 'guided_anchoring/ga_retinanet_x101_32x4d_fpn_1x.py',
+        # 'guided_anchoring/ga_rpn_r101_caffe_rpn_1x.py',
+        # 'guided_anchoring/ga_faster_r50_caffe_fpn_1x.py',
+        # 'guided_anchoring/ga_rpn_r50_caffe_fpn_1x.py',
+        # ---
+        # 'foveabox/fovea_r50_fpn_4gpu_1x.py',
+        # 'foveabox/fovea_align_gn_ms_r101_fpn_4gpu_2x.py',
+        # 'foveabox/fovea_align_gn_r50_fpn_4gpu_2x.py',
+        # 'foveabox/fovea_align_gn_r101_fpn_4gpu_2x.py',
+        # 'foveabox/fovea_align_gn_ms_r50_fpn_4gpu_2x.py',
+        # ---
+        # 'hrnet/cascade_rcnn_hrnetv2p_w32_20e.py',
+        # 'hrnet/mask_rcnn_hrnetv2p_w32_1x.py',
+        # 'hrnet/cascade_mask_rcnn_hrnetv2p_w32_20e.py',
+        # 'hrnet/htc_hrnetv2p_w32_20e.py',
+        # 'hrnet/faster_rcnn_hrnetv2p_w18_1x.py',
+        # 'hrnet/mask_rcnn_hrnetv2p_w18_1x.py',
+        # 'hrnet/faster_rcnn_hrnetv2p_w32_1x.py',
+        # 'hrnet/faster_rcnn_hrnetv2p_w40_1x.py',
+        # 'hrnet/fcos_hrnetv2p_w32_gn_1x_4gpu.py',
+        # ---
+        # 'gn+ws/faster_rcnn_r50_fpn_gn_ws_1x.py',
+        # 'gn+ws/mask_rcnn_x101_32x4d_fpn_gn_ws_2x.py',
+        # 'gn+ws/mask_rcnn_r50_fpn_gn_ws_2x.py',
+        # 'gn+ws/mask_rcnn_r50_fpn_gn_ws_20_23_24e.py',
+        # ---
+        # 'wider_face/ssd300_wider_face.py',
+        # ---
+        # 'pascal_voc/ssd300_voc.py',
+        # 'pascal_voc/faster_rcnn_r50_fpn_1x_voc0712.py',
+        # 'pascal_voc/ssd512_voc.py',
+        # ---
+        # 'gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_syncbn_1x.py',
+        # 'gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_syncbn_1x.py',
+        # 'gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_1x.py',
+        # 'gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_1x.py',
+        # 'gcnet/mask_rcnn_r50_fpn_sbn_1x.py',
+        # ---
+        # 'gn/mask_rcnn_r50_fpn_gn_contrib_2x.py',
+        # 'gn/mask_rcnn_r50_fpn_gn_2x.py',
+        # 'gn/mask_rcnn_r101_fpn_gn_2x.py',
+        # ---
+        # 'reppoints/reppoints_moment_x101_dcn_fpn_2x.py',
+        # 'reppoints/reppoints_moment_r50_fpn_2x.py',
+        # 'reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py',
+        # 'reppoints/reppoints_partial_minmax_r50_fpn_1x.py',
+        # 'reppoints/bbox_r50_grid_center_fpn_1x.py',
+        # 'reppoints/reppoints_moment_r101_dcn_fpn_2x.py',
+        # 'reppoints/reppoints_moment_r101_fpn_2x_mt.py',
+        # 'reppoints/reppoints_moment_r50_fpn_2x_mt.py',
+        # 'reppoints/reppoints_minmax_r50_fpn_1x.py',
+        # 'reppoints/reppoints_moment_r50_fpn_1x.py',
+        # 'reppointtrains_r50_caffe_fpn_gn_1x_4gpu.py',
+        # ---
+        # 'albu_example/mask_rcnn_r50_fpn_1x.py',
+        # ---
+        # 'libra_rcnn/libra_faster_rcnn_r50_fpn_1x.py',
+        # 'libra_rcnn/libra_retinanet_r50_fpn_1x.py',
+        # 'libra_rcnn/libra_faster_rcnn_r101_fpn_1x.py',
+        # 'libra_rcnn/libra_faster_rcnn_x101_64x4d_fpn_1x.py',
+        # 'libra_rcnn/libra_fast_rcnn_r50_fpn_1x.py',
+        # ---
+        # 'ghm/retinanet_ghm_r50_fpn_1x.py',
+        # ---
+        # 'fp16/retinanet_r50_fpn_fp16_1x.py',
+        'fp16/mask_rcnn_r50_fpn_fp16_1x.py',
+        # 'fp16/faster_rcnn_r50_fpn_fp16_1x.py'
+    ]
+
+    print('Using {} config files'.format(len(config_names)))
+
+    for config_fname in config_names:
+        config_fpath = join(config_dpath, config_fname)
+        config_mod = import_module_from_path(config_fpath)
+
+        # remove loading pipeline
+        config_mod.train_pipeline.pop(0)
+        config_mod.train_pipeline.pop(0)
+        config_mod.test_pipeline.pop(0)
+
+        train_pipeline = Compose(config_mod.train_pipeline)
+        test_pipeline = Compose(config_mod.test_pipeline)
+
+        print('Test training data pipeline: \n{!r}'.format(train_pipeline))
+        print('Test testing data pipeline: \n{!r}'.format(test_pipeline))
+
+        img = np.random.randint(0, 255, size=(888, 666, 3), dtype=np.uint8)
+        results = dict(
+            filename='test_img.png',
+            img=img,
+            img_shape=img.shape,
+            ori_shape=img.shape,
+            gt_bboxes=np.array([[35.2, 11.7, 39.7, 15.7]], dtype=np.float32),
+            gt_labels=np.array([1], dtype=np.int64),
+            gt_masks=(img == 233).astype(np.uint8),
+        )
+        results['bbox_fields'] = ['gt_bboxes']
+        results['mask_fields'] = ['gt_masks']
+        output_results = train_pipeline(results)
+        assert output_results is not None
+
+        results = dict(
+            filename='test_img.png',
+            img=img,
+            img_shape=img.shape,
+            ori_shape=img.shape,
+            gt_bboxes=np.array([[35.2, 11.7, 39.7, 15.7]], dtype=np.float32),
+            gt_labels=np.array([1], dtype=np.int64),
+            gt_masks=(img == 233).astype(np.uint8),
+        )
+        results['bbox_fields'] = ['gt_bboxes']
+        results['mask_fields'] = ['gt_masks']
+        output_results = test_pipeline(results)
+        assert output_results is not None
+
+        # test empty GT
+        results = dict(
+            filename='test_img.png',
+            img=img,
+            img_shape=img.shape,
+            ori_shape=img.shape,
+            gt_bboxes=np.zeros((0, 4), dtype=np.float32),
+            gt_labels=np.array([], dtype=np.int64),
+            gt_masks=[],
+        )
+        results['bbox_fields'] = ['gt_bboxes']
+        results['mask_fields'] = ['gt_masks']
+        output_results = train_pipeline(results)
+        assert output_results is not None
+
+        results = dict(
+            filename='test_img.png',
+            img=img,
+            img_shape=img.shape,
+            ori_shape=img.shape,
+            gt_bboxes=np.zeros((0, 4), dtype=np.float32),
+            gt_labels=np.array([], dtype=np.int64),
+            gt_masks=[],
+        )
+        results['bbox_fields'] = ['gt_bboxes']
+        results['mask_fields'] = ['gt_masks']
+        output_results = test_pipeline(results)
+        assert output_results is not None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -190,117 +190,13 @@ def test_config_data_pipeline():
     # config_names = [relpath(p, config_dpath) for p in config_fpaths]
 
     # Only tests a representative subset of configurations
-
+    # TODO: test pipelines using Albu
     config_names = [
-        # 'dcn/faster_rcnn_dconv_c3-c5_r50_fpn_1x.py',
-        # 'dcn/cascade_mask_rcnn_dconv_c3-c5_r50_fpn_1x.py',
-        # 'dcn/faster_rcnn_dpool_r50_fpn_1x.py',
-        # 'dcn/mask_rcnn_dconv_c3-c5_r50_fpn_1x.py',
-        # 'dcn/faster_rcnn_dconv_c3-c5_x101_32x4d_fpn_1x.py',
-        # 'dcn/cascade_rcnn_dconv_c3-c5_r50_fpn_1x.py',
-        # 'dcn/faster_rcnn_mdpool_r50_fpn_1x.py',
-        # 'dcn/faster_rcnn_mdconv_c3-c5_group4_r50_fpn_1x.py',
-        # 'dcn/faster_rcnn_mdconv_c3-c5_r50_fpn_1x.py',
-        # ---
-        # 'htc/htc_x101_32x4d_fpn_20e_16gpu.py',
-        # 'htc/htc_without_semantic_r50_fpn_1x.py',
-        # 'htc/htc_dconv_c3-c5_mstrain_400_1400_x101_64x4d_fpn_20e.py',
-        # 'htc/htc_x101_64x4d_fpn_20e_16gpu.py',
-        # 'htc/htc_r50_fpn_1x.py',
-        # 'htc/htc_r101_fpn_20e.py',
-        # 'htc/htc_r50_fpn_20e.py',
-        # ---
-        # 'cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py',
-        # 'cityscapes/faster_rcnn_r50_fpn_1x_cityscapes.py',
-        # ---
-        # 'scratch/scratch_faster_rcnn_r50_fpn_gn_6x.py',
-        # 'scratch/scratch_mask_rcnn_r50_fpn_gn_6x.py',
-        # ---
-        # 'grid_rcnn/grid_rcnn_gn_head_x101_32x4d_fpn_2x.py',
-        # 'grid_rcnn/grid_rcnn_gn_head_r50_fpn_2x.py',
-        # ---
-        # 'double_heads/dh_faster_rcnn_r50_fpn_1x.py',
-        # ---
-        # 'empirical_attention/faster_rcnn_r50_fpn_attention_0010_dcn_1x.py',
-        # 'empirical_attention/faster_rcnn_r50_fpn_attention_1111_1x.py',
-        # 'empirical_attention/faster_rcnn_r50_fpn_attention_0010_1x.py',
-        # 'empirical_attention/faster_rcnn_r50_fpn_attention_1111_dcn_1x.py',
-        # ---
-        # 'ms_rcnn/ms_rcnn_r101_caffe_fpn_1x.py',
-        # 'ms_rcnn/ms_rcnn_x101_64x4d_fpn_1x.py',
-        # 'ms_rcnn/ms_rcnn_r50_caffe_fpn_1x.py',
-        # ---
-        # 'guided_anchoring/ga_faster_x101_32x4d_fpn_1x.py',
-        # 'guided_anchoring/ga_rpn_x101_32x4d_fpn_1x.py',
-        # 'guided_anchoring/ga_retinanet_r50_caffe_fpn_1x.py',
-        # 'guided_anchoring/ga_fast_r50_caffe_fpn_1x.py',
-        # 'guided_anchoring/ga_retinanet_x101_32x4d_fpn_1x.py',
-        # 'guided_anchoring/ga_rpn_r101_caffe_rpn_1x.py',
-        # 'guided_anchoring/ga_faster_r50_caffe_fpn_1x.py',
-        # 'guided_anchoring/ga_rpn_r50_caffe_fpn_1x.py',
-        # ---
-        # 'foveabox/fovea_r50_fpn_4gpu_1x.py',
-        # 'foveabox/fovea_align_gn_ms_r101_fpn_4gpu_2x.py',
-        # 'foveabox/fovea_align_gn_r50_fpn_4gpu_2x.py',
-        # 'foveabox/fovea_align_gn_r101_fpn_4gpu_2x.py',
-        # 'foveabox/fovea_align_gn_ms_r50_fpn_4gpu_2x.py',
-        # ---
-        # 'hrnet/cascade_rcnn_hrnetv2p_w32_20e.py',
-        # 'hrnet/mask_rcnn_hrnetv2p_w32_1x.py',
-        # 'hrnet/cascade_mask_rcnn_hrnetv2p_w32_20e.py',
-        # 'hrnet/htc_hrnetv2p_w32_20e.py',
-        # 'hrnet/faster_rcnn_hrnetv2p_w18_1x.py',
-        # 'hrnet/mask_rcnn_hrnetv2p_w18_1x.py',
-        # 'hrnet/faster_rcnn_hrnetv2p_w32_1x.py',
-        # 'hrnet/faster_rcnn_hrnetv2p_w40_1x.py',
-        # 'hrnet/fcos_hrnetv2p_w32_gn_1x_4gpu.py',
-        # ---
-        # 'gn+ws/faster_rcnn_r50_fpn_gn_ws_1x.py',
-        # 'gn+ws/mask_rcnn_x101_32x4d_fpn_gn_ws_2x.py',
-        # 'gn+ws/mask_rcnn_r50_fpn_gn_ws_2x.py',
-        # 'gn+ws/mask_rcnn_r50_fpn_gn_ws_20_23_24e.py',
-        # ---
-        # 'wider_face/ssd300_wider_face.py',
-        # ---
-        # 'pascal_voc/ssd300_voc.py',
-        # 'pascal_voc/faster_rcnn_r50_fpn_1x_voc0712.py',
-        # 'pascal_voc/ssd512_voc.py',
-        # ---
-        # 'gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_syncbn_1x.py',
-        # 'gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_syncbn_1x.py',
-        # 'gcnet/mask_rcnn_r4_gcb_c3-c5_r50_fpn_1x.py',
-        # 'gcnet/mask_rcnn_r16_gcb_c3-c5_r50_fpn_1x.py',
-        # 'gcnet/mask_rcnn_r50_fpn_sbn_1x.py',
-        # ---
-        # 'gn/mask_rcnn_r50_fpn_gn_contrib_2x.py',
-        # 'gn/mask_rcnn_r50_fpn_gn_2x.py',
-        # 'gn/mask_rcnn_r101_fpn_gn_2x.py',
-        # ---
-        # 'reppoints/reppoints_moment_x101_dcn_fpn_2x.py',
-        # 'reppoints/reppoints_moment_r50_fpn_2x.py',
-        # 'reppoints/reppoints_moment_x101_dcn_fpn_2x_mt.py',
-        # 'reppoints/reppoints_partial_minmax_r50_fpn_1x.py',
-        # 'reppoints/bbox_r50_grid_center_fpn_1x.py',
-        # 'reppoints/reppoints_moment_r101_dcn_fpn_2x.py',
-        # 'reppoints/reppoints_moment_r101_fpn_2x_mt.py',
-        # 'reppoints/reppoints_moment_r50_fpn_2x_mt.py',
-        # 'reppoints/reppoints_minmax_r50_fpn_1x.py',
-        # 'reppoints/reppoints_moment_r50_fpn_1x.py',
-        # 'reppointtrains_r50_caffe_fpn_gn_1x_4gpu.py',
-        # ---
+        'wider_face/ssd300_wider_face.py',
+        'pascal_voc/ssd300_voc.py',
+        'pascal_voc/ssd512_voc.py',
         # 'albu_example/mask_rcnn_r50_fpn_1x.py',
-        # ---
-        # 'libra_rcnn/libra_faster_rcnn_r50_fpn_1x.py',
-        # 'libra_rcnn/libra_retinanet_r50_fpn_1x.py',
-        # 'libra_rcnn/libra_faster_rcnn_r101_fpn_1x.py',
-        # 'libra_rcnn/libra_faster_rcnn_x101_64x4d_fpn_1x.py',
-        # 'libra_rcnn/libra_fast_rcnn_r50_fpn_1x.py',
-        # ---
-        # 'ghm/retinanet_ghm_r50_fpn_1x.py',
-        # ---
-        # 'fp16/retinanet_r50_fpn_fp16_1x.py',
         'fp16/mask_rcnn_r50_fpn_fp16_1x.py',
-        # 'fp16/faster_rcnn_r50_fpn_fp16_1x.py'
     ]
 
     print('Using {} config files'.format(len(config_names)))
@@ -310,17 +206,21 @@ def test_config_data_pipeline():
         config_mod = import_module_from_path(config_fpath)
 
         # remove loading pipeline
-        config_mod.train_pipeline.pop(0)
+        loading_pipeline = config_mod.train_pipeline.pop(0)
         config_mod.train_pipeline.pop(0)
         config_mod.test_pipeline.pop(0)
 
         train_pipeline = Compose(config_mod.train_pipeline)
         test_pipeline = Compose(config_mod.test_pipeline)
 
+        print(
+            'Building data pipeline, config_fpath = {!r}'.format(config_fpath))
         print('Test training data pipeline: \n{!r}'.format(train_pipeline))
         print('Test testing data pipeline: \n{!r}'.format(test_pipeline))
 
         img = np.random.randint(0, 255, size=(888, 666, 3), dtype=np.uint8)
+        if loading_pipeline.get('to_float32', False):
+            img = img.astype(np.float32)
         results = dict(
             filename='test_img.png',
             img=img,
@@ -328,7 +228,7 @@ def test_config_data_pipeline():
             ori_shape=img.shape,
             gt_bboxes=np.array([[35.2, 11.7, 39.7, 15.7]], dtype=np.float32),
             gt_labels=np.array([1], dtype=np.int64),
-            gt_masks=(img == 233).astype(np.uint8),
+            gt_masks=[(img[..., 0] == 233).astype(np.uint8)],
         )
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']
@@ -342,7 +242,7 @@ def test_config_data_pipeline():
             ori_shape=img.shape,
             gt_bboxes=np.array([[35.2, 11.7, 39.7, 15.7]], dtype=np.float32),
             gt_labels=np.array([1], dtype=np.int64),
-            gt_masks=(img == 233).astype(np.uint8),
+            gt_masks=[(img[..., 0] == 233).astype(np.uint8)],
         )
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']


### PR DESCRIPTION
Fix https://github.com/open-mmlab/mmdetection/issues/2192, https://github.com/open-mmlab/mmdetection/issues/2171.
This PR fixes the bugs in the transformation when the GT box is empty.
A test function `test_config_data_pipeline` is also added to test the cases when GT is empty and test the correct implementation of the data pipeline.

**Notice**: For now, only augmentation used by SSD and mask RCNN is covered, which are two of the most common augmentation pipelines used in the codebase. For pipelines using `albumentations`, the pipeline will throw None if the GT box is empty. We will try to fix this in a new PR.