### PR TITLE
fix a bug of pisa loss, when some images in one batch images have no gts.

### DIFF
--- a/mmdet/models/losses/pisa_loss.py
+++ b/mmdet/models/losses/pisa_loss.py
@@ -50,7 +50,8 @@ def isr_p(cls_score,
     for i in range(len(sampling_results)):
         gt_i = sampling_results[i].pos_assigned_gt_inds
         gts.append(gt_i + last_max_gt)
-        last_max_gt = gt_i.max() + 1
+        if len(gt_i) != 0:
+            last_max_gt = gt_i.max() + 1
     gts = torch.cat(gts)
     assert len(gts) == num_pos
 


### PR DESCRIPTION
If some images in one batch images have no gts, there might be a bug in line 53 of pisa loss (can not perform `gt_i.max()` ). This PR has already been discussed with yuhang.