### PR TITLE
Fixed nan loss by filtering out-of-frame gt_bboxes in coco.py

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -113,12 +113,9 @@ class CocoDataset(CustomDataset):
             if ann.get('ignore', False):
                 continue
             x1, y1, w, h = ann['bbox']
-            x2 = x1 + w
-            y2 = y1 + h
-            if ((x1 < 0 or x1 >= img_info['width'] or y1 < 0
-                 or y1 >= img_info['height'])
-                    and (x2 < 0 or x2 >= img_info['width'] or y2 < 0
-                         or y2 >= img_info['height'])):
+            inter_w = max(0, min(x1 + w, img_info['width']) - max(x1, 0))
+            inter_h = max(0, min(y1 + h, img_info['height']) - max(y1, 0))
+            if inter_w * inter_h == 0:
                 continue
             if ann['area'] <= 0 or w < 1 or h < 1:
                 continue

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -115,11 +115,11 @@ class CocoDataset(CustomDataset):
             x1, y1, w, h = ann['bbox']
             x2 = x1 + w
             y2 = y1 + h
-            if ((x1 < 0 or x1 >= img_info['width'] or 
+            if ((x1 < 0 or x1 >= img_info['width'] or
                  y1 < 0 or y1 >= img_info['height']) and
-                (x2 < 0 or x2 >= img_info['width'] or 
-                 y2 < 0 or y2 >= img_info['height'])): 
-                continue 
+                (x2 < 0 or x2 >= img_info['width'] or
+                 y2 < 0 or y2 >= img_info['height'])):
+                continue
             if ann['area'] <= 0 or w < 1 or h < 1:
                 continue
             if ann['category_id'] not in self.cat_ids:

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -109,11 +109,18 @@ class CocoDataset(CustomDataset):
         gt_labels = []
         gt_bboxes_ignore = []
         gt_masks_ann = []
-
+        
+        is_out_of_frame = lambda x, y: (
+            x < 0 or x >= img_info['width'] or 
+            y < 0 or y >= img_info['height']
+        )
         for i, ann in enumerate(ann_info):
             if ann.get('ignore', False):
                 continue
             x1, y1, w, h = ann['bbox']
+            
+            if is_out_of_frame(x1, y1) and is_out_of_frame(x1+w, y1+h):
+                continue 
             if ann['area'] <= 0 or w < 1 or h < 1:
                 continue
             if ann['category_id'] not in self.cat_ids:

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -115,10 +115,10 @@ class CocoDataset(CustomDataset):
             x1, y1, w, h = ann['bbox']
             x2 = x1 + w
             y2 = y1 + h
-            if ((x1 < 0 or x1 >= img_info['width'] or
-                 y1 < 0 or y1 >= img_info['height']) and
-                (x2 < 0 or x2 >= img_info['width'] or
-                 y2 < 0 or y2 >= img_info['height'])):
+            if ((x1 < 0 or x1 >= img_info['width'] or y1 < 0
+                 or y1 >= img_info['height'])
+                    and (x2 < 0 or x2 >= img_info['width'] or y2 < 0
+                         or y2 >= img_info['height'])):
                 continue
             if ann['area'] <= 0 or w < 1 or h < 1:
                 continue

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -109,17 +109,16 @@ class CocoDataset(CustomDataset):
         gt_labels = []
         gt_bboxes_ignore = []
         gt_masks_ann = []
-        
-        is_out_of_frame = lambda x, y: (
-            x < 0 or x >= img_info['width'] or 
-            y < 0 or y >= img_info['height']
-        )
         for i, ann in enumerate(ann_info):
             if ann.get('ignore', False):
                 continue
             x1, y1, w, h = ann['bbox']
-            
-            if is_out_of_frame(x1, y1) and is_out_of_frame(x1+w, y1+h):
+            x2 = x1 + w
+            y2 = y1 + h
+            if ((x1 < 0 or x1 >= img_info['width'] or 
+                 y1 < 0 or y1 >= img_info['height']) and
+                (x2 < 0 or x2 >= img_info['width'] or 
+                 y2 < 0 or y2 >= img_info['height'])): 
                 continue 
             if ann['area'] <= 0 or w < 1 or h < 1:
                 continue


### PR DESCRIPTION
There may exist out-of-frame annotations in custom datasets. These abnormal annotations will cause nan loss. For example, such cases exist in the object365 datasets, and I found both Libra RCNN and Cascade RCNN diverged due to nan loss. After filtering these abnormal cases, these detectors converged. Even though this should be avoided by dataset annotators, it can be more robust of mmdetection to filter out-of-frame annotations.