### PR TITLE
fix losses['loss_bbox'] bug

### DIFF
--- a/mmdet/datasets/xml_style.py
+++ b/mmdet/datasets/xml_style.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from .custom import CustomDataset
 from .registry import DATASETS
-
+from PIL import Image
 
 @DATASETS.register_module
 class XMLDataset(CustomDataset):
@@ -26,8 +26,16 @@ class XMLDataset(CustomDataset):
             tree = ET.parse(xml_path)
             root = tree.getroot()
             size = root.find('size')
-            width = int(size.find('width').text)
-            height = int(size.find('height').text)
+            width = 0
+            height = 0
+            if size is None:
+                imgname = osp.join(self.img_prefix, 'JPEGImages',
+                                '{}.jpg'.format(img_id))
+                img = Image.open(imgname)
+                width,height = img.size
+            else:
+                width = int(size.find('width').text)
+                height = int(size.find('height').text)
             img_infos.append(
                 dict(id=img_id, filename=filename, width=width, height=height))
         return img_infos

--- a/mmdet/models/bbox_heads/bbox_head.py
+++ b/mmdet/models/bbox_heads/bbox_head.py
@@ -118,6 +118,7 @@ class BBoxHead(nn.Module):
                 losses['acc'] = accuracy(cls_score, labels)
         if bbox_pred is not None:
             pos_inds = labels > 0
+            losses['loss_bbox'] = torch.tensor(0.).to(bbox_pred.device)
             if pos_inds.any():
                 if self.reg_class_agnostic:
                     pos_bbox_pred = bbox_pred.view(


### PR DESCRIPTION
I think it is necessary to initialize 'losses['loss_bbox'] ', otherwise when 'pos_inds.any()' is False, losses will be missing the key('loss_bbox')