### PR TITLE
enable self-defined OptimizerHook

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -134,7 +134,7 @@ def train_detector(model,
     if fp16_cfg is not None:
         optimizer_config = Fp16OptimizerHook(
             **cfg.optimizer_config, **fp16_cfg, distributed=distributed)
-    elif distributed:
+    elif distributed and 'type' not in cfg.optimizer_config:
         optimizer_config = DistOptimizerHook(**cfg.optimizer_config)
     else:
         optimizer_config = cfg.optimizer_config


### PR DESCRIPTION
Enable self-defined OptimizerHook by inheriting it from mmcv, if do this, you should give the **type** of OptimizerHook in config file.