### PR TITLE
Modify the code casting digit string as int to convert to float and t…

### DIFF
--- a/mmdet/datasets/xml_style.py
+++ b/mmdet/datasets/xml_style.py
@@ -47,8 +47,7 @@ class XMLDataset(CustomDataset):
             label = self.cat2label[name]
             difficult = int(obj.find('difficult').text)
             bnd_box = obj.find('bndbox')
-	    
-	    # Coordinates may be float type
+            # Coordinates may be float type
             bbox = [
                 int(float(bnd_box.find('xmin').text)),
                 int(float(bnd_box.find('ymin').text)),

--- a/mmdet/datasets/xml_style.py
+++ b/mmdet/datasets/xml_style.py
@@ -48,10 +48,10 @@ class XMLDataset(CustomDataset):
             difficult = int(obj.find('difficult').text)
             bnd_box = obj.find('bndbox')
             bbox = [
-                int(bnd_box.find('xmin').text),
-                int(bnd_box.find('ymin').text),
-                int(bnd_box.find('xmax').text),
-                int(bnd_box.find('ymax').text)
+                int(float(bnd_box.find('xmin').text)),
+                int(float(bnd_box.find('ymin').text)),
+                int(float(bnd_box.find('xmax').text)),
+                int(float(bnd_box.find('ymax').text))
             ]
             ignore = False
             if self.min_size:

--- a/mmdet/datasets/xml_style.py
+++ b/mmdet/datasets/xml_style.py
@@ -47,6 +47,8 @@ class XMLDataset(CustomDataset):
             label = self.cat2label[name]
             difficult = int(obj.find('difficult').text)
             bnd_box = obj.find('bndbox')
+	    
+	    # Coordinates may be float type
             bbox = [
                 int(float(bnd_box.find('xmin').text)),
                 int(float(bnd_box.find('ymin').text)),


### PR DESCRIPTION
Occasionally, certain labeltool types can be floating points. If the coordinates are floating points, an error will occur. Therefore, it was corrected to prevent the error from occurring.

Thx !