### PR TITLE
Add optimizer constructor

### DIFF
--- a/mmdet/core/optimizer/__init__.py
+++ b/mmdet/core/optimizer/__init__.py
@@ -1,5 +1,9 @@
-from .builder import build_optimizer
+from .builder import build_optimizer, build_optimizer_constructor
 from .copy_of_sgd import CopyOfSGD
-from .registry import OPTIMIZERS
+from .default_constructor import DefaultOptimizerConstructor
+from .registry import OPTIMIZER_BUILDERS, OPTIMIZERS
 
-__all__ = ['OPTIMIZERS', 'build_optimizer', 'CopyOfSGD']
+__all__ = [
+    'OPTIMIZER_BUILDERS', 'OPTIMIZERS', 'DefaultOptimizerConstructor',
+    'build_optimizer', 'build_optimizer_constructor', 'CopyOfSGD'
+]

--- a/mmdet/core/optimizer/builder.py
+++ b/mmdet/core/optimizer/builder.py
@@ -1,101 +1,23 @@
-import re
+import copy
 
-import torch
+from mmcv.utils import build_from_cfg
 
-from mmdet.utils import build_from_cfg
-from .registry import OPTIMIZERS
+from .registry import OPTIMIZER_BUILDERS
 
 
-def build_optimizer(model, optimizer_cfg):
-    """Build optimizer from configs.
+def build_optimizer_constructor(cfg):
+    return build_from_cfg(cfg, OPTIMIZER_BUILDERS)
 
-    Args:
-        model (:obj:`nn.Module`): The model with parameters to be optimized.
-        optimizer_cfg (dict): The config dict of the optimizer.
-            Positional fields are:
-                - type: class name of the optimizer.
-                - lr: base learning rate.
-            Optional fields are:
-                - any arguments of the corresponding optimizer type, e.g.,
-                  weight_decay, momentum, etc.
-                - paramwise_options: a dict with 4 accepted fileds
-                  (bias_lr_mult, bias_decay_mult, norm_decay_mult,
-                  dwconv_decay_mult).
-                  `bias_lr_mult` and `bias_decay_mult` will be multiplied to
-                  the lr and weight decay respectively for all bias parameters
-                  (except for the normalization layers), and
-                  `norm_decay_mult` will be multiplied to the weight decay
-                  for all weight and bias parameters of normalization layers.
-                  `dwconv_decay_mult` will be multiplied to the weight decay
-                  for all weight and bias parameters of depthwise conv layers.
 
-    Returns:
-        torch.optim.Optimizer: The initialized optimizer.
-
-    Example:
-        >>> import torch
-        >>> model = torch.nn.modules.Conv1d(1, 1, 1)
-        >>> optimizer_cfg = dict(type='SGD', lr=0.01, momentum=0.9,
-        >>>                      weight_decay=0.0001)
-        >>> optimizer = build_optimizer(model, optimizer_cfg)
-    """
-    if hasattr(model, 'module'):
-        model = model.module
-
-    optimizer_cfg = optimizer_cfg.copy()
-    paramwise_options = optimizer_cfg.pop('paramwise_options', None)
-    # if no paramwise option is specified, just use the global setting
-    if paramwise_options is None:
-        params = model.parameters()
-    else:
-        assert isinstance(paramwise_options, dict)
-        # get base lr and weight decay
-        base_lr = optimizer_cfg['lr']
-        base_wd = optimizer_cfg.get('weight_decay', None)
-        # weight_decay must be explicitly specified if mult is specified
-        if ('bias_decay_mult' in paramwise_options
-                or 'norm_decay_mult' in paramwise_options
-                or 'dwconv_decay_mult' in paramwise_options):
-            assert base_wd is not None
-        # get param-wise options
-        bias_lr_mult = paramwise_options.get('bias_lr_mult', 1.)
-        bias_decay_mult = paramwise_options.get('bias_decay_mult', 1.)
-        norm_decay_mult = paramwise_options.get('norm_decay_mult', 1.)
-        dwconv_decay_mult = paramwise_options.get('dwconv_decay_mult', 1.)
-        named_modules = dict(model.named_modules())
-        # set param-wise lr and weight decay
-        params = []
-        for name, param in model.named_parameters():
-            param_group = {'params': [param]}
-            if not param.requires_grad:
-                # FP16 training needs to copy gradient/weight between master
-                # weight copy and model weight, it is convenient to keep all
-                # parameters here to align with model.parameters()
-                params.append(param_group)
-                continue
-
-            # for norm layers, overwrite the weight decay of weight and bias
-            # TODO: obtain the norm layer prefixes dynamically
-            if re.search(r'(bn|gn)(\d+)?.(weight|bias)', name):
-                if base_wd is not None:
-                    param_group['weight_decay'] = base_wd * norm_decay_mult
-            # for other layers, overwrite both lr and weight decay of bias
-            elif name.endswith('.bias'):
-                param_group['lr'] = base_lr * bias_lr_mult
-                if base_wd is not None:
-                    param_group['weight_decay'] = base_wd * bias_decay_mult
-
-            module_name = name.replace('.weight', '').replace('.bias', '')
-            if module_name in named_modules and base_wd is not None:
-                module = named_modules[module_name]
-                # if this Conv2d is depthwise Conv2d
-                if isinstance(module, torch.nn.Conv2d) and \
-                        module.in_channels == module.groups:
-                    param_group['weight_decay'] = base_wd * dwconv_decay_mult
-            # otherwise use the global settings
-
-            params.append(param_group)
-
-    optimizer_cfg['params'] = params
-
-    return build_from_cfg(optimizer_cfg, OPTIMIZERS)
+def build_optimizer(model, cfg):
+    optimizer_cfg = copy.deepcopy(cfg)
+    constructor_type = optimizer_cfg.pop('constructor',
+                                         'DefaultOptimizerConstructor')
+    paramwise_cfg = optimizer_cfg.pop('paramwise_cfg', None)
+    optim_constructor = build_optimizer_constructor(
+        dict(
+            type=constructor_type,
+            optimizer_cfg=optimizer_cfg,
+            paramwise_cfg=paramwise_cfg))
+    optimizer = optim_constructor(model)
+    return optimizer

