### PR TITLE
Migrate to mmcv get_logger and print_log

### DIFF
--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -2,9 +2,9 @@ from multiprocessing import Pool
 
 import mmcv
 import numpy as np
+from mmcv.utils import print_log
 from terminaltables import AsciiTable
 
-from mmdet.utils import print_log
 from .bbox_overlaps import bbox_overlaps
 from .class_names import get_classes
 

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -1,9 +1,9 @@
 from collections.abc import Sequence
 
 import numpy as np
+from mmcv.utils import print_log
 from terminaltables import AsciiTable
 
-from mmdet.utils import print_log
 from .bbox_overlaps import bbox_overlaps
 
 

--- a/mmdet/datasets/cityscapes.py
+++ b/mmdet/datasets/cityscapes.py
@@ -9,8 +9,8 @@ import tempfile
 import mmcv
 import numpy as np
 import pycocotools.mask as maskUtils
+from mmcv.utils import print_log
 
-from mmdet.utils import print_log
 from .builder import DATASETS
 from .coco import CocoDataset
 

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -5,12 +5,12 @@ import tempfile
 
 import mmcv
 import numpy as np
+from mmcv.utils import print_log
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 from terminaltables import AsciiTable
 
 from mmdet.core import eval_recalls
-from mmdet.utils import print_log
 from .builder import DATASETS
 from .custom import CustomDataset
 

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -5,9 +5,9 @@ import mmcv
 import numpy as np
 import pycocotools.mask as maskUtils
 import torch.nn as nn
+from mmcv.utils import print_log
 
 from mmdet.core import auto_fp16
-from mmdet.utils import print_log
 
 
 class BaseDetector(nn.Module, metaclass=ABCMeta):

--- a/mmdet/ops/dcn/deform_conv.py
+++ b/mmdet/ops/dcn/deform_conv.py
@@ -4,11 +4,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import CONV_LAYERS
+from mmcv.utils import print_log
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 from torch.nn.modules.utils import _pair, _single
 
-from mmdet.utils import print_log
 from . import deform_conv_ext
 
 

--- a/mmdet/utils/__init__.py
+++ b/mmdet/utils/__init__.py
@@ -1,7 +1,5 @@
 from .collect_env import collect_env
 from .flops_counter import get_model_complexity_info
-from .logger import get_root_logger, print_log
+from .logger import get_root_logger
 
-__all__ = [
-    'get_model_complexity_info', 'get_root_logger', 'print_log', 'collect_env'
-]
+__all__ = ['get_model_complexity_info', 'get_root_logger', 'collect_env']

--- a/mmdet/utils/logger.py
+++ b/mmdet/utils/logger.py
@@ -1,66 +1,9 @@
 import logging
 
-from mmcv.runner import get_dist_info
+from mmcv.utils import get_logger
 
 
 def get_root_logger(log_file=None, log_level=logging.INFO):
-    """Get the root logger.
-
-    The logger will be initialized if it has not been initialized. By default a
-    StreamHandler will be added. If `log_file` is specified, a FileHandler will
-    also be added. The name of the root logger is the top-level package name,
-    e.g., "mmdet".
-
-    Args:
-        log_file (str | None): The log filename. If specified, a FileHandler
-            will be added to the root logger.
-        log_level (int): The root logger level. Note that only the process of
-            rank 0 is affected, while other processes will set the level to
-            "Error" and be silent most of the time.
-
-    Returns:
-        logging.Logger: The root logger.
-    """
-    logger = logging.getLogger(__name__.split('.')[0])  # i.e., mmdet
-    # if the logger has been initialized, just return it
-    if logger.hasHandlers():
-        return logger
-
-    format_str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-    logging.basicConfig(format=format_str, level=log_level)
-    rank, _ = get_dist_info()
-    if rank != 0:
-        logger.setLevel('ERROR')
-    elif log_file is not None:
-        file_handler = logging.FileHandler(log_file, 'w')
-        file_handler.setFormatter(logging.Formatter(format_str))
-        file_handler.setLevel(log_level)
-        logger.addHandler(file_handler)
+    logger = get_logger(name='mmdet', log_file=log_file, log_level=log_level)
 
     return logger
-
-
-def print_log(msg, logger=None, level=logging.INFO):
-    """Print a log message.
-
-    Args:
-        msg (str): The message to be logged.
-        logger (logging.Logger | str | None): The logger to be used. Some
-            special loggers are:
-            - "root": the root logger obtained with `get_root_logger()`.
-            - "silent": no message will be printed.
-            - None: The `print()` method will be used to print log messages.
-        level (int): Logging level. Only available when `logger` is a Logger
-            object or "root".
-    """
-    if logger is None:
-        print(msg)
-    elif logger == 'root':
-        _logger = get_root_logger()
-        _logger.log(level, msg)
-    elif isinstance(logger, logging.Logger):
-        logger.log(level, msg)
-    elif logger != 'silent':
-        raise TypeError(
-            'logger should be either a logging.Logger object, "root", '
-            f'"silent" or None, but got {logger}')


### PR DESCRIPTION
This PR removed `mmdet.utils.get_root_logger` and `mmdet.utils.print_log`, `mmcv.utils.get_logger` and `mmcv.utils.print_log` are used instead. 