### PR TITLE
prevent possible bugs in loading and transforms caused by shallow copy

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -186,17 +186,17 @@ class LoadAnnotations(object):
 
     def _load_bboxes(self, results):
         ann_info = results['ann_info']
-        results['gt_bboxes'] = ann_info['bboxes']
+        results['gt_bboxes'] = ann_info['bboxes'].copy()
 
         gt_bboxes_ignore = ann_info.get('bboxes_ignore', None)
         if gt_bboxes_ignore is not None:
-            results['gt_bboxes_ignore'] = gt_bboxes_ignore
+            results['gt_bboxes_ignore'] = gt_bboxes_ignore.copy()
             results['bbox_fields'].append('gt_bboxes_ignore')
         results['bbox_fields'].append('gt_bboxes')
         return results
 
     def _load_labels(self, results):
-        results['gt_labels'] = results['ann_info']['labels']
+        results['gt_labels'] = results['ann_info']['labels'].copy()
         return results
 
     def _poly2mask(self, mask_ann, img_h, img_w):

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -603,7 +603,8 @@ class Expand(object):
         results['img'] = expand_img
         # expand bboxes
         for key in results.get('bbox_fields', []):
-            results[key] += np.tile((left, top), 2).astype(results[key].dtype)
+            results[key] = results[key] + np.tile(
+                (left, top), 2).astype(results[key].dtype)
 
         # expand masks
         for key in results.get('mask_fields', []):
@@ -713,7 +714,7 @@ class MinIoURandomCrop(object):
                     if not mask.any():
                         continue
                     for key in results.get('bbox_fields', []):
-                        boxes = results[key]
+                        boxes = results[key].copy()
                         mask = is_center_of_bboxes_in_patch(boxes, patch)
                         boxes = boxes[mask]
                         boxes[:, 2:] = boxes[:, 2:].clip(max=patch[2:])


### PR DESCRIPTION
1. Add numpy array.copy() in loading for both bboxes and labels. 
2. Add protection to avoid in-place modification of results in transforms.py