### PR TITLE
Fix loss_bbox in fovea_head.py when num_pos=0

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
+known_third_party = PIL,asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,6 +3,6 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = PIL,asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
+known_third_party = asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,robustness_eval,roi_align,roi_pool,seaborn,six,terminaltables,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/mmdet/models/anchor_heads/fovea_head.py
+++ b/mmdet/models/anchor_heads/fovea_head.py
@@ -223,6 +223,7 @@ class FoveaHead(nn.Module):
                 pos_bbox_targets,
                 pos_weights,
                 avg_factor=num_pos)
+            loss_bbox = loss_bbox.unsqueeze(0)
         else:
             loss_bbox = torch.tensor([0],
                                      dtype=flatten_bbox_preds.dtype,

--- a/mmdet/models/anchor_heads/fovea_head.py
+++ b/mmdet/models/anchor_heads/fovea_head.py
@@ -223,9 +223,8 @@ class FoveaHead(nn.Module):
                 pos_bbox_targets,
                 pos_weights,
                 avg_factor=num_pos)
-            loss_bbox = loss_bbox.unsqueeze(0)
         else:
-            loss_bbox = torch.tensor([0],
+            loss_bbox = torch.tensor(0,
                                      dtype=flatten_bbox_preds.dtype,
                                      device=flatten_bbox_preds.device)
         return dict(loss_cls=loss_cls, loss_bbox=loss_bbox)

--- a/mmdet/models/anchor_heads/fovea_head.py
+++ b/mmdet/models/anchor_heads/fovea_head.py
@@ -224,9 +224,9 @@ class FoveaHead(nn.Module):
                 pos_weights,
                 avg_factor=num_pos)
         else:
-            loss_bbox = torch.tensor(0,
+            loss_bbox = torch.tensor([0],
                                      dtype=flatten_bbox_preds.dtype,
-                                     device=flatten_bbox_preds.device)
+                                     device=flatten_bbox_preds.device).sum()
         return dict(loss_cls=loss_cls, loss_bbox=loss_bbox)
 
     def fovea_target(self, gt_bbox_list, gt_label_list, featmap_sizes, points):

--- a/mmdet/models/anchor_heads/fovea_head.py
+++ b/mmdet/models/anchor_heads/fovea_head.py
@@ -224,9 +224,10 @@ class FoveaHead(nn.Module):
                 pos_weights,
                 avg_factor=num_pos)
         else:
-            loss_bbox = torch.tensor([0],
-                                     dtype=flatten_bbox_preds.dtype,
-                                     device=flatten_bbox_preds.device).sum()
+            loss_bbox = torch.tensor(
+                0,
+                dtype=flatten_bbox_preds.dtype,
+                device=flatten_bbox_preds.device)
         return dict(loss_cls=loss_cls, loss_bbox=loss_bbox)
 
     def fovea_target(self, gt_bbox_list, gt_label_list, featmap_sizes, points):


### PR DESCRIPTION
During multi-GPU training, when num_pos == 0 on line 216 in fovea_head.py, it causes loss_bbox to be a tensor vector of shape [1] while when num_pos > 0, it causes loss_bbox to be a scalar of shape [], causing the gather function to fail. 

This pull request fixes this bug by unsqueezing loss_bbox when num_pos > 0.