--- a/mmdet/core/optimizer/default_constructor.py
+++ b/mmdet/core/optimizer/default_constructor.py
@@ -88,9 +88,7 @@ class DefaultOptimizerConstructor(object):
             isinstance(module, torch.nn.Conv2d)
             and module.in_channels == module.groups)
 
-        children = list(module.children())
-        recursive = False if len(children) > 0 else True
-        for name, param in module.named_parameters(recurse=recursive):
+        for name, param in module.named_parameters(recurse=False):
             param_group = {'params': [param]}
             if not param.requires_grad:
                 params.append(param_group)
@@ -114,8 +112,8 @@ class DefaultOptimizerConstructor(object):
                         'weight_decay'] = self.base_wd * bias_decay_mult
             params.append(param_group)
 
-        for module in children:
-            self.add_params(params, module)
+        for child_mod in module.children():
+            self.add_params(params, child_mod)
 
     def __call__(self, model):
         if hasattr(model, 'module'):

--- a/mmdet/core/optimizer/default_constructor.py
+++ b/mmdet/core/optimizer/default_constructor.py
@@ -37,15 +37,15 @@ class DefaultOptimizerConstructor(object):
         >>> optimizer_cfg = dict(type='SGD', lr=0.01, momentum=0.9,
         >>>                      weight_decay=0.0001)
         >>> paramwise_cfg = dict(norm_decay_mult=0.)
