### PR TITLE
fix the nan loss bug in dirty data when training SSD

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -147,8 +147,6 @@ class Resize(object):
         img_shape = results['img_shape']
         for key in results.get('bbox_fields', []):
             bboxes = results[key] * results['scale_factor']
-            bboxes[:, 0::2] = np.clip(bboxes[:, 0::2], 0, img_shape[1])
-            bboxes[:, 1::2] = np.clip(bboxes[:, 1::2], 0, img_shape[0])
             results[key] = bboxes
 
     def _resize_masks(self, results):


### PR DESCRIPTION
First thank you for your nice work!
I meet the problem when I train SSD in some unclear data.
https://github.com/open-mmlab/mmdetection/blob/8bc0b9ce6d7d0656a8476ee8f31fa0441f8c4319/mmdet/datasets/pipelines/transforms.py#L150 when the data is all right, np.clip will have no effect
But when gt box is out of image area in few dirty data, 
np.clip will lead to x1=x2 or y1=y2. then 
https://github.com/open-mmlab/mmdetection/blob/8bc0b9ce6d7d0656a8476ee8f31fa0441f8c4319/mmdet/core/bbox/coder/delta_xywh_bbox_coder.py#L78 will be zero and 
https://github.com/open-mmlab/mmdetection/blob/8bc0b9ce6d7d0656a8476ee8f31fa0441f8c4319/mmdet/core/bbox/coder/delta_xywh_bbox_coder.py#L83 will be nan, cause the L1 smooth loss be NAN.
@ZwwWayne 

Signed-off-by: wangxionghui.kk <wangxionghui.kk@bytedance.com>