### PR TITLE
Support Img fields during transform

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -36,6 +36,7 @@ class LoadImageFromFile(object):
             mean=np.zeros(num_channels, dtype=np.float32),
             std=np.ones(num_channels, dtype=np.float32),
             to_rgb=False)
+        results['img_fields'] = ['img']
         return results
 
     def __repr__(self):

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -135,12 +135,13 @@ class Resize(object):
                     results[key], results['scale'], return_scale=True)
             results[key] = img
 
-        scale_factor = np.array([w_scale, h_scale, w_scale, h_scale],
-                                dtype=np.float32)
-        results['img_shape'] = img.shape
-        results['pad_shape'] = img.shape  # in case that there is no padding
-        results['scale_factor'] = scale_factor
-        results['keep_ratio'] = self.keep_ratio
+            scale_factor = np.array([w_scale, h_scale, w_scale, h_scale],
+                                    dtype=np.float32)
+            results['img_shape'] = img.shape
+            # in case that there is no padding
+            results['pad_shape'] = img.shape
+            results['scale_factor'] = scale_factor
+            results['keep_ratio'] = self.keep_ratio
 
     def _resize_bboxes(self, results):
         img_shape = results['img_shape']

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -120,21 +120,23 @@ class Resize(object):
         results['scale_idx'] = scale_idx
 
     def _resize_img(self, results):
-        if self.keep_ratio:
-            img, scale_factor = mmcv.imrescale(
-                results['img'], results['scale'], return_scale=True)
-            # the w_scale and h_scale has minor difference
-            # a real fix should be done in the mmcv.imrescale in the future
-            new_h, new_w = img.shape[:2]
-            h, w = results['img'].shape[:2]
-            w_scale = new_w / w
-            h_scale = new_h / h
-        else:
-            img, w_scale, h_scale = mmcv.imresize(
-                results['img'], results['scale'], return_scale=True)
+        for key in results.get('img_fields', []):
+            if self.keep_ratio:
+                img, scale_factor = mmcv.imrescale(
+                    results[key], results['scale'], return_scale=True)
+                # the w_scale and h_scale has minor difference
+                # a real fix should be done in the mmcv.imrescale in the future
+                new_h, new_w = img.shape[:2]
+                h, w = results[key].shape[:2]
+                w_scale = new_w / w
+                h_scale = new_h / h
+            else:
+                img, w_scale, h_scale = mmcv.imresize(
+                    results[key], results['scale'], return_scale=True)
+            results[key] = img
+
         scale_factor = np.array([w_scale, h_scale, w_scale, h_scale],
                                 dtype=np.float32)
-        results['img'] = img
         results['img_shape'] = img.shape
         results['pad_shape'] = img.shape  # in case that there is no padding
         results['scale_factor'] = scale_factor
@@ -233,8 +235,9 @@ class RandomFlip(object):
             results['flip_direction'] = self.direction
         if results['flip']:
             # flip image
