### PR TITLE
Fix (flip): not setting default values of flip during loading

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -31,8 +31,10 @@ class LoadImageFromFile(object):
         results['pad_shape'] = img.shape
         results['scale_factor'] = 1.0
         num_channels = 1 if len(img.shape) < 3 else img.shape[2]
-        results['img_norm_cfg'] = [[0.0] * num_channels, [1.0] * num_channels,
-                                   False]
+        results['img_norm_cfg'] = dict(
+            mean=np.zeros(num_channels, dtype=np.float32),
+            std=np.ones(num_channels, dtype=np.float32),
+            to_rgb=False)
         return results
 
     def __repr__(self):

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -29,7 +29,6 @@ class LoadImageFromFile(object):
         results['ori_shape'] = img.shape
         # Set initial values for default meta_keys
         results['pad_shape'] = img.shape
-        results['flip'] = False
         results['scale_factor'] = 1.0
         num_channels = 1 if len(img.shape) < 3 else img.shape[2]
         results['img_norm_cfg'] = [[0.0] * num_channels, [1.0] * num_channels,


### PR DESCRIPTION
PR https://github.com/open-mmlab/mmdetection/commit/b47348691f87e27e22f24196ecaa7bc3da63351f introduces a bug with random flip augmentation. 
In the implementation of random flip as indicated [here](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/pipelines/transforms.py#L236), it will only set flip to either True or False when the key `flip` is not in the `result` dictionary. Therefore, after setting `flip=False` in results during the loading process, `flip` in `results` will not be reset according to the flip probability and always be False, and the flip augmentation will never be executed.

**Notice**: since this bug will cause the random flip augmentation ineffective, the performance of models trained after PR https://github.com/open-mmlab/mmdetection/commit/b47348691f87e27e22f24196ecaa7bc3da63351f between this PR is not guaranteed. The users might need to re-train their models if the performance is unexpected.