### PR TITLE
V2.0 classwise

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -59,7 +59,15 @@ python tools/test.py configs/pascal_voc/faster_rcnn_r50_fpn_1x_voc.py \
     8 --out results.pkl --eval bbox segm
 ```
 
-4. Test Mask R-CNN on COCO test-dev with 8 GPUs, and generate the json file to be submit to the official evaluation server.
+4. Test Mask R-CNN with 8 GPUs, and evaluate the **classwise** bbox and mask AP.
+
+```shell
+./tools/dist_test.sh configs/mask_rcnn_r50_fpn_1x_coco.py \
+    checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth \
+    8 --out results.pkl --eval bbox segm --options "classwise=True"
+```
+
+5. Test Mask R-CNN on COCO test-dev with 8 GPUs, and generate the json file to be submit to the official evaluation server.
 
 ```shell
 ./tools/dist_test.sh configs/mask_rcnn_r50_fpn_1x_coco.py \
@@ -69,7 +77,7 @@ python tools/test.py configs/pascal_voc/faster_rcnn_r50_fpn_1x_voc.py \
 
 You will get two json files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcnn_test-dev_results.segm.json`.
 
-5. Test Mask R-CNN on Cityscapes test with 8 GPUs, and generate the txt and png files to be submit to the official evaluation server.
+6. Test Mask R-CNN on Cityscapes test with 8 GPUs, and generate the txt and png files to be submit to the official evaluation server.
 
 ```shell
 ./tools/dist_test.sh configs/cityscapes/mask_rcnn_r50_fpn_1x_cityscapes.py \
@@ -78,14 +86,6 @@ You will get two json files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcn
 ```
 
 The generated png and txt would be under `./mask_rcnn_cityscapes_test_results` directory.
-
-6. Test Mask R-CNN with 8 GPUs, and evaluate the bbox and mask AP.
-
-```shell
-./tools/dist_test.sh configs/mask_rcnn_r50_fpn_1x_coco.py \
-    checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth \
-    8 --out results.pkl --eval bbox segm --options "classwise=True"
-```
 
 ### Webcam demo
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -79,6 +79,14 @@ You will get two json files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcn
 
 The generated png and txt would be under `./mask_rcnn_cityscapes_test_results` directory.
 
+6. Test Mask R-CNN with 8 GPUs, and evaluate the bbox and mask AP.
+
+```shell
+./tools/dist_test.sh configs/mask_rcnn_r50_fpn_1x_coco.py \
+    checkpoints/mask_rcnn_r50_fpn_1x_20181010-069fa190.pth \
+    8 --out results.pkl --eval bbox segm --options "classwise=True"
+```
+
 ### Webcam demo
 
 We provide a webcam demo to illustrate the results.

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -1,3 +1,4 @@
+import itertools
 import logging
 import os.path as osp
 import tempfile
@@ -6,6 +7,7 @@ import mmcv
 import numpy as np
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
+from terminaltables import AsciiTable
 
 from mmdet.core import eval_recalls
 from mmdet.utils import print_log
@@ -401,7 +403,38 @@ class CocoDataset(CustomDataset):
                 cocoEval.accumulate()
                 cocoEval.summarize()
                 if classwise:  # Compute per-category AP
-                    pass  # TODO
+                    # Compute per-category AP
+                    # from https://github.com/facebookresearch/detectron2/
+                    precisions = cocoEval.eval['precision']
+                    # precision: (iou, recall, cls, area range, max dets)
+                    assert len(self.cat_ids) == precisions.shape[2]
+
+                    results_per_category = []
+                    for idx, catId in enumerate(self.cat_ids):
+                        # area range index 0: all area ranges
+                        # max dets index -1: typically 100 per image
+                        nm = self.coco.loadCats(catId)[0]
+                        precision = precisions[:, :, idx, 0, -1]
+                        precision = precision[precision > -1]
+                        if precision.size:
+                            ap = np.mean(precision)
+                        else:
+                            ap = float('nan')
+                        results_per_category.append(
+                            ('{}'.format(nm['name']),
+                             '{:0.3f}'.format(float(ap * 100))))
+
+                    N_COLS = min(6, len(results_per_category) * 2)
+                    results_flatten = list(
+                        itertools.chain(*results_per_category))
+                    headers = ['category', 'AP'] * (N_COLS // 2)
+                    results_2d = itertools.zip_longest(
+                        *[results_flatten[i::N_COLS] for i in range(N_COLS)])
+                    table_data = [headers]
+                    table_data += [result for result in results_2d]
+                    table = AsciiTable(table_data)
+                    print(table.table)
+
                 metric_items = [
                     'mAP', 'mAP_50', 'mAP_75', 'mAP_s', 'mAP_m', 'mAP_l'
                 ]

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -424,16 +424,18 @@ class CocoDataset(CustomDataset):
                             ('{}'.format(nm['name']),
                              '{:0.3f}'.format(float(ap * 100))))
 
-                    N_COLS = min(6, len(results_per_category) * 2)
+                    num_columns = min(6, len(results_per_category) * 2)
                     results_flatten = list(
                         itertools.chain(*results_per_category))
-                    headers = ['category', 'AP'] * (N_COLS // 2)
-                    results_2d = itertools.zip_longest(
-                        *[results_flatten[i::N_COLS] for i in range(N_COLS)])
+                    headers = ['category', 'AP'] * (num_columns // 2)
+                    results_2d = itertools.zip_longest(*[
+                        results_flatten[i::num_columns]
+                        for i in range(num_columns)
+                    ])
                     table_data = [headers]
                     table_data += [result for result in results_2d]
                     table = AsciiTable(table_data)
-                    print(table.table)
+                    print_log(table.table)
 
                 metric_items = [
                     'mAP', 'mAP_50', 'mAP_75', 'mAP_s', 'mAP_m', 'mAP_l'

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -422,7 +422,7 @@ class CocoDataset(CustomDataset):
                             ap = float('nan')
                         results_per_category.append(
                             ('{}'.format(nm['name']),
-                             '{:0.3f}'.format(float(ap * 100))))
+                             '{:0.3f}'.format(float(ap))))
 
                     num_columns = min(6, len(results_per_category) * 2)
                     results_flatten = list(
@@ -435,7 +435,7 @@ class CocoDataset(CustomDataset):
                     table_data = [headers]
                     table_data += [result for result in results_2d]
                     table = AsciiTable(table_data)
-                    print_log(table.table)
+                    print_log('\n' + table.table, logger=logger)
 
                 metric_items = [
                     'mAP', 'mAP_50', 'mAP_75', 'mAP_s', 'mAP_m', 'mAP_l'


### PR DESCRIPTION
Showing class-wise mAP could helps users better analyze the model and there are indeed some need according to https://github.com/open-mmlab/mmdetection/issues/2325, https://github.com/open-mmlab/mmdetection/issues/1903, https://github.com/open-mmlab/mmdetection/issues/1526, etc.

This PR adds the class-wise mAP evaluation on the COCO dataset back to the v2.0 branch after the https://github.com/open-mmlab/mmdetection/pull/2042. To use this API, add `--options "classwise=True"` when using the test script or add `classwise=True` in the evaluation config for training-time evaluation.

An example of testing Faster RCNN R50 is as the following picture.
![image](https://user-images.githubusercontent.com/40779233/79529974-9ddf4800-80a0-11ea-82af-c9a67433f457.png)



