### PR TITLE
Fix dist_train

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -7,7 +7,7 @@ log_config = dict(
         # dict(type='TensorboardLoggerHook')
     ])
 # yapf:enable
-dist_params = dict(backend='nccl', port=29510)
+dist_params = dict(backend='nccl')
 log_level = 'INFO'
 load_from = None
 resume_from = None

--- a/tools/test.py
+++ b/tools/test.py
@@ -83,7 +83,7 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local-rank', type=int, default=0)
+    parser.add_argument('--local_rank', type=int, default=0)
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)

--- a/tools/train.py
+++ b/tools/train.py
@@ -49,7 +49,7 @@ def parse_args():
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
         help='job launcher')
-    parser.add_argument('--local-rank', type=int, default=0)
+    parser.add_argument('--local_rank', type=int, default=0)
     parser.add_argument(
         '--autoscale-lr',
         action='store_true',


### PR DESCRIPTION
This PR fixed `local_rank` typo and remove `dist_params.port` from `default_runtime.py` 