### PR TITLE
Merge non dist and dist train

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -90,34 +90,6 @@ def train_detector(model,
                    meta=None):
     logger = get_root_logger(cfg.log_level)
 
-    # start training
-    if distributed:
-        _dist_train(
-            model,
-            dataset,
-            cfg,
-            validate=validate,
-            logger=logger,
-            timestamp=timestamp,
-            meta=meta)
-    else:
-        _non_dist_train(
-            model,
-            dataset,
-            cfg,
-            validate=validate,
-            logger=logger,
-            timestamp=timestamp,
-            meta=meta)
-
-
-def _dist_train(model,
-                dataset,
-                cfg,
-                validate=False,
-                logger=None,
-                timestamp=None,
-                meta=None):
     # prepare data loaders
     dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]
     data_loaders = [
@@ -125,18 +97,24 @@ def _dist_train(model,
             ds,
             cfg.data.imgs_per_gpu,
             cfg.data.workers_per_gpu,
-            dist=True,
+            # cfg.gpus will be ignored if distributed
+            cfg.gpus,
+            dist=distributed,
             seed=cfg.seed) for ds in dataset
     ]
+
     # put model on gpus
-    find_unused_parameters = cfg.get('find_unused_parameters', False)
-    # Sets the `find_unused_parameters` parameter in
-    # torch.nn.parallel.DistributedDataParallel
-    model = MMDistributedDataParallel(
-        model.cuda(),
-        device_ids=[torch.cuda.current_device()],
-        broadcast_buffers=False,
-        find_unused_parameters=find_unused_parameters)
+    if distributed:
+        find_unused_parameters = cfg.get('find_unused_parameters', False)
+        # Sets the `find_unused_parameters` parameter in
+        # torch.nn.parallel.DistributedDataParallel
+        model = MMDistributedDataParallel(
+            model.cuda(),
+            device_ids=[torch.cuda.current_device()],
+            broadcast_buffers=False,
+            find_unused_parameters=find_unused_parameters)
+    else:
+        model = MMDataParallel(model, device_ids=range(cfg.gpus)).cuda()
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)
@@ -155,73 +133,16 @@ def _dist_train(model,
     if fp16_cfg is not None:
         optimizer_config = Fp16OptimizerHook(**cfg.optimizer_config,
                                              **fp16_cfg)
-    else:
+    elif distributed:
         optimizer_config = DistOptimizerHook(**cfg.optimizer_config)
+    else:
+        optimizer_config = cfg.optimizer_config
 
     # register hooks
     runner.register_training_hooks(cfg.lr_config, optimizer_config,
                                    cfg.checkpoint_config, cfg.log_config)
-    runner.register_hook(DistSamplerSeedHook())
-    # register eval hooks
-    if validate:
-        val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
-        val_dataloader = build_dataloader(
-            val_dataset,
-            imgs_per_gpu=1,
-            workers_per_gpu=cfg.data.workers_per_gpu,
-            dist=True,
-            shuffle=False)
-        eval_cfg = cfg.get('evaluation', {})
-        runner.register_hook(DistEvalHook(val_dataloader, **eval_cfg))
-
-    if cfg.resume_from:
-        runner.resume(cfg.resume_from)
-    elif cfg.load_from:
-        runner.load_checkpoint(cfg.load_from)
-    runner.run(data_loaders, cfg.workflow, cfg.total_epochs)
-
-
-def _non_dist_train(model,
-                    dataset,
-                    cfg,
-                    validate=False,
-                    logger=None,
-                    timestamp=None,
-                    meta=None):
-    # prepare data loaders
-    dataset = dataset if isinstance(dataset, (list, tuple)) else [dataset]
-    data_loaders = [
-        build_dataloader(
-            ds,
-            cfg.data.imgs_per_gpu,
-            cfg.data.workers_per_gpu,
-            cfg.gpus,
-            dist=False,
-            seed=cfg.seed) for ds in dataset
-    ]
-    # put model on gpus
-    model = MMDataParallel(model, device_ids=range(cfg.gpus)).cuda()
-
-    # build runner
-    optimizer = build_optimizer(model, cfg.optimizer)
-    runner = Runner(
-        model,
-        batch_processor,
-        optimizer,
-        cfg.work_dir,
-        logger=logger,
-        meta=meta)
-    # an ugly walkaround to make the .log and .log.json filenames the same
-    runner.timestamp = timestamp
-    # fp16 setting
-    fp16_cfg = cfg.get('fp16', None)
-    if fp16_cfg is not None:
-        optimizer_config = Fp16OptimizerHook(
-            **cfg.optimizer_config, **fp16_cfg, distributed=False)
-    else:
-        optimizer_config = cfg.optimizer_config
-    runner.register_training_hooks(cfg.lr_config, optimizer_config,
-                                   cfg.checkpoint_config, cfg.log_config)
+    if distributed:
+        runner.register_hook(DistSamplerSeedHook())
 
     # register eval hooks
     if validate:
@@ -230,10 +151,11 @@ def _non_dist_train(model,
             val_dataset,
             imgs_per_gpu=1,
             workers_per_gpu=cfg.data.workers_per_gpu,
-            dist=False,
+            dist=distributed,
             shuffle=False)
         eval_cfg = cfg.get('evaluation', {})
-        runner.register_hook(EvalHook(val_dataloader, **eval_cfg))
+        eval_hook = DistEvalHook if distributed else EvalHook
+        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
 
     if cfg.resume_from:
         runner.resume(cfg.resume_from)

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -131,8 +131,8 @@ def train_detector(model,
     # fp16 setting
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
-        optimizer_config = Fp16OptimizerHook(**cfg.optimizer_config,
-                                             **fp16_cfg)
+        optimizer_config = Fp16OptimizerHook(
+            **cfg.optimizer_config, **fp16_cfg, distributed=distributed)
     elif distributed:
         optimizer_config = DistOptimizerHook(**cfg.optimizer_config)
     else:


### PR DESCRIPTION
I think that the `_dist_train` and `_non_dist_train` functions can be merged in order to reduce duplicate code and avoid potential divergences between the 2 modes.

It might be another reason that I'm not aware of to keep both functions separated  but after #2324 being merged I can't find one.