### PR TITLE
Fix topk bug in ATSSAssigner

### DIFF
--- a/mmdet/core/bbox/assigners/atss_assigner.py
+++ b/mmdet/core/bbox/assigners/atss_assigner.py
@@ -119,8 +119,9 @@ class ATSSAssigner(BaseAssigner):
             # select k bbox whose center are closest to the gt center
             end_idx = start_idx + bboxes_per_level
             distances_per_level = distances[start_idx:end_idx, :]
+            selectable_k = min(self.topk, bboxes_per_level)
             _, topk_idxs_per_level = distances_per_level.topk(
-                self.topk, dim=0, largest=False)
+                selectable_k, dim=0, largest=False)
             candidate_idxs.append(topk_idxs_per_level + start_idx)
             start_idx = end_idx
         candidate_idxs = torch.cat(candidate_idxs, dim=0)


### PR DESCRIPTION
If `self.topk` is larger than `bboxes_per_level`, `distances_per_level.topk()` causes the error below.
```
  File "/home/shinya/work/mmdetection/mmdet/core/bbox/assigners/atss_assigner.py", line 123, in assign
    self.topk, dim=0, largest=False)
RuntimeError: invalid argument 5: k not in range for dimension at /opt/conda/conda-bld/pytorch_1587428398394/work/aten/src/THC/generic/THCTensorTopK.cu:23
```

I encountered this error when I trained a model on COCO by multi-scale training (`img_scale=[(1333, 480), (1333, 960)]`).
This error can be reproduced by training on small inputs like `img_scale=(1333, 128)`.