### PR TITLE
Refactor (resnet.py): remove unnecessary initialization of dcn

### DIFF
--- a/mmdet/models/backbones/resnet.py
+++ b/mmdet/models/backbones/resnet.py
@@ -477,6 +477,12 @@ class ResNet(nn.Module):
                 elif isinstance(m, (_BatchNorm, nn.GroupNorm)):
                     constant_init(m, 1)
 
+            if self.dcn is not None:
+                for m in self.modules():
+                    if isinstance(m, Bottleneck) and hasattr(
+                            m.conv2, 'conv_offset'):
+                        constant_init(m.conv2.conv_offset, 0)
+
             if self.zero_init_residual:
                 for m in self.modules():
                     if isinstance(m, Bottleneck):

--- a/mmdet/models/backbones/resnet.py
+++ b/mmdet/models/backbones/resnet.py
@@ -477,12 +477,6 @@ class ResNet(nn.Module):
                 elif isinstance(m, (_BatchNorm, nn.GroupNorm)):
                     constant_init(m, 1)
 
-            if self.dcn is not None:
-                for m in self.modules():
-                    if isinstance(m, Bottleneck) and hasattr(
-                            m, 'conv2_offset'):
-                        constant_init(m.conv2_offset, 0)
-
             if self.zero_init_residual:
                 for m in self.modules():
                     if isinstance(m, Bottleneck):


### PR DESCRIPTION
This PR removes the unnecessary initialization of DCN since the conv_offset and weight has been initialized in the DCN modules.