### PR TITLE
Make FSAF loss more robust to no gt

### DIFF
--- a/mmdet/models/dense_heads/fsaf_head.py
+++ b/mmdet/models/dense_heads/fsaf_head.py
@@ -241,11 +241,12 @@ class FSAFHead(RetinaHead):
             min_levels=argmin)
         num_pos = torch.cat(pos_inds, 0).sum().float()
         acc = self.calculate_accuracy(cls_scores, labels_list, pos_inds)
+
+        if num_pos == 0:  # No gt
+            avg_factor = num_pos + float(num_total_neg)
+        else:
+            avg_factor = num_pos
         for i in range(len(losses_cls)):
-            if num_pos == 0:
-                avg_factor = num_pos + float(num_total_neg)
-            else:
-                avg_factor = num_pos
             losses_cls[i] /= avg_factor
             losses_bbox[i] /= avg_factor
         return dict(

--- a/mmdet/models/dense_heads/fsaf_head.py
+++ b/mmdet/models/dense_heads/fsaf_head.py
@@ -239,12 +239,15 @@ class FSAFHead(RetinaHead):
             labels_list,
             list(range(len(losses_cls))),
             min_levels=argmin)
-        # Clamp num_pos to 1e-3 to prevent 0/0
-        num_pos = torch.cat(pos_inds, 0).sum().float().clamp(min=1e-3)
+        num_pos = torch.cat(pos_inds, 0).sum().float()
         acc = self.calculate_accuracy(cls_scores, labels_list, pos_inds)
         for i in range(len(losses_cls)):
-            losses_cls[i] /= num_pos
-            losses_bbox[i] /= num_pos
+            if num_pos == 0:
+                avg_factor = num_pos + float(num_total_neg)
+            else:
+                avg_factor = num_pos
+            losses_cls[i] /= avg_factor
+            losses_bbox[i] /= avg_factor
         return dict(
             loss_cls=losses_cls,
             loss_bbox=losses_bbox,


### PR DESCRIPTION
Changed the default num_pos to num_neg when num_pos = 0. Otherwise, the loss would be very high when gt is absent in the batch. 