### PR TITLE
Update utils.py

### DIFF
--- a/mmdet/core/anchor/utils.py
+++ b/mmdet/core/anchor/utils.py
@@ -30,7 +30,7 @@ def anchor_inside_flags(flat_anchors,
             (flat_anchors[:, 3] < img_h + allowed_border)
     else:
         inside_flags = valid_flags
-    return inside_flags
+    return inside_flags.to(torch.bool)
 
 
 def calc_region(bbox, ratio, featmap_size=None):


### PR DESCRIPTION
fix when I training with pytorch 1.5.0, I got list of warning. this commit fix 
```
/opt/conda/conda-bld/pytorch_1587428398394/work/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
/opt/conda/conda-bld/pytorch_1587428398394/work/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
/opt/conda/conda-bld/pytorch_1587428398394/work/aten/src/ATen/native/IndexingUtils.h:20: UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.
```