### PR TITLE
Deprecate DistOptimizerHook

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -5,10 +5,10 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import DistSamplerSeedHook, Runner
+from mmcv.runner import DistSamplerSeedHook, OptimizerHook, Runner
 
-from mmdet.core import (DistEvalHook, DistOptimizerHook, EvalHook,
-                        Fp16OptimizerHook, build_optimizer)
+from mmdet.core import (DistEvalHook, EvalHook, Fp16OptimizerHook,
+                        build_optimizer)
 from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.utils import get_root_logger
 
@@ -148,7 +148,7 @@ def train_detector(model,
         optimizer_config = Fp16OptimizerHook(
             **cfg.optimizer_config, **fp16_cfg, distributed=distributed)
     elif distributed and 'type' not in cfg.optimizer_config:
-        optimizer_config = DistOptimizerHook(**cfg.optimizer_config)
+        optimizer_config = OptimizerHook(**cfg.optimizer_config)
     else:
         optimizer_config = cfg.optimizer_config
 

--- a/mmdet/core/utils/dist_utils.py
+++ b/mmdet/core/utils/dist_utils.py
@@ -42,15 +42,5 @@ def allreduce_grads(params, coalesce=True, bucket_size_mb=-1):
 
 
 class DistOptimizerHook(OptimizerHook):
-
-    def __init__(self, grad_clip=None, coalesce=True, bucket_size_mb=-1):
-        self.grad_clip = grad_clip
-        self.coalesce = coalesce
-        self.bucket_size_mb = bucket_size_mb
-
-    def after_train_iter(self, runner):
-        runner.optimizer.zero_grad()
-        runner.outputs['loss'].backward()
-        if self.grad_clip is not None:
-            self.clip_grads(runner.model.parameters())
-        runner.optimizer.step()
+    """Deprecated optimizer hook for distributed training"""
+    pass

--- a/mmdet/core/utils/dist_utils.py
+++ b/mmdet/core/utils/dist_utils.py
@@ -46,7 +46,6 @@ class DistOptimizerHook(OptimizerHook):
     """Deprecated optimizer hook for distributed training"""
 
     def __init__(self, *args, **kwargs):
-        warnings.warn(
-            '"DistOptimizerHook" is deprecated, please switch to'
-            '"mmcv.runner.OptimizerHook".', DeprecationWarning)
+        warnings.warn('"DistOptimizerHook" is deprecated, please switch to'
+                      '"mmcv.runner.OptimizerHook".')
         super().__init__(*args, **kwargs)

--- a/mmdet/core/utils/dist_utils.py
+++ b/mmdet/core/utils/dist_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 
 import torch.distributed as dist
@@ -43,4 +44,9 @@ def allreduce_grads(params, coalesce=True, bucket_size_mb=-1):
 
 class DistOptimizerHook(OptimizerHook):
     """Deprecated optimizer hook for distributed training"""
-    pass
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            '"DistOptimizerHook" is deprecated, please switch to'
+            '"mmcv.runner.OptimizerHook".', DeprecationWarning)
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
DistOptimizerHook is deprecated as its methods are all the same with its base class