### PR TITLE
Add train_cfg/test_cfg in AnchorHead

### DIFF
--- a/mmdet/models/anchor_heads/atss_head.py
+++ b/mmdet/models/anchor_heads/atss_head.py
@@ -123,7 +123,7 @@ class ATSSHead(AnchorHead):
         return cls_score, bbox_pred, centerness
 
     def loss_single(self, anchors, cls_score, bbox_pred, centerness, labels,
-                    label_weights, bbox_targets, num_total_samples, cfg):
+                    label_weights, bbox_targets, num_total_samples):
 
         anchors = anchors.reshape(-1, 4)
         cls_score = cls_score.permute(0, 2, 3,
@@ -186,7 +186,6 @@ class ATSSHead(AnchorHead):
              gt_bboxes,
              gt_labels,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
 
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
@@ -202,7 +201,6 @@ class ATSSHead(AnchorHead):
             valid_flag_list,
             gt_bboxes,
             img_metas,
-            cfg,
             gt_bboxes_ignore_list=gt_bboxes_ignore,
             gt_labels_list=gt_labels,
             label_channels=label_channels)
@@ -226,8 +224,7 @@ class ATSSHead(AnchorHead):
                 labels_list,
                 label_weights_list,
                 bbox_targets_list,
-                num_total_samples=num_total_samples,
-                cfg=cfg)
+                num_total_samples=num_total_samples)
 
         bbox_avg_factor = sum(bbox_avg_factor)
         bbox_avg_factor = reduce_mean(bbox_avg_factor).item()

--- a/mmdet/models/anchor_heads/fcos_head.py
+++ b/mmdet/models/anchor_heads/fcos_head.py
@@ -53,7 +53,9 @@ class FCOSHead(nn.Module):
                      use_sigmoid=True,
                      loss_weight=1.0),
                  conv_cfg=None,
-                 norm_cfg=dict(type='GN', num_groups=32, requires_grad=True)):
+                 norm_cfg=dict(type='GN', num_groups=32, requires_grad=True),
+                 train_cfg=None,
+                 test_cfg=None):
         super(FCOSHead, self).__init__()
         self.num_classes = num_classes
         self.cls_out_channels = num_classes
@@ -65,6 +67,8 @@ class FCOSHead(nn.Module):
         self.loss_cls = build_loss(loss_cls)
         self.loss_bbox = build_loss(loss_bbox)
         self.loss_centerness = build_loss(loss_centerness)
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
         self.conv_cfg = conv_cfg
         self.norm_cfg = norm_cfg
         self.fp16_enabled = False
@@ -147,7 +151,6 @@ class FCOSHead(nn.Module):
              gt_bboxes,
              gt_labels,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         assert len(cls_scores) == len(bbox_preds) == len(centernesses)
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]

--- a/mmdet/models/anchor_heads/fovea_head.py
+++ b/mmdet/models/anchor_heads/fovea_head.py
@@ -62,7 +62,9 @@ class FoveaHead(nn.Module):
                  loss_cls=None,
                  loss_bbox=None,
                  conv_cfg=None,
-                 norm_cfg=None):
+                 norm_cfg=None,
+                 train_cfg=None,
+                 test_cfg=None):
         super(FoveaHead, self).__init__()
         self.num_classes = num_classes
         self.cls_out_channels = num_classes
@@ -84,6 +86,8 @@ class FoveaHead(nn.Module):
         self.loss_bbox = build_loss(loss_bbox)
         self.conv_cfg = conv_cfg
         self.norm_cfg = norm_cfg
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
         self._init_layers()
 
     def _init_layers(self):
@@ -195,7 +199,6 @@ class FoveaHead(nn.Module):
              gt_bbox_list,
              gt_label_list,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         assert len(cls_scores) == len(bbox_preds)
 

--- a/mmdet/models/anchor_heads/free_anchor_retina_head.py
+++ b/mmdet/models/anchor_heads/free_anchor_retina_head.py
@@ -38,7 +38,6 @@ class FreeAnchorRetinaHead(RetinaHead):
              gt_bboxes,
              gt_labels,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
         assert len(featmap_sizes) == len(self.anchor_generators)