-            results['img'] = mmcv.imflip(
-                results['img'], direction=results['flip_direction'])
+            for key in results.get('img_fields', []):
+                results[key] = mmcv.imflip(
+                    results[key], direction=results['flip_direction'])
             # flip bboxes
             for key in results.get('bbox_fields', []):
                 results[key] = self.bbox_flip(results[key],
@@ -276,12 +279,13 @@ class Pad(object):
         assert size is None or size_divisor is None
 
     def _pad_img(self, results):
-        if self.size is not None:
-            padded_img = mmcv.impad(results['img'], self.size, self.pad_val)
-        elif self.size_divisor is not None:
-            padded_img = mmcv.impad_to_multiple(
-                results['img'], self.size_divisor, pad_val=self.pad_val)
-        results['img'] = padded_img
+        for key in results.get('img_fields', []):
+            if self.size is not None:
+                padded_img = mmcv.impad(results[key], self.size, self.pad_val)
+            elif self.size_divisor is not None:
+                padded_img = mmcv.impad_to_multiple(
+                    results[key], self.size_divisor, pad_val=self.pad_val)
+            results[key] = padded_img
         results['pad_shape'] = padded_img.shape
         results['pad_fixed_size'] = self.size
         results['pad_size_divisor'] = self.size_divisor
@@ -327,8 +331,9 @@ class Normalize(object):
         self.to_rgb = to_rgb
 
     def __call__(self, results):
-        results['img'] = mmcv.imnormalize(results['img'], self.mean, self.std,
-                                          self.to_rgb)
+        for key in results.get('img_fields', []):
+            results[key] = mmcv.imnormalize(results[key], self.mean, self.std,
+                                            self.to_rgb)
         results['img_norm_cfg'] = dict(
             mean=self.mean, std=self.std, to_rgb=self.to_rgb)
         return results
@@ -352,18 +357,19 @@ class RandomCrop(object):
         self.crop_size = crop_size
 
     def __call__(self, results):
-        img = results['img']
-        margin_h = max(img.shape[0] - self.crop_size[0], 0)
-        margin_w = max(img.shape[1] - self.crop_size[1], 0)
-        offset_h = np.random.randint(0, margin_h + 1)
-        offset_w = np.random.randint(0, margin_w + 1)
-        crop_y1, crop_y2 = offset_h, offset_h + self.crop_size[0]
-        crop_x1, crop_x2 = offset_w, offset_w + self.crop_size[1]
+        for key in results.get('img_fields', []):
+            img = results[key]
+            margin_h = max(img.shape[0] - self.crop_size[0], 0)
+            margin_w = max(img.shape[1] - self.crop_size[1], 0)
+            offset_h = np.random.randint(0, margin_h + 1)
+            offset_w = np.random.randint(0, margin_w + 1)
+            crop_y1, crop_y2 = offset_h, offset_h + self.crop_size[0]
+            crop_x1, crop_x2 = offset_w, offset_w + self.crop_size[1]
 
-        # crop the image
-        img = img[crop_y1:crop_y2, crop_x1:crop_x2, ...]
-        img_shape = img.shape
-        results['img'] = img
+            # crop the image
+            img = img[crop_y1:crop_y2, crop_x1:crop_x2, ...]
+            img_shape = img.shape
+            results[key] = img
         results['img_shape'] = img_shape
 
         # crop bboxes accordingly and clip to the image boundary

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -149,6 +149,7 @@ def test_config_data_pipeline():
             gt_labels=np.array([1], dtype=np.int64),
             gt_masks=dummy_masks(img.shape[0], img.shape[1], mode=mode),
         )
+        results['img_fields'] = ['img']
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']
         output_results = train_pipeline(results)
@@ -164,6 +165,7 @@ def test_config_data_pipeline():
             gt_labels=np.array([1], dtype=np.int64),
             gt_masks=dummy_masks(img.shape[0], img.shape[1], mode=mode),
         )
+        results['img_fields'] = ['img']
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']
         output_results = test_pipeline(results)
@@ -182,6 +184,7 @@ def test_config_data_pipeline():
             gt_masks=dummy_masks(
                 img.shape[0], img.shape[1], num_obj=0, mode=mode),
         )
+        results['img_fields'] = ['img']
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']
         output_results = train_pipeline(results)
@@ -198,6 +201,7 @@ def test_config_data_pipeline():
             gt_masks=dummy_masks(
                 img.shape[0], img.shape[1], num_obj=0, mode=mode),
         )
+        results['img_fields'] = ['img']
         results['bbox_fields'] = ['gt_bboxes']
         results['mask_fields'] = ['gt_masks']
         output_results = test_pipeline(results)

--- a/tests/test_pipelines/test_transform.py
+++ b/tests/test_pipelines/test_transform.py
@@ -10,10 +10,12 @@ from mmdet.datasets.builder import PIPELINES
 
 
 def test_resize():
+    # test assertion if img_scale is a list
     with pytest.raises(AssertionError):
         transform = dict(type='Resize', img_scale=[1333, 800], keep_ratio=True)
         build_from_cfg(transform, PIPELINES)
 
+    # test assertion if len(img_scale) while ratio_range is not None
     with pytest.raises(AssertionError):
         transform = dict(
             type='Resize',
@@ -22,6 +24,7 @@ def test_resize():
             keep_ratio=True)
         build_from_cfg(transform, PIPELINES)
 
