### PR TITLE
Remove unnecessary operation with -1 in AnchorGenerator

### DIFF
--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -8,10 +8,10 @@ class AnchorGenerator(object):
         >>> self = AnchorGenerator(9, [1.], [1.])
         >>> all_anchors = self.grid_anchors((2, 2), device='cpu')
         >>> print(all_anchors)
-        tensor([[ 0.,  0.,  8.,  8.],
-                [16.,  0., 24.,  8.],
-                [ 0., 16.,  8., 24.],
-                [16., 16., 24., 24.]])
+        tensor([[ 0.,  0.,  9.,  9.],
+                [16.,  0., 25.,  9.],
+                [ 0., 16.,  9., 25.],
+                [16., 16., 25., 25.]])
     """
 
     def __init__(self, base_size, scales, ratios, scale_major=True, ctr=None):
@@ -30,8 +30,8 @@ class AnchorGenerator(object):
         w = self.base_size
         h = self.base_size
         if self.ctr is None:
-            x_ctr = 0.5 * (w - 1)
-            y_ctr = 0.5 * (h - 1)
+            x_ctr = 0.5 * w
+            y_ctr = 0.5 * h
         else:
             x_ctr, y_ctr = self.ctr
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -47,8 +47,8 @@ class AnchorGenerator(object):
         # yapf: disable
         base_anchors = torch.stack(
             [
-                x_ctr - 0.5 * (ws - 1), y_ctr - 0.5 * (hs - 1),
-                x_ctr + 0.5 * (ws - 1), y_ctr + 0.5 * (hs - 1)
+                x_ctr - 0.5 * ws, y_ctr - 0.5 * hs,
+                x_ctr + 0.5 * ws, y_ctr + 0.5 * hs
             ],
             dim=-1).round()
         # yapf: enable


### PR DESCRIPTION
The AnchorGenerator does a -1 operation in 2 places.
In the case with for example SSD when using an input size of 300 and a scale factor of 1., the expected behaviour would be that the generated anchors produce bounding boxes with a width and a height of 30, which is not the case here (it is 28).

Other implementations such as the Tensorflow Object Detection framework don't have this behaviour.
https://github.com/tensorflow/models/blob/34a3581c0e09c293cd67b5ac2d64e8bc753cefce/research/object_detection/anchor_generators/grid_anchor_generator.py#L213: 
`return tf.concat([centers - .5 * sizes, centers + .5 * sizes], 1)`
