### PR TITLE
Use img_metas to indicate batch

### DIFF
--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -57,7 +57,7 @@ def single_gpu_test(model,
             result = bbox_results, encoded_mask_results
         results.append(result)
 
-        batch_size = data['img'][0].size(0)
+        batch_size = len(data['img_metas'][0].data)
         for _ in range(batch_size):
             prog_bar.update()
     return results
@@ -100,9 +100,7 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
         results.append(result)
 
         if rank == 0:
-            batch_size = (
-                len(data['img_meta']._data)
-                if 'img_meta' in data else data['img'][0].size(0))
+            batch_size = len(data['img_metas'][0].data)
             for _ in range(batch_size * world_size):
                 prog_bar.update()
 


### PR DESCRIPTION
This PR fixes a legacy issue of `img_metas` in apis/test.py. Since `img_meta` has bee deprecated and `img_metas` always exists, use `img_metas` to indicate the batch size is a more stable and general manner.

The PR has been tested on mask rcnn models, which could produce similar results.