### PR TITLE
compute pure inference time instead

### DIFF
--- a/mmcv
+++ b/mmcv
@@ -1,0 +1,1 @@
+/Users/yuhangcao/Desktop/mmcv/mmcv

--- a/mmcv
+++ b/mmcv
@@ -1,1 +1,0 @@
-/Users/yuhangcao/Desktop/mmcv/mmcv

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -55,7 +55,7 @@ def single_gpu_test(model,
 
         torch.cuda.synchronize()
         elapsed = time.perf_counter() - start_time
-        batch_size = len(data['img_meta']._data)
+        batch_size = data['img'][0].size(0)
         prog_bar.update(completed=batch_size, elapsed_time=elapsed)
 
         # encode mask results
@@ -129,7 +129,9 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
         if rank == 0:
             torch.cuda.synchronize()
             elapsed = time.perf_counter() - start_time
-            batch_size = len(data['img_meta']._data)
+            batch_size = len(
+                data['img_meta']._data
+            ) if 'img_meta' in data else data['img'][0].size(0)
             prog_bar.update(
                 completed=batch_size * world_size, elapsed_time=elapsed)
 

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -43,7 +43,6 @@ def single_gpu_test(model,
     results = []
     dataset = data_loader.dataset
     prog_bar = mmcv.ProgressBar(len(dataset))
-
     for i, data in enumerate(data_loader):
         with torch.no_grad():
             result = model(return_loss=False, rescale=True, **data)

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -2,13 +2,37 @@ import os.path as osp
 import pickle
 import shutil
 import tempfile
+import time
 
 import mmcv
+import numpy as np
+import pycocotools.mask as mask_util
 import torch
 import torch.distributed as dist
 from mmcv.runner import get_dist_info
 
 from mmdet.core import tensor2imgs
+
+
+# TODO: move this function to more proper place
+def encode_mask_results(mask_results):
+    if isinstance(mask_results, tuple):  # mask scoring
+        cls_segms, cls_mask_scores = mask_results
+    else:
+        cls_segms = mask_results
+    num_classes = len(cls_segms)
+    encoded_mask_results = [[] for _ in range(num_classes)]
+    for i in range(len(cls_segms)):
+        for cls_segm in cls_segms[i]:
+            encoded_mask_results[i].append(
+                mask_util.encode(
+                    np.array(
+                        cls_segm[:, :, np.newaxis], order='F',
+                        dtype='uint8'))[0])  # encoded with RLE
+    if isinstance(mask_results, tuple):
+        return encoded_mask_results, cls_mask_scores
+    else:
+        return encoded_mask_results
 
 
 def single_gpu_test(model,
@@ -20,9 +44,25 @@ def single_gpu_test(model,
     results = []
     dataset = data_loader.dataset
     prog_bar = mmcv.ProgressBar(len(dataset))
+
     for i, data in enumerate(data_loader):
+
+        torch.cuda.synchronize()
+        start_time = time.perf_counter()
+
         with torch.no_grad():
             result = model(return_loss=False, rescale=True, **data)
+
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - start_time
+        batch_size = data['img'][0].size(0)
+        prog_bar.update(completed=batch_size, elapsed_time=elapsed)
+
+        # encode mask results
+        if isinstance(result, tuple):
+            bbox_results, mask_results = result
+            encoded_mask_results = encode_mask_results(mask_results)
+            result = bbox_results, encoded_mask_results
         results.append(result)
 
         if show or out_dir:
@@ -49,10 +89,6 @@ def single_gpu_test(model,
                     show=show,
                     out_file=out_file,
                     score_thr=show_score_thr)
-
-        batch_size = data['img'][0].size(0)
-        for _ in range(batch_size):
-            prog_bar.update()
     return results
 
 
@@ -81,17 +117,28 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
     rank, world_size = get_dist_info()
     if rank == 0:
         prog_bar = mmcv.ProgressBar(len(dataset))
+
     for i, data in enumerate(data_loader):
+
+        torch.cuda.synchronize()
+        start_time = time.perf_counter()
+
         with torch.no_grad():
             result = model(return_loss=False, rescale=True, **data)
-        results.append(result)
 
         if rank == 0:
-            batch_size = (
-                len(data['img_meta']._data)
-                if 'img_meta' in data else data['img'][0].size(0))
-            for _ in range(batch_size * world_size):
-                prog_bar.update()
+            torch.cuda.synchronize()
+            elapsed = time.perf_counter() - start_time
+            batch_size = data['img'][0].size(0)
+            prog_bar.update(
+                completed=batch_size * world_size, elapsed_time=elapsed)
+
+        # encode mask results
+        if isinstance(result, tuple):
+            bbox_results, mask_results = result
+            encoded_mask_results = encode_mask_results(mask_results)
+            result = bbox_results, encoded_mask_results
+        results.append(result)
 
     # collect results from all ranks
     if gpu_collect:

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -55,7 +55,7 @@ def single_gpu_test(model,
 
         torch.cuda.synchronize()
         elapsed = time.perf_counter() - start_time
-        batch_size = data['img'][0].size(0)
+        batch_size = len(data['img_metas'])
         prog_bar.update(completed=batch_size, elapsed_time=elapsed)
 
         # encode mask results
@@ -129,9 +129,7 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
         if rank == 0:
             torch.cuda.synchronize()
             elapsed = time.perf_counter() - start_time
-            batch_size = len(
-                data['img_meta']._data
-            ) if 'img_meta' in data else data['img'][0].size(0)
+            batch_size = len(data['img_metas'])
             prog_bar.update(
                 completed=batch_size * world_size, elapsed_time=elapsed)
 

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -55,7 +55,7 @@ def single_gpu_test(model,
 
         torch.cuda.synchronize()
         elapsed = time.perf_counter() - start_time
-        batch_size = data['img'][0].size(0)
+        batch_size = len(data['img_meta']._data)
         prog_bar.update(completed=batch_size, elapsed_time=elapsed)
 
         # encode mask results
@@ -129,7 +129,7 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
         if rank == 0:
             torch.cuda.synchronize()
             elapsed = time.perf_counter() - start_time
-            batch_size = data['img'][0].size(0)
+            batch_size = len(data['img_meta']._data)
             prog_bar.update(
                 completed=batch_size * world_size, elapsed_time=elapsed)
 

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -508,9 +508,9 @@ class PhotoMetricDistortion(object):
     def __repr__(self):
         repr_str = self.__class__.__name__
         repr_str += f'(\nbrightness_delta={self.brightness_delta},\n'
-        repr_str += f'contrast_range='
+        repr_str += 'contrast_range='
         repr_str += f'{(self.contrast_lower, self.contrast_upper)},\n'
-        repr_str += f'saturation_range='
+        repr_str += 'saturation_range='
         repr_str += f'{(self.saturation_lower, self.saturation_upper)},\n'
         repr_str += f'hue_delta={self.hue_delta})'
         return repr_str

--- a/mmdet/models/dense_heads/fsaf_head.py
+++ b/mmdet/models/dense_heads/fsaf_head.py
@@ -260,7 +260,8 @@ class FSAFHead(RetinaHead):
                 for cls, pos in zip(cls_scores, pos_inds)
             ]
             labels = [
-                l.reshape(-1)[pos] for l, pos in zip(labels_list, pos_inds)
+                label.reshape(-1)[pos]
+                for label, pos in zip(labels_list, pos_inds)
             ]
 
             def argmax(x):

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pycocotools.mask as mask_util
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -232,12 +231,7 @@ class FCNMaskHead(nn.Module):
             im_mask[(inds, ) + spatial_inds] = masks_chunk
 
         for i in range(N):
-            rle = mask_util.encode(
-                np.array(
-                    im_mask[i][:, :, None].cpu().numpy(),
-                    order='F',
-                    dtype='uint8'))[0]
-            cls_segms[labels[i]].append(rle)
+            cls_segms[labels[i]].append(im_mask[i].cpu().numpy())
         return cls_segms
 
 

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -150,8 +150,8 @@ def load_json_logs(json_logs):
     log_dicts = [dict() for _ in json_logs]
     for json_log, log_dict in zip(json_logs, log_dicts):
         with open(json_log, 'r') as log_file:
-            for l in log_file:
-                log = json.loads(l.strip())
+            for line in log_file:
+                log = json.loads(line.strip())
                 # skip lines without `epoch` field
                 if 'epoch' not in log:
                     continue

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -52,23 +52,16 @@ def main():
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
         wrap_fp16_model(model)
-    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
+    load_checkpoint(model, args.checkpoint, map_location='cpu')
     if args.fuse_conv_bn:
         model = fuse_module(model)
-    # old versions did not save class info in checkpoints, this walkaround is
-    # for backward compatibility
-    if 'CLASSES' in checkpoint['meta']:
-        model.CLASSES = checkpoint['meta']['CLASSES']
-    else:
-        model.CLASSES = dataset.CLASSES
 
     model = MMDataParallel(model, device_ids=[0])
 
     model.eval()
-    dataset = data_loader.dataset
 
     # the first several iterations may be very slow so skip them
-    num_warmup = min(5, len(dataset) - 1)
+    num_warmup = 5
     pure_inf_time = 0
 
     # benchmark with 200 image and take the average

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -1,0 +1,100 @@
+import argparse
+import time
+
+import torch
+from mmcv import Config
+from mmcv.parallel import MMDataParallel
+from mmcv.runner import load_checkpoint
+from tools.fuse_conv_bn import fuse_module
+
+from mmdet.core import wrap_fp16_model
+from mmdet.datasets import build_dataloader, build_dataset
+from mmdet.models import build_detector
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='MMDet benchmark a model')
+    parser.add_argument('config', help='test config file path')
+    parser.add_argument('checkpoint', help='checkpoint file')
+    parser.add_argument(
+        '--log-interval', default=50, help='interval of logging')
+    parser.add_argument(
+        '--fuse-conv-bn',
+        action='store_true',
+        help='Whether to fuse conv and bn, this will slightly increase'
+        'the inference speed')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+
+    cfg = Config.fromfile(args.config)
+    # set cudnn_benchmark
+    if cfg.get('cudnn_benchmark', False):
+        torch.backends.cudnn.benchmark = True
+    cfg.model.pretrained = None
+    cfg.data.test.test_mode = True
+
+    # build the dataloader
+    # TODO: support multiple images per gpu (only minor changes are needed)
+    dataset = build_dataset(cfg.data.test)
+    data_loader = build_dataloader(
+        dataset,
+        samples_per_gpu=1,
+        workers_per_gpu=cfg.data.workers_per_gpu,
+        dist=False,
+        shuffle=False)
+
+    # build the model and load checkpoint
+    model = build_detector(cfg.model, train_cfg=None, test_cfg=cfg.test_cfg)
+    fp16_cfg = cfg.get('fp16', None)
+    if fp16_cfg is not None:
+        wrap_fp16_model(model)
+    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
+    if args.fuse_conv_bn:
+        model = fuse_module(model)
+    # old versions did not save class info in checkpoints, this walkaround is
+    # for backward compatibility
+    if 'CLASSES' in checkpoint['meta']:
+        model.CLASSES = checkpoint['meta']['CLASSES']
+    else:
+        model.CLASSES = dataset.CLASSES
+
+    model = MMDataParallel(model, device_ids=[0])
+
+    model.eval()
+    dataset = data_loader.dataset
+
+    # the first several iterations may be very slow so skip them
+    num_warmup = min(5, len(dataset) - 1)
+    pure_inf_time = 0
+
+    # benchmark with 200 image and take the average
+    for i, data in enumerate(data_loader):
+
+        torch.cuda.synchronize()
+        start_time = time.perf_counter()
+
+        with torch.no_grad():
+            model(return_loss=False, rescale=True, **data)
+
+        torch.cuda.synchronize()
+        elapsed = time.perf_counter() - start_time
+
+        if i >= num_warmup:
+            pure_inf_time += elapsed
+            if (i + 1) % args.log_interval == 0:
+                fps = (i + 1 - num_warmup) / pure_inf_time
+                print(f'Done image [{i + 1:<3}/ 200], fps: {fps:.1f} img / s')
+
+        if (i + 1) == 200:
+            pure_inf_time += elapsed
+            fps = (i + 1 - num_warmup) / pure_inf_time
+            print(f'Overall fps: {fps:.1f} img / s')
+            break
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
The original inference time includes the time of data loading, model forward and post-processing. For the models of instance segmentation, the post-processing time also includes the time of RLE encoding. This PR excludes the time of data loading and RLE encoding to compute the pure inference time.