### PR TITLE
Fix base_channels of regnet

### DIFF
--- a/mmdet/models/backbones/regnet.py
+++ b/mmdet/models/backbones/regnet.py
@@ -81,7 +81,7 @@ class RegNet(ResNet):
     def __init__(self,
                  arch,
                  in_channels=3,
-                 base_channels=64,
+                 base_channels=32,
                  strides=(2, 2, 2, 2),
                  dilations=(1, 1, 1, 1),
                  out_indices=(0, 1, 2, 3),


### PR DESCRIPTION
Fix the bug of regnet configs, the `base_channels` of stem layer should be 32 rather than 64.
The wrong base_channels will create a different stem layer that does not match the checkpoints, which will degrade the performance.