### PR TITLE
Support for custom classes

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
+known_third_party = asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,pytest,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -374,29 +374,33 @@ python tools/pytorch2onnx.py ${CONFIG_FILE} ${CHECKPOINT_FILE} --out ${ONNX_FILE
 
 The simplest way is to convert your dataset to existing dataset formats (COCO or PASCAL VOC).
 
-Here we show an example of adding a custom dataset of 5 classes, assuming it is also in COCO format.
+Here we show an example of using a custom dataset of 5 classes, assuming it is also in COCO format.
 
-In `mmdet/datasets/my_dataset.py`:
-
-```python
-from .coco import CocoDataset
-from .registry import DATASETS
-
-
-@DATASETS.register_module
-class MyDataset(CocoDataset):
-
-    CLASSES = ('a', 'b', 'c', 'd', 'e')
-```
-
-In `mmdet/datasets/__init__.py`:
+In `configs/my_custom_config.py`:
 
 ```python
-from .my_dataset import MyDataset
+...
+# dataset settings
+dataset_type = 'CocoDataset'
+classes = ('a', 'b', 'c', 'd', 'e')
+...
+data = dict(
+    imgs_per_gpu=2,
+    workers_per_gpu=2,
+    train=dict(
+        type=dataset_type,
+        classes=classes,
+        ...),
+    val=dict(
+        type=dataset_type,
+        classes=classes,
+        ...),
+    test=dict(
+        type=dataset_type,
+        classes=classes,
+        ...))
+...
 ```
-
-Then you can use `MyDataset` in config files, with the same API as CocoDataset.
-
 
 It is also fine if you do not want to convert the annotation format to COCO or PASCAL format.
 Actually, we define a simple annotation format and all existing datasets are

--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -42,7 +42,8 @@ class CustomDataset(Dataset):
                  seg_prefix=None,
                  proposal_file=None,
                  test_mode=False,
-                 filter_empty_gt=True):
+                 filter_empty_gt=True,
+                 classes=None):
         self.ann_file = ann_file
         self.data_root = data_root
         self.img_prefix = img_prefix
@@ -50,6 +51,9 @@ class CustomDataset(Dataset):
         self.proposal_file = proposal_file
         self.test_mode = test_mode
         self.filter_empty_gt = filter_empty_gt
+
+        if classes is not None:
+            self.CLASSES = classes
 
         # join paths if data_root is specified
         if self.data_root is not None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from mmdet.datasets import DATASETS
+
+
+@pytest.mark.parametrize('dataset', [
+    'XMLDataset', 'CocoDataset', 'VOCDataset', 'CityscapesDataset',
+    'WIDERFaceDataset', 'CustomDataset'
+])
+def test_custom_classes_override_default(dataset):
+    dataset_class = DATASETS.get(dataset)
+    dataset_class.load_annotations = MagicMock()
+
+    original_classes = dataset_class.CLASSES
+
+    custom_dataset = dataset_class(
+        ann_file=MagicMock(),
+        pipeline=[],
+        classes=('foo', 'bar'),
+        test_mode=True,
+        img_prefix='VOC2007' if dataset == 'VOCDataset' else '')
+
+    assert custom_dataset.custom_classes
+    assert custom_dataset.CLASSES != original_classes
+    assert custom_dataset.CLASSES == ('foo', 'bar')

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -22,6 +22,5 @@ def test_custom_classes_override_default(dataset):
         test_mode=True,
         img_prefix='VOC2007' if dataset == 'VOCDataset' else '')
 
-    assert custom_dataset.custom_classes
     assert custom_dataset.CLASSES != original_classes
     assert custom_dataset.CLASSES == ('foo', 'bar')


### PR DESCRIPTION
*Changes:*

With the changes stated in this PR, we added the possibility to specify a custom set of classes in the config file and use a dataset format which has already been defined, e.g., Coco dataset format.

In order to make use of these changes, we have to specify the parameter `classes` in the config file (as we have explained in the updated documentation). If `classes` is not specified, then the data loader will use the categories specified in the `self.CLASSES` by default.


*Justification:*

Using this repository, we have run into the need of using our own datasets with custom classes, but we need to use it as a dependency installed in an environment, i.e., access to source code is not feasible.

We also believe that these changes can facilitate the use of custom classes (instead of creating a new custom dataset), while improving the reproducibility of results (you can share a configuration file without having to create a new dataset). In order to add custom classes with the current state of the repository, you would have to add a new dataset file and also modify the `dataset_type` in the config file, while with our changes you could just change the config file (as long as the format of your data is already defined).