### PR TITLE
Refactor (tools): use '-' rather than '_' for command option

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -64,7 +64,7 @@ python tools/test.py configs/pascal_voc/faster_rcnn_r50_fpn_1x_voc.py \
 ```shell
 ./tools/dist_test.sh configs/mask_rcnn_r50_fpn_1x_coco.py \
     checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth \
-    8 --format_only --options "jsonfile_prefix=./mask_rcnn_test-dev_results"
+    8 --format-only --options "jsonfile_prefix=./mask_rcnn_test-dev_results"
 ```
 
 You will get two json files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcnn_test-dev_results.segm.json`.
@@ -74,7 +74,7 @@ You will get two json files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcn
 ```shell
 ./tools/dist_test.sh configs/cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py \
     checkpoints/mask_rcnn_r50_fpn_1x_cityscapes_20200227-afe51d5a.pth \
-    8  --format_only --options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
+    8  --format-only --options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
 ```
 
 The generated png and txt would be under `./mask_rcnn_cityscapes_test_results` directory.
@@ -202,12 +202,12 @@ If you want to specify the working directory in the command, you can add an argu
 Optional arguments are:
 
 - `--validate` (**strongly recommended**): Perform evaluation at every k (default value is 1, which can be modified like [this](https://github.com/open-mmlab/mmdetection/blob/master/configs/mask_rcnn_r50_fpn_1x_coco.py#L174)) epochs during the training.
-- `--work_dir ${WORK_DIR}`: Override the working directory specified in the config file.
-- `--resume_from ${CHECKPOINT_FILE}`: Resume from a previous checkpoint file.
+- `--work-dir ${WORK_DIR}`: Override the working directory specified in the config file.
+- `--resume-from ${CHECKPOINT_FILE}`: Resume from a previous checkpoint file.
 
-Difference between `resume_from` and `load_from`:
-`resume_from` loads both the model weights and optimizer status, and the epoch is also inherited from the specified checkpoint. It is usually used for resuming the training process that is interrupted accidentally.
-`load_from` only loads the model weights and the training epoch starts from 0. It is usually used for finetuning.
+Difference between `resume-from` and `load-from`:
+`resume-from` loads both the model weights and optimizer status, and the epoch is also inherited from the specified checkpoint. It is usually used for resuming the training process that is interrupted accidentally.
+`load-from` only loads the model weights and the training epoch starts from 0. It is usually used for finetuning.
 
 ### Train with multiple machines
 

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -93,9 +93,9 @@ def plot_curve(log_dicts, args):
 
 def add_plot_parser(subparsers):
     parser_plt = subparsers.add_parser(
-        'plot_curve', help='parser for plotting curves')
+        'plot-curve', help='parser for plotting curves')
     parser_plt.add_argument(
-        'json_logs',
+        'json-logs',
         type=str,
         nargs='+',
         help='path of train log in json format')
@@ -121,10 +121,10 @@ def add_plot_parser(subparsers):
 
 def add_time_parser(subparsers):
     parser_time = subparsers.add_parser(
-        'cal_train_time',
+        'cal-train-time',
         help='parser for computing the average time per training iteration')
     parser_time.add_argument(
-        'json_logs',
+        'json-logs',
         type=str,
         nargs='+',
         help='path of train log in json format')

--- a/tools/coco_error_analysis.py
+++ b/tools/coco_error_analysis.py
@@ -159,7 +159,7 @@ def analyze_results(res_file, ann_file, res_types, out_dir):
 def main():
     parser = ArgumentParser(description='COCO Error Analysis Tool')
     parser.add_argument('result', help='result file (json format) path')
-    parser.add_argument('out_dir', help='dir to save analyze result images')
+    parser.add_argument('out-dir', help='dir to save analyze result images')
     parser.add_argument(
         '--ann',
         default='data/coco/annotations/instances_val2017.json',

--- a/tools/convert_datasets/cityscapes.py
+++ b/tools/convert_datasets/cityscapes.py
@@ -114,9 +114,9 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description='Convert Cityscapes annotations to COCO format')
     parser.add_argument('cityscapes_path', help='cityscapes data path')
-    parser.add_argument('--img_dir', default='leftImg8bit', type=str)
-    parser.add_argument('--gt_dir', default='gtFine', type=str)
-    parser.add_argument('-o', '--out_dir', help='output path')
+    parser.add_argument('--img-dir', default='leftImg8bit', type=str)
+    parser.add_argument('--gt-dir', default='gtFine', type=str)
+    parser.add_argument('-o', '--out-dir', help='output path')
     parser.add_argument(
         '--nproc', default=1, type=int, help='number of process')
     args = parser.parse_args()

--- a/tools/publish_model.py
+++ b/tools/publish_model.py
@@ -7,8 +7,8 @@ import torch
 def parse_args():
     parser = argparse.ArgumentParser(
         description='Process a checkpoint to be published')
-    parser.add_argument('in_file', help='input checkpoint filename')
-    parser.add_argument('out_file', help='output checkpoint filename')
+    parser.add_argument('in-file', help='input checkpoint filename')
+    parser.add_argument('out-file', help='output checkpoint filename')
     args = parser.parse_args()
     return args
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -51,12 +51,12 @@ def parse_args():
     parser.add_argument('checkpoint', help='checkpoint file')
     parser.add_argument('--out', help='output result file in pickle format')
     parser.add_argument(
-        '--fuse_conv_bn',
+        '--fuse-conv-bn',
         action='store_true',
         help='Whether to fuse conv and bn, this will slightly increase'
         'the inference speed')
     parser.add_argument(
-        '--format_only',
+        '--format-only',
         action='store_true',
         help='Format the output results without perform evaluation. It is'
         'useful when you want to format the result to a specific format and '
@@ -69,7 +69,7 @@ def parse_args():
         ' "segm", "proposal" for COCO, and "mAP", "recall" for PASCAL VOC')
     parser.add_argument('--show', action='store_true', help='show results')
     parser.add_argument(
-        '--gpu_collect',
+        '--gpu-collect',
         action='store_true',
         help='whether to use gpu to collect results.')
     parser.add_argument(
@@ -83,7 +83,7 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
+    parser.add_argument('--local-rank', type=int, default=0)
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)

--- a/tools/train.py
+++ b/tools/train.py
@@ -20,9 +20,9 @@ from mmdet.utils import collect_env, get_root_logger
 def parse_args():
     parser = argparse.ArgumentParser(description='Train a detector')
     parser.add_argument('config', help='train config file path')
-    parser.add_argument('--work_dir', help='the dir to save logs and models')
+    parser.add_argument('--work-dir', help='the dir to save logs and models')
     parser.add_argument(
-        '--resume_from', help='the checkpoint file to resume from')
+        '--resume-from', help='the checkpoint file to resume from')
     parser.add_argument(
         '--validate',
         action='store_true',
@@ -43,7 +43,7 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local_rank', type=int, default=0)
+    parser.add_argument('--local-rank', type=int, default=0)
     parser.add_argument(
         '--autoscale-lr',
         action='store_true',

--- a/tools/upgrade_model_version.py
+++ b/tools/upgrade_model_version.py
@@ -32,8 +32,8 @@ def convert(in_file, out_file):
 
 def main():
     parser = argparse.ArgumentParser(description='Upgrade model version')
-    parser.add_argument('in_file', help='input checkpoint file')
-    parser.add_argument('out_file', help='output checkpoint file')
+    parser.add_argument('in-file', help='input checkpoint file')
+    parser.add_argument('out-file', help='output checkpoint file')
     args = parser.parse_args()
     convert(args.in_file, args.out_file)
 


### PR DESCRIPTION
This PR refactors command options in `tools`. It changes the option style from `--xx_xx` to `--xx-xx` for more natural usage.