--- a/mmdet/models/anchor_heads/ga_rpn_head.py
+++ b/mmdet/models/anchor_heads/ga_rpn_head.py
@@ -40,7 +40,6 @@ class GARPNHead(GuidedAnchorHead):
              loc_preds,
              gt_bboxes,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         losses = super(GARPNHead, self).loss(
             cls_scores,
@@ -50,7 +49,6 @@ class GARPNHead(GuidedAnchorHead):
             gt_bboxes,
             None,
             img_metas,
-            cfg,
             gt_bboxes_ignore=gt_bboxes_ignore)
         return dict(
             loss_rpn_cls=losses['loss_cls'],

--- a/mmdet/models/anchor_heads/reppoints_head.py
+++ b/mmdet/models/anchor_heads/reppoints_head.py
@@ -64,7 +64,9 @@ class RepPointsHead(nn.Module):
                  use_grid_points=False,
                  center_init=True,
                  transform_method='moment',
-                 moment_mul=0.01):
+                 moment_mul=0.01,
+                 train_cfg=None,
+                 test_cfg=None):
         super(RepPointsHead, self).__init__()
         self.in_channels = in_channels
         self.num_classes = num_classes
@@ -77,6 +79,8 @@ class RepPointsHead(nn.Module):
         self.point_strides = point_strides
         self.conv_cfg = conv_cfg
         self.norm_cfg = norm_cfg
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
 
         self.background_label = (
             num_classes if background_label is None else background_label)
@@ -423,7 +427,6 @@ class RepPointsHead(nn.Module):
              gt_bboxes,
              gt_labels,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
         assert len(featmap_sizes) == len(self.point_generators)
@@ -434,7 +437,7 @@ class RepPointsHead(nn.Module):
                                                        img_metas)
         pts_coordinate_preds_init = self.offset_to_pts(center_list,
                                                        pts_preds_init)
-        if cfg.init.assigner['type'] == 'PointAssigner':
+        if self.train_cfg.init.assigner['type'] == 'PointAssigner':
             # Assign target for center list
             candidate_list = center_list
         else:
@@ -447,7 +450,7 @@ class RepPointsHead(nn.Module):
             valid_flag_list,
             gt_bboxes,
             img_metas,
-            cfg.init,
+            self.train_cfg.init,
             gt_bboxes_ignore_list=gt_bboxes_ignore,
             gt_labels_list=gt_labels,
             label_channels=label_channels,
@@ -481,7 +484,7 @@ class RepPointsHead(nn.Module):
             valid_flag_list,
             gt_bboxes,
             img_metas,
-            cfg.refine,
+            self.train_cfg.refine,
             gt_bboxes_ignore_list=gt_bboxes_ignore,
             gt_labels_list=gt_labels,
             label_channels=label_channels,

--- a/mmdet/models/anchor_heads/rpn_head.py
+++ b/mmdet/models/anchor_heads/rpn_head.py
@@ -40,7 +40,6 @@ class RPNHead(AnchorHead):
              bbox_preds,
              gt_bboxes,
              img_metas,
-             cfg,
              gt_bboxes_ignore=None):
         losses = super(RPNHead, self).loss(
             cls_scores,
@@ -48,7 +47,6 @@ class RPNHead(AnchorHead):
             gt_bboxes,
             None,
             img_metas,
-            cfg,
             gt_bboxes_ignore=gt_bboxes_ignore)
         return dict(
             loss_rpn_cls=losses['loss_cls'], loss_rpn_bbox=losses['loss_bbox'])

--- a/mmdet/models/detectors/rpn.py
+++ b/mmdet/models/detectors/rpn.py
@@ -20,6 +20,9 @@ class RPN(BaseDetector, RPNTestMixin):
         super(RPN, self).__init__()
         self.backbone = builder.build_backbone(backbone)
         self.neck = builder.build_neck(neck) if neck is not None else None
+        rpn_train_cfg = train_cfg.rpn if train_cfg is not None else None
+        rpn_head.update(train_cfg=rpn_train_cfg)
+        rpn_head.update(test_cfg=test_cfg.rpn)
         self.rpn_head = builder.build_head(rpn_head)
         self.train_cfg = train_cfg
         self.test_cfg = test_cfg
@@ -54,7 +57,7 @@ class RPN(BaseDetector, RPNTestMixin):
         x = self.extract_feat(img)
         rpn_outs = self.rpn_head(x)
 
-        rpn_loss_inputs = rpn_outs + (gt_bboxes, img_metas, self.train_cfg.rpn)
+        rpn_loss_inputs = rpn_outs + (gt_bboxes, img_metas)
         losses = self.rpn_head.loss(
             *rpn_loss_inputs, gt_bboxes_ignore=gt_bboxes_ignore)
         return losses

--- a/mmdet/models/detectors/single_stage.py
+++ b/mmdet/models/detectors/single_stage.py
@@ -25,6 +25,8 @@ class SingleStageDetector(BaseDetector):
         self.backbone = builder.build_backbone(backbone)
         if neck is not None:
             self.neck = builder.build_neck(neck)
