### PR TITLE
Add ability to specify device ids for non-distributed training

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -200,7 +200,9 @@ def _non_dist_train(model,
             seed=cfg.seed) for ds in dataset
     ]
     # put model on gpus
-    model = MMDataParallel(model, device_ids=range(cfg.gpus)).cuda()
+    gpu_ids = range(cfg.gpus) if cfg.gpu_ids is None else cfg.gpu_ids
+    assert len(gpu_ids) == cfg.gpus
+    model = MMDataParallel(model.cuda(gpu_ids[0]), device_ids=gpu_ids)
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -195,14 +195,12 @@ def _non_dist_train(model,
             ds,
             cfg.data.imgs_per_gpu,
             cfg.data.workers_per_gpu,
-            cfg.gpus,
+            len(cfg.gpu_ids),
             dist=False,
             seed=cfg.seed) for ds in dataset
     ]
     # put model on gpus
-    gpu_ids = range(cfg.gpus) if cfg.gpu_ids is None else cfg.gpu_ids
-    assert len(gpu_ids) == cfg.gpus
-    model = MMDataParallel(model.cuda(gpu_ids[0]), device_ids=gpu_ids)
+    model = MMDataParallel(model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)

--- a/tools/train.py
+++ b/tools/train.py
@@ -33,6 +33,12 @@ def parse_args():
         default=1,
         help='number of gpus to use '
         '(only applicable to non-distributed training)')
+    parser.add_argument(
+        '--gpu-ids',
+        type=int,
+        nargs='*',
+        help='ids of gpus to use '
+        '(only applicable to non-distributed training)')
     parser.add_argument('--seed', type=int, default=None, help='random seed')
     parser.add_argument(
         '--deterministic',
@@ -68,6 +74,7 @@ def main():
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
     cfg.gpus = args.gpus
+    cfg.gpu_ids = args.gpu_ids
 
     if args.autoscale_lr:
         # apply the linear scaling rule (https://arxiv.org/abs/1706.02677)

--- a/tools/train.py
+++ b/tools/train.py
@@ -31,7 +31,6 @@ def parse_args():
     group_gpus.add_argument(
         '--gpus',
         type=int,
-        default=1,
         help='number of gpus to use '
         '(only applicable to non-distributed training)')
     group_gpus.add_argument(
@@ -74,7 +73,10 @@ def main():
         cfg.work_dir = args.work_dir
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
-    cfg.gpu_ids = range(args.gpus) if args.gpu_ids is None else args.gpu_ids
+    if args.gpu_ids is not None:
+        cfg.gpu_ids = args.gpu_ids
+    else:
+        cfg.gpu_ids = range(1) if args.gpus is None else range(args.gpus)
 
     if args.autoscale_lr:
         # apply the linear scaling rule (https://arxiv.org/abs/1706.02677)

--- a/tools/train.py
+++ b/tools/train.py
@@ -36,7 +36,7 @@ def parse_args():
     group_gpus.add_argument(
         '--gpu-ids',
         type=int,
-        nargs='*',
+        nargs='+',
         help='ids of gpus to use '
         '(only applicable to non-distributed training)')
     parser.add_argument('--seed', type=int, default=None, help='random seed')


### PR DESCRIPTION
The motivation for this pull request is to simultaneously train different models on the multi-gpu system
with each model trained on separate device (or devices).

Changes to be committed:
modified:   mmdet/apis/train.py
modified:   tools/train.py