### PR TITLE
added missing cython to docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,5 +17,6 @@ RUN conda clean --all
 RUN git clone https://github.com/open-mmlab/mmdetection.git /mmdetection
 WORKDIR /mmdetection
 ENV FORCE_CUDA="1"
+RUN pip install cython --no-cache-dir
 RUN pip install "git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI"
 RUN pip install --no-cache-dir -e .


### PR DESCRIPTION
Without explicitly installing cython the image creation silently creates errors.

```
  gcc -pthread -B /opt/conda/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -I/opt/conda/lib/python3.7/site-packages/numpy/core/include -I../common -I/opt/conda/include/python3.7m -c pycocotools/_mask.c -o build/temp.linux-x86_64-3.7/pycocotools/_mask.o -Wno-cpp -Wno-unused-function -std=c99
  gcc: error: pycocotools/_mask.c: No such file or directory
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for pycocotools
  Running setup.py clean for pycocotools
Failed to build pycocotools
```

See also https://github.com/cocodataset/cocoapi/issues/172