### PR TITLE
fix bug of openssl, error message as below

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
+RUN rm /var/lib/dpkg/info/openssl.list
 RUN apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Selecting previously unselected package libglib2.0-0:amd64.
dpkg: unrecoverable fatal error, aborting:
 files list file for package 'openssl' is missing final newline
E: Sub-process /usr/bin/dpkg returned an error code (2)
The command '/bin/sh -c apt-get update && apt-get install -y libglib2.0-0 libsm6 libxrender-dev libxext6  && apt-get clean  && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100