-        >>> optimizer_builder = DefaultOptimizerConstructor(
+        >>> optim_builder = DefaultOptimizerConstructor(
         >>>     optimizer_cfg, paramwise_cfg)
-        >>> optimizer = optimizer_builder(model, optimizer_cfg)
+        >>> optimizer = optim_builder(model)
     """
 
     def __init__(self, optimizer_cfg, paramwise_cfg=None):
         if not isinstance(optimizer_cfg, dict):
-            raise TypeError(f'optimizer_cfg should be a dict',
-                            f'but got {type(optimizer_cfg)}')
+            raise TypeError('optimizer_cfg should be a dict',
+                            'but got {}'.format(type(optimizer_cfg)))
         self.optimizer_cfg = optimizer_cfg
         self.paramwise_cfg = {} if paramwise_cfg is None else paramwise_cfg
         self.base_lr = optimizer_cfg['lr']
@@ -54,15 +54,15 @@ class DefaultOptimizerConstructor(object):
 
     def _validate_cfg(self):
         if not isinstance(self.paramwise_cfg, dict):
-            raise TypeError(f'paramwise_cfg should be None or a dict, '
-                            f'but got {type(self.paramwise_cfg)}')
+            raise TypeError('paramwise_cfg should be None or a dict, '
+                            'but got {}'.format(type(self.paramwise_cfg)))
         # get base lr and weight decay
         # weight_decay must be explicitly specified if mult is specified
         if ('bias_decay_mult' in self.paramwise_cfg
                 or 'norm_decay_mult' in self.paramwise_cfg
                 or 'dwconv_decay_mult' in self.paramwise_cfg):
             if self.base_wd is None:
-                raise ValueError(f'base_wd should not be None')
+                raise ValueError('base_wd should not be None')
 
     def add_params(self, params, module):
         """Add all parameters of module to the params list.

--- a/mmdet/core/optimizer/default_constructor.py
+++ b/mmdet/core/optimizer/default_constructor.py
@@ -1,0 +1,135 @@
+import torch
+from mmcv.utils import build_from_cfg
+from torch.nn import GroupNorm, LayerNorm
+from torch.nn.modules.batchnorm import _BatchNorm
+from torch.nn.modules.instancenorm import _InstanceNorm
+
+from .registry import OPTIMIZER_BUILDERS, OPTIMIZERS
+
+
+@OPTIMIZER_BUILDERS.register_module
+class DefaultOptimizerConstructor(object):
+    """Default constructor for optimizers.
+
+    Attributes:
+        model (:obj:`nn.Module`): The model with parameters to be optimized.
+        optimizer_cfg (dict): The config dict of the optimizer.
+            Positional fields are:
+                - type: class name of the optimizer.
+                - lr: base learning rate.
+            Optional fields are:
+                - any arguments of the corresponding optimizer type, e.g.,
+                  weight_decay, momentum, etc.
+        paramwise_cfg (dict, optional): Parameter-wise options. Accepted fields
+            are:
+            - bias_lr_mult: It will be multiplied to the learning rate for
+              all bias parameters (except for those in normalization layers).
+            - bias_decay_mult: It will be multiplied to the weight decay for
+              all bias parameters (except for those in normalization layers and
+              depthwise conv layers).
+            - norm_decay_mult: will be multiplied to the weight decay
+              for all weight and bias parameters of normalization layers.
+            - dwconv_decay_mult: will be multiplied to the weight decay
+              for all weight and bias parameters of depthwise conv layers.
+
+    Example:
+        >>> model = torch.nn.modules.Conv1d(1, 1, 1)
+        >>> optimizer_cfg = dict(type='SGD', lr=0.01, momentum=0.9,
+        >>>                      weight_decay=0.0001)
+        >>> paramwise_cfg = dict(norm_decay_mult=0.)
+        >>> optimizer_builder = DefaultOptimizerConstructor(
+        >>>     optimizer_cfg, paramwise_cfg)
+        >>> optimizer = optimizer_builder(model, optimizer_cfg)
+    """
+
+    def __init__(self, optimizer_cfg, paramwise_cfg=None):
+        if not isinstance(optimizer_cfg, dict):
+            raise TypeError(f'optimizer_cfg should be a dict',
+                            f'but got {type(optimizer_cfg)}')
+        self.optimizer_cfg = optimizer_cfg
+        self.paramwise_cfg = {} if paramwise_cfg is None else paramwise_cfg
+        self.base_lr = optimizer_cfg['lr']
+        self.base_wd = optimizer_cfg.get('weight_decay', None)
+        self._validate_cfg()
+
+    def _validate_cfg(self):
+        if not isinstance(self.paramwise_cfg, dict):
+            raise TypeError(f'paramwise_cfg should be None or a dict, '
+                            f'but got {type(self.paramwise_cfg)}')
+        # get base lr and weight decay
+        # weight_decay must be explicitly specified if mult is specified
+        if ('bias_decay_mult' in self.paramwise_cfg
+                or 'norm_decay_mult' in self.paramwise_cfg
+                or 'dwconv_decay_mult' in self.paramwise_cfg):
+            if self.base_wd is None:
+                raise ValueError(f'base_wd should not be None')
+
+    def add_params(self, params, module):
+        """Add all parameters of module to the params list.
+
+        The parameters of the given module will be added to the list of param
+        groups, with specific rules defined by paramwise_cfg.
+
+        Args:
+            params (list[dict]): A list of param groups, it will be modified
+                in place.
+            module (nn.Module): The module to be added.
+        """
+        # get param-wise options
+        bias_lr_mult = self.paramwise_cfg.get('bias_lr_mult', 1.)
+        bias_decay_mult = self.paramwise_cfg.get('bias_decay_mult', 1.)
+        norm_decay_mult = self.paramwise_cfg.get('norm_decay_mult', 1.)
+        dwconv_decay_mult = self.paramwise_cfg.get('dwconv_decay_mult', 1.)
+
+        # special rules for norm layers and depth-wise conv layers
+        is_norm = isinstance(module,
+                             (_BatchNorm, _InstanceNorm, GroupNorm, LayerNorm))
+        is_dwconv = (
+            isinstance(module, torch.nn.Conv2d)
+            and module.in_channels == module.groups)
+
+        children = list(module.children())
+        recursive = False if len(children) > 0 else True
+        for name, param in module.named_parameters(recurse=recursive):
+            param_group = {'params': [param]}
+            if not param.requires_grad:
+                params.append(param_group)
+                continue
+            # bias_lr_mult affects all bias parameters except for norm.bias
+            if name == 'bias' and not is_norm:
+                param_group['lr'] = self.base_lr * bias_lr_mult
+            # apply weight decay policies
+            if self.base_wd is not None:
+                # norm decay
+                if is_norm:
+                    param_group[
+                        'weight_decay'] = self.base_wd * norm_decay_mult
+                # depth-wise conv
+                elif is_dwconv:
+                    param_group[
+                        'weight_decay'] = self.base_wd * dwconv_decay_mult
+                # bias lr and decay
+                elif name == 'bias':
+                    param_group[
+                        'weight_decay'] = self.base_wd * bias_decay_mult
+            params.append(param_group)
+
+        for module in children:
+            self.add_params(params, module)
+
+    def __call__(self, model):
+        if hasattr(model, 'module'):
+            model = model.module
+
+        optimizer_cfg = self.optimizer_cfg.copy()
+        # if no paramwise option is specified, just use the global setting
+        if not self.paramwise_cfg:
+            optimizer_cfg['params'] = model.parameters()
+            return build_from_cfg(optimizer_cfg, OPTIMIZERS)
+
+        # set param-wise lr and weight decay recursively
+        params = []
+        self.add_params(params, model)
+        optimizer_cfg['params'] = params
+
+        return build_from_cfg(optimizer_cfg, OPTIMIZERS)

--- a/mmdet/core/optimizer/registry.py
+++ b/mmdet/core/optimizer/registry.py
@@ -1,10 +1,10 @@
 import inspect
 
 import torch
-
-from mmdet.utils import Registry
+from mmcv.utils import Registry
 
 OPTIMIZERS = Registry('optimizer')
+OPTIMIZER_BUILDERS = Registry('optimizer builder')
 
 
 def register_torch_optimizers():

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -328,7 +328,7 @@ def test_build_optimizer_constructor():
     optimizer = optim_constructor(model)
     check_optimizer(optimizer, model, **paramwise_cfg)
 
-    from mmaction.core import OPTIMIZERS
+    from mmdet.core import OPTIMIZERS
     from mmcv.utils import build_from_cfg
 
     @OPTIMIZER_BUILDERS.register_module

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,394 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from mmdet.core import (OPTIMIZER_BUILDERS, DefaultOptimizerConstructor,
+                        build_optimizer, build_optimizer_constructor)
+from mmdet.core.optimizer.registry import TORCH_OPTIMIZERS
+
+
+class SubModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.conv1 = nn.Conv2d(2, 2, kernel_size=1, groups=2)
+        self.gn = nn.GroupNorm(2, 2)
+        self.param1 = nn.Parameter(torch.ones(1))
+
+    def forward(self, x):
+        return x
+
+
+class ExampleModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.param1 = nn.Parameter(torch.ones(1))
+        self.conv1 = nn.Conv2d(3, 4, kernel_size=1, bias=False)
+        self.conv2 = nn.Conv2d(4, 2, kernel_size=1)
+        self.bn = nn.BatchNorm2d(2)
+        self.sub = SubModel()
+
+    def forward(self, x):
+        return x
+
+
+class PseudoDataParallel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.module = ExampleModel()
+
+    def forward(self, x):
+        return x
+
+
+base_lr = 0.01
+base_wd = 0.0001
+momentum = 0.9
+
+
+def check_default_optimizer(optimizer, model, prefix=''):
+    assert isinstance(optimizer, torch.optim.SGD)
+    assert optimizer.defaults['lr'] == base_lr
+    assert optimizer.defaults['momentum'] == momentum
+    assert optimizer.defaults['weight_decay'] == base_wd
+    param_groups = optimizer.param_groups[0]
+    param_names = [
+        'param1', 'conv1.weight', 'conv2.weight', 'conv2.bias', 'bn.weight',
+        'bn.bias', 'sub.param1', 'sub.conv1.weight', 'sub.conv1.bias',
+        'sub.gn.weight', 'sub.gn.bias'
+    ]
+    param_dict = dict(model.named_parameters())
+    assert len(param_groups['params']) == len(param_names)
+    for i in range(len(param_groups['params'])):
+        assert torch.equal(param_groups['params'][i],
+                           param_dict[prefix + param_names[i]])
+
+
+def check_optimizer(optimizer,
+                    model,
+                    prefix='',
+                    bias_lr_mult=1,
+                    bias_decay_mult=1,
+                    norm_decay_mult=1,
+                    dwconv_decay_mult=1):
+    param_groups = optimizer.param_groups
+    assert isinstance(optimizer, torch.optim.SGD)
+    assert optimizer.defaults['lr'] == base_lr
+    assert optimizer.defaults['momentum'] == momentum
+    assert optimizer.defaults['weight_decay'] == base_wd
+    model_parameters = list(model.parameters())
+    assert len(param_groups) == len(model_parameters)
+    for i, param in enumerate(model_parameters):
+        param_group = param_groups[i]
+        assert torch.equal(param_group['params'][0], param)
+        assert param_group['momentum'] == momentum
+    # param1
+    param1 = param_groups[0]
+    assert param1['lr'] == base_lr
+    assert param1['weight_decay'] == base_wd
+    # conv1.weight
+    conv1_weight = param_groups[1]
+    assert conv1_weight['lr'] == base_lr
+    assert conv1_weight['weight_decay'] == base_wd
+    # conv2.weight
+    conv2_weight = param_groups[2]
+    assert conv2_weight['lr'] == base_lr
+    assert conv2_weight['weight_decay'] == base_wd
+    # conv2.bias
+    conv2_bias = param_groups[3]
+    assert conv2_bias['lr'] == base_lr * bias_lr_mult
+    assert conv2_bias['weight_decay'] == base_wd * bias_decay_mult
+    # bn.weight
+    bn_weight = param_groups[4]
+    assert bn_weight['lr'] == base_lr
+    assert bn_weight['weight_decay'] == base_wd * norm_decay_mult
+    # bn.bias
+    bn_bias = param_groups[5]
+    assert bn_bias['lr'] == base_lr
+    assert bn_bias['weight_decay'] == base_wd * norm_decay_mult
+    # sub.param1
+    sub_param1 = param_groups[6]
+    assert sub_param1['lr'] == base_lr
+    assert sub_param1['weight_decay'] == base_wd
+    # sub.conv1.weight
+    sub_conv1_weight = param_groups[7]
+    assert sub_conv1_weight['lr'] == base_lr
+    assert sub_conv1_weight['weight_decay'] == base_wd * dwconv_decay_mult
+    # sub.conv1.bias
+    sub_conv1_bias = param_groups[8]
+    assert sub_conv1_bias['lr'] == base_lr * bias_lr_mult
+    assert sub_conv1_bias['weight_decay'] == base_wd * dwconv_decay_mult
+    # sub.gn.weight
+    sub_gn_weight = param_groups[9]
+    assert sub_gn_weight['lr'] == base_lr
+    assert sub_gn_weight['weight_decay'] == base_wd * norm_decay_mult
+    # sub.gn.bias
+    sub_gn_bias = param_groups[10]
+    assert sub_gn_bias['lr'] == base_lr
+    assert sub_gn_bias['weight_decay'] == base_wd * norm_decay_mult
+
+
+def test_default_optimizer_constructor():
+    model = ExampleModel()
+
+    with pytest.raises(TypeError):
+        # optimizer_cfg must be a dict
+        optimizer_cfg = []
+        optim_constructor = DefaultOptimizerConstructor(optimizer_cfg)
+        optim_constructor(model)
+
+    with pytest.raises(TypeError):
+        # paramwise_cfg must be a dict or None
+        optimizer_cfg = dict(lr=0.0001)
+        paramwise_cfg = ['error']
+        optim_constructor = DefaultOptimizerConstructor(
+            optimizer_cfg, paramwise_cfg)
+        optim_constructor(model)
+
+    with pytest.raises(ValueError):
+        # bias_decay_mult/norm_decay_mult is specified but weight_decay is None
+        optimizer_cfg = dict(lr=0.0001, weight_decay=None)
+        paramwise_cfg = dict(bias_decay_mult=1, norm_decay_mult=1)
+        optim_constructor = DefaultOptimizerConstructor(
+            optimizer_cfg, paramwise_cfg)
+        optim_constructor(model)
+
+    # basic config with ExampleModel
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg)
+    optimizer = optim_constructor(model)
+    check_default_optimizer(optimizer, model)
+
+    # basic config with pseudo data parallel
+    model = PseudoDataParallel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = None
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg)
+    optimizer = optim_constructor(model)
+    check_default_optimizer(optimizer, model, prefix='module.')
+
+    # basic config with DataParallel
+    if torch.cuda.is_available():
+        model = torch.nn.DataParallel(ExampleModel())
+        optimizer_cfg = dict(
+            type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+        paramwise_cfg = None
+        optim_constructor = DefaultOptimizerConstructor(optimizer_cfg)
+        optimizer = optim_constructor(model)
+        check_default_optimizer(optimizer, model, prefix='module.')
+
+    # Empty paramwise_cfg with ExampleModel
+    model = ExampleModel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = dict()
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,
+                                                    paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_default_optimizer(optimizer, model)
+
+    # Empty paramwise_cfg with ExampleModel and no grad
+    model = ExampleModel()
+    for param in model.parameters():
+        param.requires_grad = False
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = dict()
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg)
+    optimizer = optim_constructor(model)
+    check_default_optimizer(optimizer, model)
+
+    # paramwise_cfg with ExampleModel
+    model = ExampleModel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = dict(
+        bias_lr_mult=2,
+        bias_decay_mult=0.5,
+        norm_decay_mult=0,
+        dwconv_decay_mult=0.1)
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,
+                                                    paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer(optimizer, model, **paramwise_cfg)
+
+    # paramwise_cfg with ExampleModel, weight decay is None
+    model = ExampleModel()
+    optimizer_cfg = dict(type='Rprop', lr=base_lr)
+    paramwise_cfg = dict(bias_lr_mult=2)
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,
+                                                    paramwise_cfg)
+    optimizer = optim_constructor(model)
+
+    param_groups = optimizer.param_groups
+    assert isinstance(optimizer, torch.optim.Rprop)
+    assert optimizer.defaults['lr'] == base_lr
+    model_parameters = list(model.parameters())
+    assert len(param_groups) == len(model_parameters)
+    for i, param in enumerate(model_parameters):
+        param_group = param_groups[i]
+        assert torch.equal(param_group['params'][0], param)
+    # param1
+    assert param_groups[0]['lr'] == base_lr
+    # conv1.weight
+    assert param_groups[1]['lr'] == base_lr
+    # conv2.weight
+    assert param_groups[2]['lr'] == base_lr
+    # conv2.bias
+    assert param_groups[3]['lr'] == base_lr * paramwise_cfg['bias_lr_mult']
+    # bn.weight
+    assert param_groups[4]['lr'] == base_lr
+    # bn.bias
+    assert param_groups[5]['lr'] == base_lr
+    # sub.param1
+    assert param_groups[6]['lr'] == base_lr
+    # sub.conv1.weight
+    assert param_groups[7]['lr'] == base_lr
+    # sub.conv1.bias
+    assert param_groups[8]['lr'] == base_lr * paramwise_cfg['bias_lr_mult']
+    # sub.gn.weight
+    assert param_groups[9]['lr'] == base_lr
+    # sub.gn.bias
+    assert param_groups[10]['lr'] == base_lr
+
+    # paramwise_cfg with pseudo data parallel
+    model = PseudoDataParallel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = dict(
+        bias_lr_mult=2,
+        bias_decay_mult=0.5,
+        norm_decay_mult=0,
+        dwconv_decay_mult=0.1)
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,
+                                                    paramwise_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer(optimizer, model, prefix='module.', **paramwise_cfg)
+
+    # paramwise_cfg with DataParallel
+    if torch.cuda.is_available():
+        model = torch.nn.DataParallel(ExampleModel())
+        optimizer_cfg = dict(
+            type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+        paramwise_cfg = dict(
+            bias_lr_mult=2,
+            bias_decay_mult=0.5,
+            norm_decay_mult=0,
+            dwconv_decay_mult=0.1)
+        optim_constructor = DefaultOptimizerConstructor(
+            optimizer_cfg, paramwise_cfg)
+        optimizer = optim_constructor(model)
+        check_optimizer(optimizer, model, prefix='module.', **paramwise_cfg)
+
+    # paramwise_cfg with ExampleModel and no grad
+    for param in model.parameters():
+        param.requires_grad = False
+    optim_constructor = DefaultOptimizerConstructor(optimizer_cfg,
+                                                    paramwise_cfg)
+    optimizer = optim_constructor(model)
+    param_groups = optimizer.param_groups
+    assert isinstance(optimizer, torch.optim.SGD)
+    assert optimizer.defaults['lr'] == base_lr
+    assert optimizer.defaults['momentum'] == momentum
+    assert optimizer.defaults['weight_decay'] == base_wd
+    for i, (name, param) in enumerate(model.named_parameters()):
+        param_group = param_groups[i]
+        assert torch.equal(param_group['params'][0], param)
+        assert param_group['momentum'] == momentum
+        assert param_group['lr'] == base_lr
+        assert param_group['weight_decay'] == base_wd
+
+
+def test_torch_optimizers():
+    torch_optimizers = [
+        'ASGD', 'Adadelta', 'Adagrad', 'Adam', 'AdamW', 'Adamax', 'LBFGS',
+        'Optimizer', 'RMSprop', 'Rprop', 'SGD', 'SparseAdam'
+    ]
+    assert set(torch_optimizers).issubset(set(TORCH_OPTIMIZERS))
+
+
+def test_build_optimizer_constructor():
+    model = ExampleModel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    paramwise_cfg = dict(
+        bias_lr_mult=2,
+        bias_decay_mult=0.5,
+        norm_decay_mult=0,
+        dwconv_decay_mult=0.1)
+    optim_constructor_cfg = dict(
+        type='DefaultOptimizerConstructor',
+        optimizer_cfg=optimizer_cfg,
+        paramwise_cfg=paramwise_cfg)
+    optim_constructor = build_optimizer_constructor(optim_constructor_cfg)
+    optimizer = optim_constructor(model)
+    check_optimizer(optimizer, model, **paramwise_cfg)
+
+    from mmaction.core import OPTIMIZERS
+    from mmcv.utils import build_from_cfg
+
+    @OPTIMIZER_BUILDERS.register_module
+    class MyOptimizerConstructor(DefaultOptimizerConstructor):
+
+        def __call__(self, model):
+            if hasattr(model, 'module'):
+                model = model.module
+
+            conv1_lr_mult = self.paramwise_cfg.get('conv1_lr_mult', 1.)
+
+            params = []
+            for name, param in model.named_parameters():
+                param_group = {'params': [param]}
+                if name.startswith('conv1') and param.requires_grad:
+                    param_group['lr'] = self.base_lr * conv1_lr_mult
+                params.append(param_group)
+            optimizer_cfg['params'] = params
+
+            return build_from_cfg(optimizer_cfg, OPTIMIZERS)
+
+    paramwise_cfg = dict(conv1_lr_mult=5)
+    optim_constructor_cfg = dict(
+        type='MyOptimizerConstructor',
+        optimizer_cfg=optimizer_cfg,
+        paramwise_cfg=paramwise_cfg)
+    optim_constructor = build_optimizer_constructor(optim_constructor_cfg)
+    optimizer = optim_constructor(model)
+
+    param_groups = optimizer.param_groups
+    assert isinstance(optimizer, torch.optim.SGD)
+    assert optimizer.defaults['lr'] == base_lr
+    assert optimizer.defaults['momentum'] == momentum
+    assert optimizer.defaults['weight_decay'] == base_wd
+    for i, param in enumerate(model.parameters()):
+        param_group = param_groups[i]
+        assert torch.equal(param_group['params'][0], param)
+        assert param_group['momentum'] == momentum
+    # conv1.weight
+    assert param_groups[1]['lr'] == base_lr * paramwise_cfg['conv1_lr_mult']
+    assert param_groups[1]['weight_decay'] == base_wd
+
+
+def test_build_optimizer():
+    model = ExampleModel()
+    optimizer_cfg = dict(
+        type='SGD', lr=base_lr, weight_decay=base_wd, momentum=momentum)
+    optimizer = build_optimizer(model, optimizer_cfg)
+    check_default_optimizer(optimizer, model)
+
+    model = ExampleModel()
+    optimizer_cfg = dict(
+        type='SGD',
+        lr=base_lr,
+        weight_decay=base_wd,
+        momentum=momentum,
+        paramwise_cfg=dict(
+            bias_lr_mult=2,
+            bias_decay_mult=0.5,
+            norm_decay_mult=0,
+            dwconv_decay_mult=0.1))
+    optimizer = build_optimizer(model, optimizer_cfg)
+    check_optimizer(optimizer, model, **optimizer_cfg['paramwise_cfg'])


### PR DESCRIPTION
This PR allows users to define their own optimizer constructors. Sometimes users want to set different learning rate or and weight decay for different parameters, but the build-in `build_optimizer()` cannot achieve the goal.