+        bbox_head.update(train_cfg=train_cfg)
+        bbox_head.update(test_cfg=test_cfg)
         self.bbox_head = builder.build_head(bbox_head)
         self.train_cfg = train_cfg
         self.test_cfg = test_cfg
@@ -66,7 +68,7 @@ class SingleStageDetector(BaseDetector):
                       gt_bboxes_ignore=None):
         x = self.extract_feat(img)
         outs = self.bbox_head(x)
-        loss_inputs = outs + (gt_bboxes, gt_labels, img_metas, self.train_cfg)
+        loss_inputs = outs + (gt_bboxes, gt_labels, img_metas)
         losses = self.bbox_head.loss(
             *loss_inputs, gt_bboxes_ignore=gt_bboxes_ignore)
         return losses

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -32,9 +32,9 @@ class TwoStageDetector(BaseDetector, RPNTestMixin):
 
         if rpn_head is not None:
             rpn_train_cfg = train_cfg.rpn if train_cfg is not None else None
-            rpn_head.update(train_cfg=rpn_train_cfg)
-            rpn_head.update(test_cfg=test_cfg.rpn)
-            self.rpn_head = builder.build_head(rpn_head)
+            rpn_head_ = rpn_head.copy()
+            rpn_head_.update(train_cfg=rpn_train_cfg, test_cfg=test_cfg.rpn)
+            self.rpn_head = builder.build_head(rpn_head_)
 
         if roi_head is not None:
             # update train and test cfg here for now

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -31,6 +31,9 @@ class TwoStageDetector(BaseDetector, RPNTestMixin):
             self.neck = builder.build_neck(neck)
 
         if rpn_head is not None:
+            rpn_train_cfg = train_cfg.rpn if train_cfg is not None else None
+            rpn_head.update(train_cfg=rpn_train_cfg)
+            rpn_head.update(test_cfg=test_cfg.rpn)
             self.rpn_head = builder.build_head(rpn_head)
 
         if roi_head is not None:
@@ -138,8 +141,7 @@ class TwoStageDetector(BaseDetector, RPNTestMixin):
         # RPN forward and loss
         if self.with_rpn:
             rpn_outs = self.rpn_head(x)
-            rpn_loss_inputs = rpn_outs + (gt_bboxes, img_metas,
-                                          self.train_cfg.rpn)
+            rpn_loss_inputs = rpn_outs + (gt_bboxes, img_metas)
             rpn_losses = self.rpn_head.loss(
                 *rpn_loss_inputs, gt_bboxes_ignore=gt_bboxes_ignore)
             losses.update(rpn_losses)

--- a/tests/test_heads.py
+++ b/tests/test_heads.py
@@ -11,7 +11,6 @@ def test_anchor_head_loss():
     """
     Tests anchor head loss when truth is empty and non-empty
     """
-    self = AnchorHead(num_classes=4, in_channels=1)
     s = 256
     img_metas = [{
         'img_shape': (s, s, 3),
@@ -38,6 +37,7 @@ def test_anchor_head_loss():
         'pos_weight': -1,
         'debug': False
     })
+    self = AnchorHead(num_classes=4, in_channels=1, train_cfg=cfg)
 
     # Anchor head expects a multiple levels of features per image
     feat = [
@@ -52,7 +52,7 @@ def test_anchor_head_loss():
 
     gt_bboxes_ignore = None
     empty_gt_losses = self.loss(cls_scores, bbox_preds, gt_bboxes, gt_labels,
-                                img_metas, cfg, gt_bboxes_ignore)
+                                img_metas, gt_bboxes_ignore)
     # When there is no truth, the cls loss should be nonzero but there should
     # be no box loss.
     empty_cls_loss = sum(empty_gt_losses['loss_cls'])
@@ -68,7 +68,7 @@ def test_anchor_head_loss():
     ]
     gt_labels = [torch.LongTensor([2])]
     one_gt_losses = self.loss(cls_scores, bbox_preds, gt_bboxes, gt_labels,
-                              img_metas, cfg, gt_bboxes_ignore)
+                              img_metas, gt_bboxes_ignore)
     onegt_cls_loss = sum(one_gt_losses['loss_cls'])
     onegt_box_loss = sum(one_gt_losses['loss_bbox'])
     assert onegt_cls_loss.item() > 0, 'cls loss should be non-zero'


### PR DESCRIPTION
This PR added `train_cfg` and `test_cfg` as class members in all anchor heads. And it also removed `cfg` in `loss` function. 