### PR TITLE
Support custom classes

### DIFF
--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -184,7 +184,6 @@ class CustomDataset(Dataset):
             raise ValueError('Unsupported type {} of classes.'.format(
                 type(classes)))
 
-        assert set(class_names).issubset(set(cls.CLASSES))
         return class_names
 
     def get_subset_by_classes(self):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -40,6 +40,18 @@ def test_custom_classes_override_default(dataset):
     assert custom_dataset.CLASSES == ['bus', 'car']
     assert custom_dataset.custom_classes
 
+    # Test overriding not a subset
+    custom_dataset = dataset_class(
+        ann_file=MagicMock(),
+        pipeline=[],
+        classes=['foo'],
+        test_mode=True,
+        img_prefix='VOC2007' if dataset == 'VOCDataset' else '')
+
+    assert custom_dataset.CLASSES != original_classes
+    assert custom_dataset.CLASSES == ['foo']
+    assert custom_dataset.custom_classes
+
     # Test default behavior
     custom_dataset = dataset_class(
         ann_file=MagicMock(),


### PR DESCRIPTION
The changes introduced in #2408 were invalidated by the assertion introduced in #2340:

```python
assert set(class_names).issubset(set(cls.CLASSES))
```

This P.R. removes this assertion and adds a test, bringing back the original intention of #2408; which was to allow overriding `CLASSES` in configs, with `CLASSES` being one of:

a)  A subset of default `cls.CLASSES ` 
b) Some classes of a custom dataset annotated in `COCO `format).

