### PR TITLE
fix rpn softmax bug

### DIFF
--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -76,10 +76,10 @@ class RPNHead(RPNTestMixin, AnchorHead):
                 scores = rpn_cls_score.sigmoid()
             else:
                 rpn_cls_score = rpn_cls_score.reshape(-1, 2)
-                # remind that we set FG labels to [0, num_class-1]
-                # since mmdet v2.0
-                # BG cat_id: num_class
-                scores = rpn_cls_score.softmax(dim=1)[:, :-1]
+                # we set FG labels to [0, num_class-1] and BG label to
+                # num_class in other heads since mmdet v2.0, However we
+                # keep BG label as 0 and FG label as 1 in rpn head
+                scores = rpn_cls_score.softmax(dim=1)[:, 1]
             rpn_bbox_pred = rpn_bbox_pred.permute(1, 2, 0).reshape(-1, 4)
             anchors = mlvl_anchors[idx]
             if cfg.nms_pre > 0 and scores.shape[0] > cfg.nms_pre:


### PR DESCRIPTION
When use softmax in rpn head，the original implementation has two problems，
https://github.com/open-mmlab/mmdetection/blob/bf9638a7c78f45948c4b812c4e206b4b65841f02/mmdet/models/dense_heads/rpn_head.py#L82
[:,:-1] will keep dimension and this line
https://github.com/open-mmlab/mmdetection/blob/bf9638a7c78f45948c4b812c4e206b4b65841f02/mmdet/models/dense_heads/rpn_head.py#L88
would sort final dimension.
Beside it, we can find we still use fg label as 1 in rpn head
https://github.com/open-mmlab/mmdetection/blob/bf9638a7c78f45948c4b812c4e206b4b65841f02/mmdet/models/dense_heads/anchor_head.py#L221