### PR TITLE
Add support for evaluation in non-dist training

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -188,7 +188,7 @@ According to the [Linear Scaling Rule](https://arxiv.org/abs/1706.02677), you ne
 ### Train with a single GPU
 
 ```shell
-python tools/train.py ${CONFIG_FILE}
+python tools/train.py ${CONFIG_FILE} [optional arguments]
 ```
 
 If you want to specify the working directory in the command, you can add an argument `--work_dir ${YOUR_WORK_DIR}`.

--- a/mmdet/core/evaluation/__init__.py
+++ b/mmdet/core/evaluation/__init__.py
@@ -1,7 +1,7 @@
 from .class_names import (cityscapes_classes, coco_classes, dataset_aliases,
                           get_classes, imagenet_det_classes,
                           imagenet_vid_classes, voc_classes)
-from .eval_hooks import DistEvalHook
+from .eval_hooks import DistEvalHook, EvalHook
 from .mean_ap import average_precision, eval_map, print_map_summary
 from .recall import (eval_recalls, plot_iou_recall, plot_num_recall,
                      print_recall_summary)
@@ -9,7 +9,7 @@ from .recall import (eval_recalls, plot_iou_recall, plot_num_recall,
 __all__ = [
     'voc_classes', 'imagenet_det_classes', 'imagenet_vid_classes',
     'coco_classes', 'cityscapes_classes', 'dataset_aliases', 'get_classes',
-    'DistEvalHook', 'average_precision', 'eval_map', 'print_map_summary',
-    'eval_recalls', 'print_recall_summary', 'plot_num_recall',
-    'plot_iou_recall'
+    'DistEvalHook', 'EvalHook', 'average_precision', 'eval_map',
+    'print_map_summary', 'eval_recalls', 'print_recall_summary',
+    'plot_num_recall', 'plot_iou_recall'
 ]

--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -4,7 +4,39 @@ from mmcv.runner import Hook
 from torch.utils.data import DataLoader
 
 
-class DistEvalHook(Hook):
+class EvalHook(Hook):
+    """Evaluation hook.
+
+    Attributes:
+        dataloader (DataLoader): A PyTorch dataloader.
+        interval (int): Evaluation interval (by epochs). Default: 1.
+    """
+
+    def __init__(self, dataloader, interval=1, **eval_kwargs):
+        if not isinstance(dataloader, DataLoader):
+            raise TypeError(
+                'dataloader must be a pytorch DataLoader, but got {}'.format(
+                    type(dataloader)))
+        self.dataloader = dataloader
+        self.interval = interval
+        self.eval_kwargs = eval_kwargs
+
+    def after_train_epoch(self, runner):
+        if not self.every_n_epochs(runner, self.interval):
+            return
+        from mmdet.apis import single_gpu_test
+        results = single_gpu_test(runner.model, self.dataloader, show=False)
+        self.evaluate(runner, results)
+
+    def evaluate(self, runner, results):
+        eval_res = self.dataloader.dataset.evaluate(
+            results, logger=runner.logger, **self.eval_kwargs)
+        for name, val in eval_res.items():
+            runner.log_buffer.output[name] = val
+        runner.log_buffer.ready = True
+
+
+class DistEvalHook(EvalHook):
     """Distributed evaluation hook.
 
     Attributes:
@@ -42,10 +74,3 @@ class DistEvalHook(Hook):
         if runner.rank == 0:
             print('\n')
             self.evaluate(runner, results)
-
-    def evaluate(self, runner, results):
-        eval_res = self.dataloader.dataset.evaluate(
-            results, logger=runner.logger, **self.eval_kwargs)
-        for name, val in eval_res.items():
-            runner.log_buffer.output[name] = val
-        runner.log_buffer.ready = True


### PR DESCRIPTION
This PR adds support for doing evaluation during single-gpu training, by adding an `EvalHook` and slightly modifying `DistEvalHook` for reusing the code.