### PR TITLE
fix bug in MultiScaleFlipAug

### DIFF
--- a/mmdet/datasets/pipelines/test_time_aug.py
+++ b/mmdet/datasets/pipelines/test_time_aug.py
@@ -92,16 +92,18 @@ class MultiScaleFlipAug(object):
         """
 
         aug_data = []
-        flip_aug = [False, True] if self.flip else [False]
+        flip_args = [[False, None]]
+        if self.flip:
+            flip_args += [[True, direction]
+                          for direction in self.flip_direction]
         for scale in self.img_scale:
-            for flip in flip_aug:
-                for direction in self.flip_direction:
-                    _results = results.copy()
-                    _results[self.scale_key] = scale
-                    _results['flip'] = flip
-                    _results['flip_direction'] = direction
-                    data = self.transforms(_results)
-                    aug_data.append(data)
+            for flip, direction in flip_args:
+                _results = results.copy()
+                _results[self.scale_key] = scale
+                _results['flip'] = flip
+                _results['flip_direction'] = direction
+                data = self.transforms(_results)
+                aug_data.append(data)
         # list of dict to dict of list
         aug_data_dict = {key: [] for key in aug_data[0]}
         for data in aug_data:

--- a/mmdet/datasets/pipelines/test_time_aug.py
+++ b/mmdet/datasets/pipelines/test_time_aug.py
@@ -92,9 +92,9 @@ class MultiScaleFlipAug(object):
         """
 
         aug_data = []
-        flip_args = [[False, None]]
+        flip_args = [(False, None)]
         if self.flip:
-            flip_args += [[True, direction]
+            flip_args += [(True, direction)
                           for direction in self.flip_direction]
         for scale in self.img_scale:
             for flip, direction in flip_args:

--- a/tests/test_data/test_models_aug_test.py
+++ b/tests/test_data/test_models_aug_test.py
@@ -40,6 +40,31 @@ def model_aug_test_template(cfg_file):
     return aug_result
 
 
+def test_aug_test_size():
+    results = dict(
+        img_prefix=osp.join(osp.dirname(__file__), '../data'),
+        img_info=dict(filename='color.jpg'))
+
+    # Define simple pipeline
+    load = dict(type='LoadImageFromFile')
+    load = build_from_cfg(load, PIPELINES)
+
+    # get config
+    transform = dict(
+        type='MultiScaleFlipAug',
+        transforms=[],
+        img_scale=[(1333, 800), (800, 600), (640, 480)],
+        flip=True,
+        flip_direction=['horizontal', 'vertical'])
+    multi_aug_test_module = build_from_cfg(transform, PIPELINES)
+
+    results = load(results)
+    results = multi_aug_test_module(load(results))
+    # len(["original", "horizontal", "vertical"]) *
+    # len([(1333, 800), (800, 600), (640, 480)])
+    assert len(results['img']) == 9
+
+
 def test_cascade_rcnn_aug_test():
     aug_result = model_aug_test_template(
         'configs/cascade_rcnn/cascade_rcnn_r50_fpn_1x_coco.py')


### PR DESCRIPTION
The original class `MultiScaleFlipAug` adds samples without flip augmentations several times when we use `flip_direction=['horizontal', 'vertical']`. This MR fixes this bug and adds test.

For example, if we use the next config:
```python
transform = dict(
        type='MultiScaleFlipAug',
        transforms=<transforms>,
        img_scale=[(1333, 800), (800, 600), (640, 480)],
        flip=True,
        flip_direction=['horizontal', 'vertical'])
``` 
The original `MultiScaleFlipAug` returns results with length = `len([(1333, 800), (800, 600), (640, 480)]) * len(['horizontal', 'vertical']) * len(['True', 'False']) = 12`.
The fixed `MultiScaleFlipAug` returns results with length = `len([(1333, 800), (800, 600), (640, 480)]) * len(['original', 'horizontal', 'vertical']) = 9`.