### PR TITLE
Fix ATSS warning

### DIFF
--- a/mmdet/models/anchor_heads/atss_head.py
+++ b/mmdet/models/anchor_heads/atss_head.py
@@ -15,7 +15,7 @@ def reduce_mean(tensor):
     if not (dist.is_available() and dist.is_initialized()):
         return tensor
     tensor = tensor.clone()
-    dist.all_reduce(tensor.div_(dist.get_world_size()), op=dist.reduce_op.SUM)
+    dist.all_reduce(tensor.div_(dist.get_world_size()), op=dist.ReduceOp.SUM)
     return tensor
 
 


### PR DESCRIPTION
Using `dist.reduce_op.SUM` causes warning when using pytorch 1.3, so change to use `dist.ReduceOp.SUM`.