### PR TITLE
Fix bug in nms cpu implementation

### DIFF
--- a/mmdet/ops/nms/src/cpu/nms_cpu.cpp
+++ b/mmdet/ops/nms/src/cpu/nms_cpu.cpp
@@ -39,8 +39,7 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
 
   for (int64_t _i = 0; _i < ndets; _i++) {
     auto i = order[_i];
-    if (suppressed[i] == 1)
-      continue;
+    if (suppressed[i] == 1) continue;
     keep[num_to_keep++] = i;
     auto ix1 = x1[i];
     auto iy1 = y1[i];
@@ -50,8 +49,7 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
 
     for (int64_t _j = _i + 1; _j < ndets; _j++) {
       auto j = order[_j];
-      if (suppressed[j] == 1)
-        continue;
+      if (suppressed[j] == 1) continue;
       auto xx1 = std::max(ix1, x1[j]);
       auto yy1 = std::max(iy1, y1[j]);
       auto xx2 = std::min(ix2, x2[j]);
@@ -61,8 +59,7 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
       auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
       auto inter = w * h;
       auto ovr = inter / (iarea + areas[j] - inter);
-      if (ovr > threshold)
-        suppressed[j] = 1;
+      if (ovr > threshold) suppressed[j] = 1;
     }
   }
   return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);

--- a/mmdet/ops/nms/src/cpu/nms_cpu.cpp
+++ b/mmdet/ops/nms/src/cpu/nms_cpu.cpp
@@ -23,10 +23,11 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
   auto order_t = std::get<1>(scores.sort(0, /* descending=*/true));
 
   auto ndets = dets.size(0);
-  at::Tensor suppressed_t =
-      at::zeros({ndets}, dets.options().dtype(at::kByte).device(at::kCPU));
+  at::Tensor suppressed_t = at::zeros({ndets}, dets.options().dtype(at::kByte));
+  at::Tensor keep_t = at::zeros({ndets}, dets.options().dtype(at::kLong));
 
   auto suppressed = suppressed_t.data_ptr<uint8_t>();
+  auto keep = keep_t.data_ptr<int64_t>();
   auto order = order_t.data_ptr<int64_t>();
   auto x1 = x1_t.data_ptr<scalar_t>();
   auto y1 = y1_t.data_ptr<scalar_t>();
@@ -34,9 +35,13 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
   auto y2 = y2_t.data_ptr<scalar_t>();
   auto areas = areas_t.data_ptr<scalar_t>();
 
