### PR TITLE
fix anchor target label

### DIFF
--- a/mmdet/models/dense_heads/anchor_head.py
+++ b/mmdet/models/dense_heads/anchor_head.py
@@ -232,8 +232,10 @@ class AnchorHead(nn.Module):
         if unmap_outputs:
             num_total_anchors = flat_anchors.size(0)
             labels = unmap(
-                labels, num_total_anchors, inside_flags,
-                fill=self.num_classes)  # fill bg label
+                labels,
+                num_total_anchors,
+                inside_flags,
+                fill=self.background_label)  # fill bg label
             label_weights = unmap(label_weights, num_total_anchors,
                                   inside_flags)
             bbox_targets = unmap(bbox_targets, num_total_anchors, inside_flags)


### PR DESCRIPTION
If I am not wrong, it would be a bug when RPN is using (``background_label = 0``), leading to all samples are positive.
Not sure that RPN in model zoo is benchmarked with this bug or not.