+    # test assertion for invalid multiscale_mode
     with pytest.raises(AssertionError):
         transform = dict(
             type='Resize',
@@ -61,10 +64,12 @@ def test_resize():
 
 
 def test_flip():
+    # test assertion for invalid flip_ratio
     with pytest.raises(AssertionError):
         transform = dict(type='RandomFlip', flip_ratio=1.5)
         build_from_cfg(transform, PIPELINES)
 
+    # test assertion for invalid direction
     with pytest.raises(AssertionError):
         transform = dict(
             type='RandomFlip', flip_ratio=1, direction='horizonta')
@@ -96,6 +101,7 @@ def test_flip():
 
 
 def test_pad():
+    # test assertion if both size_divisor and size is None
     with pytest.raises(AssertionError):
         transform = dict(type='Pad')
         build_from_cfg(transform, PIPELINES)

--- a/tests/test_pipelines/test_transform.py
+++ b/tests/test_pipelines/test_transform.py
@@ -1,0 +1,163 @@
+import copy
+import os.path as osp
+
+import mmcv
+import numpy as np
+import pytest
+from mmcv.utils import build_from_cfg
+
+from mmdet.datasets.builder import PIPELINES
+
+
+def test_resize():
+    with pytest.raises(AssertionError):
+        transform = dict(type='Resize', img_scale=[1333, 800], keep_ratio=True)
+        build_from_cfg(transform, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='Resize',
+            img_scale=[(1333, 800), (1333, 600)],
+            ratio_range=(0.9, 1.1),
+            keep_ratio=True)
+        build_from_cfg(transform, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='Resize',
+            img_scale=[(1333, 800), (1333, 600)],
+            keep_ratio=True,
+            multiscale_mode='2333')
+        build_from_cfg(transform, PIPELINES)
+
+    transform = dict(type='Resize', img_scale=(1333, 800), keep_ratio=True)
+    resize_module = build_from_cfg(transform, PIPELINES)
+
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = resize_module(results)
+    assert np.equal(results['img'], results['img2']).all()
+
+    results.pop('scale')
+    transform = dict(
+        type='Resize',
+        img_scale=(1280, 800),
+        multiscale_mode='value',
+        keep_ratio=False)
+    resize_module = build_from_cfg(transform, PIPELINES)
+    results = resize_module(results)
+    assert np.equal(results['img'], results['img2']).all()
+    assert results['img_shape'] == (800, 1280, 3)
+
+
+def test_flip():
+    with pytest.raises(AssertionError):
+        transform = dict(type='RandomFlip', flip_ratio=1.5)
+        build_from_cfg(transform, PIPELINES)
+
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='RandomFlip', flip_ratio=1, direction='horizonta')
+        build_from_cfg(transform, PIPELINES)
+
+    transform = dict(type='RandomFlip', flip_ratio=1)
+    flip_module = build_from_cfg(transform, PIPELINES)
+
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+    original_img = copy.deepcopy(img)
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = flip_module(results)
+    assert np.equal(results['img'], results['img2']).all()
+
+    flip_module = build_from_cfg(transform, PIPELINES)
+    results = flip_module(results)
+    assert np.equal(results['img'], results['img2']).all()
+    assert np.equal(original_img, results['img']).all()
+
+
+def test_pad():
+    with pytest.raises(AssertionError):
+        transform = dict(type='Pad')
+        build_from_cfg(transform, PIPELINES)
+
+    transform = dict(type='Pad', size_divisor=32)
+    transform = build_from_cfg(transform, PIPELINES)
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+    original_img = copy.deepcopy(img)
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = transform(results)
+    assert np.equal(results['img'], results['img2']).all()
+    # original img already divisible by 32
+    assert np.equal(results['img'], original_img).all()
+    img_shape = results['img'].shape
+    assert img_shape[0] % 32 == 0
+    assert img_shape[1] % 32 == 0
+
+    resize_transform = dict(
+        type='Resize', img_scale=(1333, 800), keep_ratio=True)
+    resize_module = build_from_cfg(resize_transform, PIPELINES)
+    results = resize_module(results)
+    results = transform(results)
+    img_shape = results['img'].shape
+    assert np.equal(results['img'], results['img2']).all()
+    assert img_shape[0] % 32 == 0
+    assert img_shape[1] % 32 == 0
+
+
+def test_normalize():
+    img_norm_cfg = dict(
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        to_rgb=True)
+    transform = dict(type='Normalize', **img_norm_cfg)
+    transform = build_from_cfg(transform, PIPELINES)
+    results = dict()
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../data/color.jpg'), 'color')
+    original_img = copy.deepcopy(img)
+    results['img'] = img
+    results['img2'] = copy.deepcopy(img)
+    results['img_shape'] = img.shape
+    results['ori_shape'] = img.shape
+    # Set initial values for default meta_keys
+    results['pad_shape'] = img.shape
+    results['scale_factor'] = 1.0
+    results['img_fields'] = ['img', 'img2']
+
+    results = transform(results)
+    assert np.equal(results['img'], results['img2']).all()
+
+    mean = np.array(img_norm_cfg['mean'])
+    std = np.array(img_norm_cfg['std'])
+    converted_img = (original_img[..., ::-1] - mean) / std
+    assert np.allclose(results['img'], converted_img)


### PR DESCRIPTION
This PR adds `img_fields` in loading during transform, which enables the similar transformation for multiple images.