### PR TITLE
Use torch.bool rather than torch.uint8 after deprecate pytorch < 1.3

### DIFF
--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -248,8 +248,8 @@ class AnchorGenerator(object):
         feat_h, feat_w = featmap_size
         valid_h, valid_w = valid_size
         assert valid_h <= feat_h and valid_w <= feat_w
-        valid_x = torch.zeros(feat_w, dtype=torch.uint8, device=device)
-        valid_y = torch.zeros(feat_h, dtype=torch.uint8, device=device)
+        valid_x = torch.zeros(feat_w, dtype=torch.bool, device=device)
+        valid_y = torch.zeros(feat_h, dtype=torch.bool, device=device)
         valid_x[:valid_w] = 1
         valid_y[:valid_h] = 1
         valid_xx, valid_yy = self._meshgrid(valid_x, valid_y)

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -28,8 +28,8 @@ class PointGenerator(object):
         feat_h, feat_w = featmap_size
         valid_h, valid_w = valid_size
         assert valid_h <= feat_h and valid_w <= feat_w
-        valid_x = torch.zeros(feat_w, dtype=torch.uint8, device=device)
-        valid_y = torch.zeros(feat_h, dtype=torch.uint8, device=device)
+        valid_x = torch.zeros(feat_w, dtype=torch.bool, device=device)
+        valid_y = torch.zeros(feat_h, dtype=torch.bool, device=device)
         valid_x[:valid_w] = 1
         valid_y[:valid_h] = 1
         valid_xx, valid_yy = self._meshgrid(valid_x, valid_y)

--- a/mmdet/core/anchor/utils.py
+++ b/mmdet/core/anchor/utils.py
@@ -24,10 +24,10 @@ def anchor_inside_flags(flat_anchors,
     img_h, img_w = img_shape[:2]
     if allowed_border >= 0:
         inside_flags = valid_flags & \
-            (flat_anchors[:, 0] >= -allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 1] >= -allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 2] < img_w + allowed_border).type(torch.uint8) & \
-            (flat_anchors[:, 3] < img_h + allowed_border).type(torch.uint8)
+            (flat_anchors[:, 0] >= -allowed_border) & \
+            (flat_anchors[:, 1] >= -allowed_border) & \
+            (flat_anchors[:, 2] < img_w + allowed_border) & \
+            (flat_anchors[:, 3] < img_h + allowed_border)
     else:
         inside_flags = valid_flags
     return inside_flags

--- a/mmdet/models/anchor_heads/anchor_head.py
+++ b/mmdet/models/anchor_heads/anchor_head.py
@@ -189,7 +189,7 @@ class AnchorHead(nn.Module):
         if not inside_flags.any():
             return (None, ) * 6
         # assign gt and sample anchors
-        anchors = flat_anchors[inside_flags.type(torch.bool), :]
+        anchors = flat_anchors[inside_flags, :]
 
         assign_result = self.assigner.assign(
             anchors, gt_bboxes, gt_bboxes_ignore,

--- a/mmdet/models/anchor_heads/atss_head.py
+++ b/mmdet/models/anchor_heads/atss_head.py
@@ -419,7 +419,7 @@ class ATSSHead(AnchorHead):
         if not inside_flags.any():
             return (None, ) * 6
         # assign gt and sample anchors
-        anchors = flat_anchors[inside_flags.type(torch.bool), :]
+        anchors = flat_anchors[inside_flags, :]
 
         num_level_anchors_inside = self.get_num_level_anchors_inside(
             num_level_anchors, inside_flags)
@@ -459,7 +459,6 @@ class ATSSHead(AnchorHead):
 
         # map up to original set of anchors
         if unmap_outputs:
-            inside_flags = inside_flags.type(torch.bool)
             num_total_anchors = flat_anchors.size(0)
             anchors = unmap(anchors, num_total_anchors, inside_flags)
             labels = unmap(


### PR DESCRIPTION
This PR changes to use `torch.bool` during index selection with flags.
The original implementation needs to be also available for PyTorch 1.1, whose support for `torch.bool` is limited. Since MMDet V2.0 do not support PyTorch 1.1 anymore, some codes can be simplified.