### PR TITLE
Fix a bug in tools/publish_model.py

### DIFF
--- a/tools/publish_model.py
+++ b/tools/publish_model.py
@@ -22,7 +22,9 @@ def process_checkpoint(in_file, out_file):
     # add the code here.
     torch.save(checkpoint, out_file)
     sha = subprocess.check_output(['sha256sum', out_file]).decode()
-    final_file = out_file.rstrip('.pth') + f'-{sha[:8]}.pth'
+    if out_file.endswith('.pth'):
+        out_file = out_file[:-4]
+    final_file = out_file + f'-{sha[:8]}.pth'
     subprocess.Popen(['mv', out_file, final_file])
 
 


### PR DESCRIPTION
`rstrip('.pth')` removes all characters in {'.', 'p', 't', 'h'} at the right. For example, if `out_file="imagenet.pth"`, then `out_file.rstrip('.pth')` is `"imagene"` where "t" is also removed.