### PR TITLE
Add procedure to remove compiled shared objects

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -77,6 +77,7 @@ It is recommended that you run step d each time you pull some updates from githu
     ```
     pip uninstall mmdet
     rm -rf ./build
+    find . -name "*.so" | xargs rm
     ```
 
 2. Following the above instructions, mmdetection is installed on `dev` mode, any local modifications made to the code will take effect without the need to reinstall it (unless you submit some commits and want to update the version number).


### PR DESCRIPTION
Since there are some shared objects in `mmdet` directory, we probably need to remove them to get a build that is the latest.