### PR TITLE
Add allow_negative_crop in RandomCrop

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -469,8 +469,8 @@ class RandomCrop(object):
 
     Args:
         crop_size (tuple): Expected size after cropping, (h, w).
-        allow_negative_crop (bool): Whether to allow a crop whose center is not
-            located in any bbox. Default to False.
+        allow_negative_crop (bool): Whether to allow a crop that does not
+            contain any bbox area. Default to False.
 
     Notes:
         - If the image is smaller than the crop size, return the original image
@@ -533,7 +533,7 @@ class RandomCrop(object):
             bboxes[:, 1::2] = np.clip(bboxes[:, 1::2], 0, img_shape[0])
             valid_inds = (bboxes[:, 2] > bboxes[:, 0]) & (
                 bboxes[:, 3] > bboxes[:, 1])
-            # If the crop center is not located in any gt-bboxes and
+            # If the crop does not contain any gt-bbox area and
             # self.allow_negative_crop is False, skip this image.
             if (key == 'gt_bboxes' and not valid_inds.any()
                     and not self.allow_negative_crop):

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -478,8 +478,8 @@ class RandomCrop(object):
           `gt_bboxes` corresponds to `gt_labels` and `gt_masks`, and
           `gt_bboxes_ignore` corresponds to `gt_labels_ignore` and
           `gt_masks_ignore`.
-        - If the crop is not located in any bbox and `allow_negative_crop` is
-          set to False, skip this image.
+        - If the crop does not contain any gt-bbox region and
+          `allow_negative_crop` is set to False, skip this image.
     """
 
     def __init__(self, crop_size, allow_negative_crop=False):

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -469,6 +469,8 @@ class RandomCrop(object):
 
     Args:
         crop_size (tuple): Expected size after cropping, (h, w).
+        allow_negative_crop (bool): Whether to allow a crop whose center is not
+            located in any bbox. Default to False.
 
     Notes:
         - If the image is smaller than the crop size, return the original image
@@ -476,13 +478,14 @@ class RandomCrop(object):
           `gt_bboxes` corresponds to `gt_labels` and `gt_masks`, and
           `gt_bboxes_ignore` corresponds to `gt_labels_ignore` and
           `gt_masks_ignore`.
-        - If there are gt bboxes in an image and the cropping area does not
-          have intersection with any gt bbox, this image is skipped.
+        - If the crop is not located in any bbox and `allow_negative_crop` is
+          set to False, skip this image.
     """
 
-    def __init__(self, crop_size):
+    def __init__(self, crop_size, allow_negative_crop=False):
         assert crop_size[0] > 0 and crop_size[1] > 0
         self.crop_size = crop_size
+        self.allow_negative_crop = allow_negative_crop
         # The key correspondence from bboxes to labels and masks.
         self.bbox2label = {
             'gt_bboxes': 'gt_labels',
@@ -520,7 +523,6 @@ class RandomCrop(object):
             results[key] = img
         results['img_shape'] = img_shape
 
-        valid_flag = False
         # crop bboxes accordingly and clip to the image boundary
         for key in results.get('bbox_fields', []):
             # e.g. gt_bboxes and gt_bboxes_ignore
@@ -531,10 +533,11 @@ class RandomCrop(object):
             bboxes[:, 1::2] = np.clip(bboxes[:, 1::2], 0, img_shape[0])
             valid_inds = (bboxes[:, 2] > bboxes[:, 0]) & (
                 bboxes[:, 3] > bboxes[:, 1])
-            # When there is no gt bbox, cropping is conducted.
-            # When the crop is valid, cropping is conducted.
-            if len(valid_inds) == 0 or valid_inds.any():
-                valid_flag = True
+            # If the crop center is not located in any gt-bboxes and
+            # self.allow_negative_crop is False, skip this image.
+            if (key == 'gt_bboxes' and not valid_inds.any()
+                    and not self.allow_negative_crop):
+                return None
             results[key] = bboxes[valid_inds, :]
             # label fields. e.g. gt_labels and gt_labels_ignore
             label_key = self.bbox2label.get(key)
@@ -547,11 +550,6 @@ class RandomCrop(object):
                 results[mask_key] = results[mask_key][
                     valid_inds.nonzero()[0]].crop(
                         np.asarray([crop_x1, crop_y1, crop_x2, crop_y2]))
-
-        # if no gt bbox remains after cropping, just skip this image
-        # TODO: check whether we can keep the image regardless of the crop.
-        if 'bbox_fields' in results and not valid_flag:
-            return None
 
         # crop semantic seg
         for key in results.get('seg_fields', []):


### PR DESCRIPTION
1. Add allow_negative_crop in RandomCrop
2. Resolve a TODO: check whether we can keep the image regardless of the crop.
3. Find out the reason of a sudden boost of nas-fpn performance using the RandomCrop in #2810. In #2810, the allow_negative_crop was implicitly set to True when there is `gt_bboxes_ignore` flag and `gt_bboxes_ignore` is an empty tensor. 
I will keep `gt_bboxes_ignore=False` in this version and provide the performance with  `gt_bboxes_ignore=True` in the nas-fpn README. 

### Conclusion after re-running the experiments
The performance is very close for coco dataset with `gt_bbox_ignore=True` or `gt_bbox_ignore=False`. Both of these are higher than that reported in the model zoo

| | before #2810  | #2810   | `gt_bbox_ignore=True`   |  `gt_bbox_ignore=False` | 
|---|---|---|---|---|
| retinanet_fpn_crop640  | 37.4  | 37.9  | 37.8  | 37.9  |
| retinanet_nas_fpn_crop640  | 40.2  | 40.5  | 40.6  | 40.7  |