### PR TITLE
Fix coco loader empty images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,6 @@ venv.bak/
 .mypy_cache/
 
 mmdet/version.py
-data/
 .vscode
 .idea
 .DS_Store

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -81,10 +81,11 @@ class CocoDataset(CustomDataset):
             ids (list[int]): integer list of img ids
         """
 
-        ids = set()
-        for i, class_id in enumerate(self.cat_ids):
-            ids |= set(self.coco.cat_img_map[class_id])
-        self.img_ids = list(ids)
+        if self.filter_empty_gt:
+            ids = set()
+            for i, class_id in enumerate(self.cat_ids):
+                ids |= set(self.coco.cat_img_map[class_id])
+            self.img_ids = list(ids)
 
         data_infos = []
         for i in self.img_ids:

--- a/tests/data/coco_sample.json
+++ b/tests/data/coco_sample.json
@@ -1,0 +1,77 @@
+{
+    "images": [
+        {
+            "file_name": "fake1.jpg",
+            "height": 800,
+            "width": 800,
+            "id": 0
+        },
+        {
+            "file_name": "fake2.jpg",
+            "height": 800,
+            "width": 800,
+            "id": 1
+        },
+        {
+            "file_name": "fake3.jpg",
+            "height": 800,
+            "width": 800,
+            "id": 2
+        }
+    ],
+    "annotations": [
+        {
+            "bbox": [
+                0,
+                0,
+                20,
+                20
+            ],
+            "area": 400.00,
+            "score": 1.0,
+            "category_id": 1,
+            "id": 1,
+            "image_id": 0
+        },
+        {
+            "bbox": [
+                0,
+                0,
+                20,
+                20
+            ],
+            "area": 400.00,
+            "score": 1.0,
+            "category_id": 2,
+            "id": 2,
+            "image_id": 0
+        },
+        {
+            "bbox": [
+                0,
+                0,
+                20,
+                20
+            ],
+            "area": 400.00,
+            "score": 1.0,
+            "category_id": 1,
+            "id": 3,
+            "image_id": 1
+        }
+    ],
+    "categories": [
+        {
+            "id": 1,
+            "name": "bus",
+            "supercategory": "none"
+        },
+        {
+            "id": 2,
+            "name": "car",
+            "supercategory": "none"
+        }
+    ],
+    "licenses": [],
+    "info": null
+}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -155,3 +155,27 @@ def test_dataset_wrapper():
     for idx in np.random.randint(0, len(repeat_factor_dataset), 3):
         assert repeat_factor_dataset[idx] == bisect.bisect_right(
             repeat_factors_cumsum, idx)
+
+
+@pytest.mark.parametrize('classes, expected_length', [(['bus'], 2),
+                                                      (['car'], 1),
+                                                      (['bus', 'car'], 2)])
+def test_allow_empty_images(classes, expected_length):
+    dataset_class = DATASETS.get('CocoDataset')
+
+    filtered_dataset = dataset_class(
+        ann_file='tests/data/coco_sample.json',
+        img_prefix='tests/data',
+        pipeline=[],
+        classes=classes,
+        filter_empty_gt=True)
+
+    full_dataset = dataset_class(
+        ann_file='tests/data/coco_sample.json',
+        img_prefix='tests/data',
+        pipeline=[],
+        classes=classes,
+        filter_empty_gt=False)
+
+    assert len(filtered_dataset) == expected_length
+    assert len(full_dataset) == 3

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -162,14 +162,14 @@ def test_dataset_wrapper():
                                                       (['bus', 'car'], 2)])
 def test_allow_empty_images(classes, expected_length):
     dataset_class = DATASETS.get('CocoDataset')
-
+    # Filter empty images
     filtered_dataset = dataset_class(
         ann_file='tests/data/coco_sample.json',
         img_prefix='tests/data',
         pipeline=[],
         classes=classes,
         filter_empty_gt=True)
-
+    # Get all
     full_dataset = dataset_class(
         ann_file='tests/data/coco_sample.json',
         img_prefix='tests/data',


### PR DESCRIPTION
This PR is related with https://github.com/open-mmlab/mmdetection/issues/3023 I followed @Shallowte idea and added a regression test. So when `filter_empty_gt` is `False` all images will be loaded independently of their annotations.
I am not sure if this is the best approach (it might be more efficient to filter images [here](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/coco.py#L40) instead ), just let me know how this could be improved