+  int64_t num_to_keep = 0;
+
   for (int64_t _i = 0; _i < ndets; _i++) {
     auto i = order[_i];
-    if (suppressed[i] == 1) continue;
+    if (suppressed[i] == 1)
+      continue;
+    keep[num_to_keep++] = i;
     auto ix1 = x1[i];
     auto iy1 = y1[i];
     auto ix2 = x2[i];
@@ -45,7 +50,8 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
 
     for (int64_t _j = _i + 1; _j < ndets; _j++) {
       auto j = order[_j];
-      if (suppressed[j] == 1) continue;
+      if (suppressed[j] == 1)
+        continue;
       auto xx1 = std::max(ix1, x1[j]);
       auto yy1 = std::max(iy1, y1[j]);
       auto xx2 = std::min(ix2, x2[j]);
@@ -55,10 +61,11 @@ at::Tensor nms_cpu_kernel(const at::Tensor& dets, const float threshold) {
       auto h = std::max(static_cast<scalar_t>(0), yy2 - yy1);
       auto inter = w * h;
       auto ovr = inter / (iarea + areas[j] - inter);
-      if (ovr >= threshold) suppressed[j] = 1;
+      if (ovr > threshold)
+        suppressed[j] = 1;
     }
   }
-  return at::nonzero(suppressed_t == 0).squeeze(1);
+  return keep_t.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep);
 }
 
 at::Tensor nms_cpu(const at::Tensor& dets, const float threshold) {

--- a/tests/test_nms.py
+++ b/tests/test_nms.py
@@ -14,31 +14,37 @@ def test_nms_device_and_dtypes_cpu():
         xdoctest -m tests/test_nms.py test_nms_device_and_dtypes_cpu
     """
     iou_thr = 0.6
-    base_dets = np.array([[49.1, 32.4, 51.0, 35.9, 0.9],
-                          [49.3, 32.9, 51.0, 35.3, 0.9],
-                          [35.3, 11.5, 39.9, 14.5, 0.4],
+    base_dets = np.array([[49.1, 32.4, 51.0, 35.9, 0.1],
+                          [49.3, 32.9, 51.0, 35.3, 0.05],
+                          [35.3, 11.5, 39.9, 14.5, 0.9],
                           [35.2, 11.7, 39.7, 15.7, 0.3]])
 
+    base_expected_suppressed = np.array([[35.3, 11.5, 39.9, 14.5, 0.9],
+                                         [49.1, 32.4, 51.0, 35.9, 0.1]])
     # CPU can handle float32 and float64
     dets = base_dets.astype(np.float32)
-    supressed, inds = nms(dets, iou_thr)
-    assert dets.dtype == supressed.dtype
-    assert len(inds) == len(supressed) == 2
+    expected_suppressed = base_expected_suppressed.astype(np.float32)
+    suppressed, inds = nms(dets, iou_thr)
+    assert dets.dtype == suppressed.dtype
+    assert np.array_equal(suppressed, expected_suppressed)
 
     dets = torch.FloatTensor(base_dets)
-    surpressed, inds = nms(dets, iou_thr)
-    assert dets.dtype == surpressed.dtype
-    assert len(inds) == len(surpressed) == 2
+    expected_suppressed = torch.FloatTensor(base_expected_suppressed)
+    suppressed, inds = nms(dets, iou_thr)
+    assert dets.dtype == suppressed.dtype
+    assert torch.equal(suppressed, expected_suppressed)
 
     dets = base_dets.astype(np.float64)
-    supressed, inds = nms(dets, iou_thr)
-    assert dets.dtype == supressed.dtype
-    assert len(inds) == len(supressed) == 2
+    expected_suppressed = base_expected_suppressed.astype(np.float64)
+    suppressed, inds = nms(dets, iou_thr)
+    assert dets.dtype == suppressed.dtype
+    assert np.array_equal(suppressed, expected_suppressed)
 
     dets = torch.DoubleTensor(base_dets)
-    surpressed, inds = nms(dets, iou_thr)
-    assert dets.dtype == surpressed.dtype
-    assert len(inds) == len(surpressed) == 2
+    expected_suppressed = torch.DoubleTensor(base_expected_suppressed)
+    suppressed, inds = nms(dets, iou_thr)
+    assert dets.dtype == suppressed.dtype
+    assert torch.equal(suppressed, expected_suppressed)
 
 
 def test_nms_device_and_dtypes_gpu():
@@ -51,20 +57,27 @@ def test_nms_device_and_dtypes_gpu():
         pytest.skip('test requires GPU and torch+cuda')
 
     iou_thr = 0.6
-    base_dets = np.array([[49.1, 32.4, 51.0, 35.9, 0.9],
-                          [49.3, 32.9, 51.0, 35.3, 0.9],
-                          [35.3, 11.5, 39.9, 14.5, 0.4],
+
+    base_dets = np.array([[49.1, 32.4, 51.0, 35.9, 0.1],
+                          [49.3, 32.9, 51.0, 35.3, 0.05],
+                          [35.3, 11.5, 39.9, 14.5, 0.9],
                           [35.2, 11.7, 39.7, 15.7, 0.3]])
+
+    base_expected_suppressed = np.array([[35.3, 11.5, 39.9, 14.5, 0.9],
+                                         [49.1, 32.4, 51.0, 35.9, 0.1]])
 
     for device_id in range(torch.cuda.device_count()):
         print(f'Run NMS on device_id = {device_id!r}')
         # GPU can handle float32 but not float64
         dets = base_dets.astype(np.float32)
-        supressed, inds = nms(dets, iou_thr, device_id)
-        assert dets.dtype == supressed.dtype
-        assert len(inds) == len(supressed) == 2
+        expected_suppressed = base_expected_suppressed.astype(np.float32)
+        suppressed, inds = nms(dets, iou_thr, device_id)
+        assert dets.dtype == suppressed.dtype
+        assert np.array_equal(suppressed, expected_suppressed)
 
         dets = torch.FloatTensor(base_dets).to(device_id)
-        surpressed, inds = nms(dets, iou_thr)
-        assert dets.dtype == surpressed.dtype
-        assert len(inds) == len(surpressed) == 2
+        expected_suppressed = torch.FloatTensor(base_expected_suppressed).to(
+            device_id)
+        suppressed, inds = nms(dets, iou_thr)
+        assert dets.dtype == suppressed.dtype
+        assert torch.equal(suppressed, expected_suppressed)

--- a/tests/test_nms.py
+++ b/tests/test_nms.py
@@ -57,7 +57,6 @@ def test_nms_device_and_dtypes_gpu():
         pytest.skip('test requires GPU and torch+cuda')
 
     iou_thr = 0.6
-
     base_dets = np.array([[49.1, 32.4, 51.0, 35.9, 0.1],
                           [49.3, 32.9, 51.0, 35.3, 0.05],
                           [35.3, 11.5, 39.9, 14.5, 0.9],


### PR DESCRIPTION
The cpu implementation does not return the suppressed detection in order of confidence.
That means that when  `multiclass_nms` has a limit on `max_num` it will not necessarily keep the detections with the highest score.

I have changed the `nms_test`, and committed this first to show how the previous behaviour fails and version in this PR fixes this.