### PR TITLE
Fix cityscapes eval

### DIFF
--- a/mmdet/datasets/cityscapes.py
+++ b/mmdet/datasets/cityscapes.py
@@ -220,9 +220,13 @@ class CityscapesDataset(CocoDataset):
         if len(metrics) > 0:
             # create CocoDataset with CityscapesDataset annotation
             self_coco = CocoDataset(self.ann_file, self.pipeline.transforms,
-                                    self.data_root, self.img_prefix,
+                                    None, self.data_root, self.img_prefix,
                                     self.seg_prefix, self.proposal_file,
                                     self.test_mode, self.filter_empty_gt)
+            # TODO: remove this in the future
+            # reload annotations of correct class
+            self_coco.CLASSES = self.CLASSES
+            self_coco.data_infos = self_coco.load_annotations(self.ann_file)
             eval_results.update(
                 self_coco.evaluate(results, metrics, logger, outfile_prefix,
                                    classwise, proposal_nums, iou_thrs))


### PR DESCRIPTION
This PR fixed cityscapes evaluation. 
Since Cityscapes classes are not total contained by COCO classes, so subclasses could not be used. We reload annotations instead. 