### PR TITLE
rm bboxes[:,:4]

### DIFF
--- a/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/approx_max_iou_assigner.py
@@ -125,17 +125,15 @@ class ApproxMaxIoUAssigner(MaxIoUAssigner):
                                         num_gts).max(dim=0)
         overlaps = torch.transpose(overlaps, 0, 1)
 
-        bboxes = squares[:, :4]
-
         if (self.ignore_iof_thr > 0 and gt_bboxes_ignore is not None
-                and gt_bboxes_ignore.numel() > 0 and bboxes.numel() > 0):
+                and gt_bboxes_ignore.numel() > 0 and squares.numel() > 0):
             if self.ignore_wrt_candidates:
                 ignore_overlaps = self.iou_calculator(
-                    bboxes, gt_bboxes_ignore, mode='iof')
+                    squares, gt_bboxes_ignore, mode='iof')
                 ignore_max_overlaps, _ = ignore_overlaps.max(dim=1)
             else:
                 ignore_overlaps = self.iou_calculator(
-                    gt_bboxes_ignore, bboxes, mode='iof')
+                    gt_bboxes_ignore, squares, mode='iof')
                 ignore_max_overlaps, _ = ignore_overlaps.max(dim=0)
             overlaps[:, ignore_max_overlaps > self.ignore_iof_thr] = -1
 

--- a/mmdet/core/bbox/assigners/max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/max_iou_assigner.py
@@ -104,7 +104,6 @@ class MaxIoUAssigner(BaseAssigner):
             if gt_labels is not None:
                 gt_labels = gt_labels.cpu()
 
-        bboxes = bboxes[:, :4]
         overlaps = self.iou_calculator(gt_bboxes, bboxes)
 
         if (self.ignore_iof_thr > 0 and gt_bboxes_ignore is not None

--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -64,6 +64,7 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False):
     """
 
     assert mode in ['iou', 'iof']
+    assert bboxes1.size(-1) == bboxes2.size(-1) == 4
 
     rows = bboxes1.size(0)
     cols = bboxes2.size(0)

--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -8,6 +8,10 @@ class BboxOverlaps2D(object):
     """2D IoU Calculator"""
 
     def __call__(self, bboxes1, bboxes2, mode='iou', is_aligned=False):
+        if bboxes2.size(-1) >= 4:
+            bboxes2 = bboxes2[..., :4]
+        if bboxes1.size(-1) >= 4:
+            bboxes1 = bboxes1[..., :4]
         return bbox_overlaps(bboxes1, bboxes2, mode, is_aligned)
 
     def __repr__(self):

--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -8,15 +8,30 @@ class BboxOverlaps2D(object):
     """2D IoU Calculator"""
 
     def __call__(self, bboxes1, bboxes2, mode='iou', is_aligned=False):
-        if bboxes2.size(-1) >= 4:
+        """Calculate IoU between 2D bboxes
+
+        Args:
+            bboxes1 (Tensor): bboxes have shape (m, 4) in <x1, y1, x2, y2>
+                format, or shape (m, 5) in <x1, y1, x2, y2, score> format.
+            bboxes2 (Tensor): bboxes have shape (m, 4) in <x1, y1, x2, y2>
+                format, shape (m, 5) in <x1, y1, x2, y2, score> format, or be
+                empty. If is_aligned is ``True``, then m and n must be equal.
+            mode (str): "iou" (intersection over union) or iof (intersection
+                over foreground).
+
+        Returns:
+            ious(Tensor): shape (m, n) if is_aligned == False else shape (m, 1)
+        """
+        assert bboxes1.size(-1) in [0, 4, 5]
+        assert bboxes2.size(-1) in [0, 4, 5]
+        if bboxes2.size(-1) == 5:
             bboxes2 = bboxes2[..., :4]
-        if bboxes1.size(-1) >= 4:
+        if bboxes1.size(-1) == 5:
             bboxes1 = bboxes1[..., :4]
         return bbox_overlaps(bboxes1, bboxes2, mode, is_aligned)
 
     def __repr__(self):
-        repr_str = self.__class__.__name__
-        repr_str += f'(mode={self.mode}, is_aligned={self.is_aligned})'
+        repr_str = self.__class__.__name__ + '()'
         return repr_str
 
 
@@ -28,8 +43,8 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False):
     bboxes1 and bboxes2.
 
     Args:
-        bboxes1 (Tensor): shape (m, 4) in <x1, y1, x2, y2> format.
-        bboxes2 (Tensor): shape (n, 4) in <x1, y1, x2, y2> format.
+        bboxes1 (Tensor): shape (m, 4) in <x1, y1, x2, y2> format or empty.
+        bboxes2 (Tensor): shape (n, 4) in <x1, y1, x2, y2> format or empty.
             If is_aligned is ``True``, then m and n must be equal.
         mode (str): "iou" (intersection over union) or iof (intersection over
             foreground).
@@ -64,7 +79,9 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False):
     """
 
     assert mode in ['iou', 'iof']
-    assert bboxes1.size(-1) == bboxes2.size(-1) == 4
+    # Either the boxes are empty or the length of boxes's last dimenstion is 4
+    assert (bboxes1.size(-1) == 4 or bboxes1.size(0) == 0)
+    assert (bboxes2.size(-1) == 4 or bboxes2.size(0) == 0)
 
     rows = bboxes1.size(0)
     cols = bboxes2.size(0)


### PR DESCRIPTION
This PR removes the boxes[:,:4] in the max_iou_assigner, which makes the assigned box agnostic.