### PR TITLE
HRNet keypoints head (Facial landmarks)

### DIFF
--- a/configs/_base_/datasets/wflw.py
+++ b/configs/_base_/datasets/wflw.py
@@ -1,0 +1,64 @@
+dataset_type = 'WflwDataset'
+data_root = '/mnt/data-home/sebastien/data/public/WFLW/'
+
+img_scale = (384, 384)
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='FocusOnFace', out_size=384),
+    dict(type='LoadAnnotations', with_bbox=True, with_keypoint=True),
+    dict(type='Resize', img_scale=img_scale, keep_ratio=False),
+    dict(type='PhotoMetricDistortion'),
+    dict(type='Corrupt', corruption='gaussian_noise'),
+    dict(type='Corrupt', corruption='jpeg_compression'),
+    dict(type='RandomFlip', flip_ratio=0.),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='Pad', size_divisor=32),
+    dict(type='KeypointsToHeatmaps', sigma=3),
+    dict(type='DefaultFormatBundle'),
+    dict(
+        type='Collect',
+        keys=['img', 'gt_bboxes', 'gt_labels', 'gt_keypoints', 'heatmaps']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(type='FocusOnFace', out_size=384),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=img_scale,
+        flip=False,
+        transforms=[
+            dict(type='Resize', img_scale=img_scale, keep_ratio=False),
+            dict(type='RandomFlip', flip_ratio=0.),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=32),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img', 'proposals']),
+        ])
+]
+data = dict(
+    samples_per_gpu=10,
+    workers_per_gpu=20,
+    train=dict(
+        type=dataset_type,
+        ann_file=data_root +
+        'WFLW_annotations/list_98pt_rect_attr_train_test/' +
+        'list_98pt_rect_attr_train.txt',
+        img_prefix=data_root + 'WFLW_images/',
+        pipeline=train_pipeline),
+    val=dict(
+        type=dataset_type,
+        ann_file=data_root +
+        'WFLW_annotations/list_98pt_rect_attr_train_test/' +
+        'list_98pt_rect_attr_test.txt',
+        img_prefix=data_root + 'WFLW_images/',
+        pipeline=test_pipeline),
+    test=dict(
+        type=dataset_type,
+        ann_file=data_root +
+        'WFLW_annotations/list_98pt_rect_attr_train_test/' +
+        'list_98pt_rect_attr_test.txt',
+        img_prefix=data_root + 'WFLW_images/',
+        pipeline=test_pipeline))
+evaluation = dict(interval=1, metric='keypoint', kpts_thr=0.1)

--- a/configs/keypoints/faster_rcnn_hrnetv2p_w32_1x.py
+++ b/configs/keypoints/faster_rcnn_hrnetv2p_w32_1x.py
@@ -1,0 +1,59 @@
+_base_ = [
+    '../_base_/models/faster_rcnn_r50_fpn.py', '../_base_/datasets/wflw.py',
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+]
+
+model = dict(
+    pretrained='open-mmlab://msra/hrnetv2_w32',
+    backbone=dict(
+        _delete_=True,
+        type='HRNet',
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256)))),
+    neck=dict(
+        _delete_=True,
+        type='HRFPN',
+        in_channels=[32, 64, 128, 256],
+        out_channels=256),
+    rpn_head=None,
+    roi_head=dict(
+        _delete_=True,
+        type='KeypointRoIHead',
+        output_heatmaps=False,
+        keypoint_head=dict(
+            type='HRNetKeypointHead',
+            num_convs=8,
+            in_channels=256,
+            features_size=[256, 256, 256, 256],
+            conv_out_channels=512,
+            num_keypoints=98,
+            loss_keypoint=dict(type='MSELoss', loss_weight=50.0)),
+        keypoint_decoder=dict(type='HeatmapDecodeOneKeypoint', upscale=4)))
+test_cfg = dict(rcnn=dict(score_thr=-1))
+
+optimizer = dict(lr=0.002)
+lr_config = dict(step=[40, 55])
+total_epochs = 60

--- a/configs/keypoints/faster_rcnn_hrnetv2p_w32_1x_noneck.py
+++ b/configs/keypoints/faster_rcnn_hrnetv2p_w32_1x_noneck.py
@@ -1,0 +1,55 @@
+_base_ = [
+    '../_base_/models/faster_rcnn_r50_fpn.py', '../_base_/datasets/wflw.py',
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+]
+
+model = dict(
+    pretrained='open-mmlab://msra/hrnetv2_w32',
+    backbone=dict(
+        _delete_=True,
+        type='HRNet',
+        extra=dict(
+            stage1=dict(
+                num_modules=1,
+                num_branches=1,
+                block='BOTTLENECK',
+                num_blocks=(4, ),
+                num_channels=(64, )),
+            stage2=dict(
+                num_modules=1,
+                num_branches=2,
+                block='BASIC',
+                num_blocks=(4, 4),
+                num_channels=(32, 64)),
+            stage3=dict(
+                num_modules=4,
+                num_branches=3,
+                block='BASIC',
+                num_blocks=(4, 4, 4),
+                num_channels=(32, 64, 128)),
+            stage4=dict(
+                num_modules=3,
+                num_branches=4,
+                block='BASIC',
+                num_blocks=(4, 4, 4, 4),
+                num_channels=(32, 64, 128, 256)))),
+    neck=None,
+    rpn_head=None,
+    roi_head=dict(
+        _delete_=True,
+        type='KeypointRoIHead',
+        output_heatmaps=False,
+        keypoint_head=dict(
+            type='HRNetKeypointHead',
+            num_convs=8,
+            in_channels=256,
+            features_size=(32, 64, 128, 256),
+            conv_out_channels=512,
+            num_keypoints=98,
+            loss_keypoint=dict(type='MSELoss', loss_weight=50.0)),
+        keypoint_decoder=dict(type='HeatmapDecodeOneKeypoint', upscale=4)))
+test_cfg = dict(rcnn=dict(score_thr=-1))
+
+optimizer = dict(lr=0.002)
+lr_config = dict(step=[40, 55])
+total_epochs = 60

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import time
 
+import cv2
 import mmcv
 import torch
 import torch.distributed as dist
@@ -31,7 +32,7 @@ def single_gpu_test(model,
             imgs = tensor2imgs(img_tensor, **img_metas[0]['img_norm_cfg'])
             assert len(imgs) == len(img_metas)
 
-            for img, img_meta in zip(imgs, img_metas):
+            for idx, (img, img_meta) in enumerate(zip(imgs, img_metas)):
                 h, w, _ = img_meta['img_shape']
                 img_show = img[:h, :w, :]
 
@@ -43,6 +44,16 @@ def single_gpu_test(model,
                 else:
                     out_file = None
 
+                # Draw keypoints
+                if isinstance(result, dict) and (result.get('keypoints', None)
+                                                 is not None):
+                    kpts = result.get('keypoints')
+                    for pt in kpts[idx]:
+                        x, y = int(pt[0]), int(pt[1])
+                        img_show = cv2.circle(img_show, (x, y), 2, (0, 255, 0),
+                                              -1)
+
+                result = result['bbox'] if isinstance(result, dict) else result
                 model.module.show_result(
                     img_show,
                     result,

--- a/mmdet/core/__init__.py
+++ b/mmdet/core/__init__.py
@@ -2,6 +2,7 @@ from .anchor import *  # noqa: F401, F403
 from .bbox import *  # noqa: F401, F403
 from .evaluation import *  # noqa: F401, F403
 from .fp16 import *  # noqa: F401, F403
+from .keypoint import *  # noqa: F401, F403
 from .mask import *  # noqa: F401, F403
 from .post_processing import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403

--- a/mmdet/core/keypoint/__init__.py
+++ b/mmdet/core/keypoint/__init__.py
@@ -1,0 +1,3 @@
+from .keypoint_target import compute_nme
+
+__all__ = ['compute_nme']

--- a/mmdet/core/keypoint/keypoint_target.py
+++ b/mmdet/core/keypoint/keypoint_target.py
@@ -1,0 +1,29 @@
+import numpy as np
+import torch
+
+
+def compute_nme(preds, target, normalize=False):
+
+    if isinstance(preds, torch.Tensor):
+        preds = preds.cpu().numpy()
+    is_visible = target[:, :, 2] == 2
+    preds = preds[:, :, :2]
+    target = target[:, :, :2]
+
+    N = preds.shape[0]
+    L = preds.shape[1]
+    rmse = np.zeros(N)
+
+    for i in range(N):
+        pts_pred, pts_gt, v = preds[i, ], target[i, ], is_visible[i, ]
+        _rmse = [
+            np.linalg.norm(pred - gt)
+            for (pred, gt, _v) in zip(pts_pred, pts_gt, v) if (_v)
+        ]
+        rmse[i] = np.sum(_rmse) / max(1, len(_rmse))
+        if normalize:
+            assert L == 98, 'Unknown interocular distance'
+            if L == 98:  # WFLW dataset
+                interocular = np.linalg.norm(pts_gt[60, ] - pts_gt[72, ])
+            rmse[i] /= interocular
+    return rmse

--- a/mmdet/datasets/__init__.py
+++ b/mmdet/datasets/__init__.py
@@ -8,6 +8,7 @@ from .deepfashion import DeepFashionDataset
 from .lvis import LVISDataset
 from .samplers import DistributedGroupSampler, DistributedSampler, GroupSampler
 from .voc import VOCDataset
+from .wflw import WflwDataset
 from .wider_face import WIDERFaceDataset
 from .xml_style import XMLDataset
 
@@ -16,5 +17,5 @@ __all__ = [
     'VOCDataset', 'CityscapesDataset', 'LVISDataset', 'GroupSampler',
     'DistributedGroupSampler', 'DistributedSampler', 'build_dataloader',
     'ConcatDataset', 'RepeatDataset', 'ClassBalancedDataset',
-    'WIDERFaceDataset', 'DATASETS', 'PIPELINES', 'build_dataset'
+    'WIDERFaceDataset', 'DATASETS', 'PIPELINES', 'build_dataset', 'WflwDataset'
 ]

--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -142,6 +142,7 @@ class CustomDataset(Dataset):
         results['seg_prefix'] = self.seg_prefix
         results['proposal_file'] = self.proposal_file
         results['bbox_fields'] = []
+        results['keypoint_fields'] = []
         results['mask_fields'] = []
         results['seg_fields'] = []
 

--- a/mmdet/datasets/pipelines/__init__.py
+++ b/mmdet/datasets/pipelines/__init__.py
@@ -1,7 +1,7 @@
 from .auto_augment import AutoAugment
 from .compose import Compose
-from .formating import (Collect, ImageToTensor, ToDataContainer, ToTensor,
-                        Transpose, to_tensor)
+from .formating import (Collect, ImageToTensor, KeypointsToHeatmaps,
+                        ToDataContainer, ToTensor, Transpose, to_tensor)
 from .instaboost import InstaBoost
 from .loading import (LoadAnnotations, LoadImageFromFile,
                       LoadMultiChannelImageFromFiles, LoadProposals)
@@ -16,5 +16,5 @@ __all__ = [
     'LoadMultiChannelImageFromFiles', 'LoadProposals', 'MultiScaleFlipAug',
     'Resize', 'RandomFlip', 'Pad', 'RandomCrop', 'Normalize', 'SegRescale',
     'MinIoURandomCrop', 'Expand', 'PhotoMetricDistortion', 'Albu',
-    'InstaBoost', 'RandomCenterCropPad', 'AutoAugment'
+    'InstaBoost', 'RandomCenterCropPad', 'AutoAugment', 'KeypointsToHeatmaps'
 ]

--- a/mmdet/datasets/wflw.py
+++ b/mmdet/datasets/wflw.py
@@ -1,0 +1,190 @@
+# ------------------------------------------------------------------------------
+# Copyright (c) Microsoft
+# Licensed under the MIT License.
+# Created by Sebastien Martin(sebastienmartin@linkernetworks.com)
+# ------------------------------------------------------------------------------
+
+import copy
+import os
+from collections.abc import Sequence
+
+import numpy as np
+import pandas as pd
+
+from ..core.keypoint import compute_nme
+from .builder import DATASETS, PIPELINES
+from .custom import CustomDataset
+
+
+@PIPELINES.register_module()
+class FocusOnFace(object):
+    """After loading image, we only want a sub part of that said image."""
+
+    def __init__(self, out_size=384):
+        """[summary]
+
+        Args:
+            out_size (int, optional): Specifies the input size of focused
+            before pre-processing (i.e. before resizing). Defaults to 384.
+        """
+        if not isinstance(out_size, Sequence):
+            out_size = [out_size, out_size]
+        self.out_size = np.array(out_size)
+
+    def __call__(self, results):
+        img_info = copy.deepcopy(results['img_info'])
+        ann = img_info['ann']
+        # Shift annotations
+        # NOTE: Assumes only one bbox or keypoints set per image (same
+        # as in original HRNet code)
+        bbox = ann['bboxes'][0]
+        pts = ann['keypoints'][0]
+        shift = ((bbox[2:] + bbox[:2]) / 2 - (self.out_size / 2)).astype(
+            np.int)
+        shift[shift < 0] = 0  # Already on the left border
+        shifted_pts = pts[:, :2] - shift
+        invisible = np.logical_or(
+            np.any(shifted_pts[:, :2] < 0, axis=1),
+            np.logical_or(shifted_pts[:, 0] > self.out_size[0],
+                          shifted_pts[:, 1] > self.out_size[1]))
+        shifted_pts = np.hstack(
+            (shifted_pts, pts[:, 2].reshape(-1, 1)))  # Add visibility
+        if np.any(invisible):
+            shifted_pts[:,
+                        2][invisible] = np.fmin(shifted_pts[:, 2][invisible],
+                                                0)
+        im_pts = np.zeros((1, shifted_pts.shape[0], 3), dtype=np.float32)
+        im_pts[0, :, :] = shifted_pts
+        h, w = bbox[3] - bbox[1], bbox[2] - bbox[0]
+        new_box = bbox - np.tile(shift, 2)
+        bboxes = np.array(new_box, dtype=np.float32).reshape((-1, 4))  # bbox
+        img_info.update({'width': w, 'height': h, 'shift': shift})
+        ann.update({
+            'bboxes': bboxes,
+            'keypoints': im_pts,
+            'n_kpts': im_pts.shape[1]
+        })
+        results['img_info'] = img_info
+        results['ann_info'] = ann
+        # Extract image ROI
+        if 'img' in results:
+            img = results['img']
+            results['img'] = img[shift[1]:shift[1] + self.out_size[1],
+                                 shift[0]:shift[0] + self.out_size[0], :]
+            results['img_shape'] = results['img'].shape
+            results['ori_shape'] = results['img'].shape
+            # Set initial values for default meta_keys
+            results['pad_shape'] = results['img'].shape
+        results['scale'] = tuple(self.out_size)
+        return results
+
+    def __repr__(self):
+        repr_str = (f'{self.__class__.__name__}()')
+        return repr_str
+
+
+@DATASETS.register_module()
+class WflwDataset(CustomDataset):
+
+    def __init__(self, **kwargs):
+        super(WflwDataset, self).__init__(**kwargs)
+        # specify annotation file for dataset
+        self.is_train = not self.test_mode
+        if self.test_mode:
+            # Faster RCNN complains otherwise
+            self.proposals = [0 for i in range(len(self))]
+        self.mean = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+        self.std = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+
+    def load_annotations(self, ann_file):
+        # Need width, height, keypoints, filename, imageID,
+        # Keypoints are represented as an N*K*3 array, for N persons, and K
+        # keypoints per person
+        # For each keypoint, we record X and Y position, as well as visibility
+        # flag (see COCO dataset)
+        anns = pd.read_csv(ann_file, sep=' ', header=None)
+        out_anns = []
+        n_kpts = 98
+        for idx in range(anns.shape[0]):
+            bboxes = np.zeros((1, 4), dtype=np.float32)
+            labels = np.zeros((1), dtype=np.int64)
+            pts = anns.iloc[idx, :(n_kpts * 2)].values
+            bbox = anns.iloc[idx, 196:200].values.astype('float32').reshape(4)
+            pts = pts.astype('float32').reshape(n_kpts, 2)
+
+            bboxes[0, :] = bbox
+            im_pts = np.ones((1, pts.shape[0], 3), dtype=np.float32) * 2
+            im_pts[0, :, :2] = pts
+            im_name = anns.iloc[idx, -1]
+            im_name = os.path.join(self.img_prefix, im_name)
+            w, h = 50, 50  # Just make it > 32 so it won't be discarded later,
+            # need to focus on face later
+            ann = {
+                'width': w,
+                'height': h,
+                'filename': im_name,
+                'image_id': idx,
+                'ann': {
+                    'bboxes': bboxes,
+                    'keypoints': im_pts,
+                    'labels': labels,
+                    'n_kpts': im_pts.shape[1]
+                }
+            }
+            out_anns.append(ann)
+        return out_anns
+
+    def evaluate(self,
+                 results,
+                 metric='mAP',
+                 logger=None,
+                 proposal_nums=(100, 300, 1000),
+                 iou_thr=0.5,
+                 kpts_thr=0.1,
+                 scale_ranges=None):
+        """Evaluate the dataset.
+
+        Args:
+            results (list): Testing results of the dataset.
+            metric (str | list[str]): Metrics to be evaluated.
+            logger (logging.Logger | None | str): Logger used for printing
+                related information during evaluation. Default: None.
+            proposal_nums (Sequence[int]): Proposal number used for evaluating
+                recalls, such as recall@100, recall@1000.
+                Default: (100, 300, 1000).
+            iou_thr (float | list[float]): IoU threshold. It must be a float
+                when evaluating mAP, and can be a list when evaluating recall.
+                Default: 0.5.
+            kpts_thr (float): Keypoints confidence threshold
+            scale_ranges (list[tuple] | None): Scale ranges for evaluating mAP.
+                Default: None.
+        """
+        if not isinstance(metric, str):
+            assert len(metric) == 1
+            metric = metric[0]
+        if metric not in ('keypoint', ):
+            res_bboxes = [
+                res[0] if isinstance(res, tuple) else res for res in results
+            ]
+            eval_results = super().evaluate(res_bboxes, metric, logger,
+                                            proposal_nums, iou_thr,
+                                            scale_ranges)
+        else:
+            # Evaluate keypoints
+            res_kpts = [res['keypoints'] for res in results]
+            data_infos = [self.data_infos[i] for i in range(len(self))]
+            nme_count = 0
+            nme_batch_sum = 0
+            for res_kpt, gt in zip(res_kpts, data_infos):
+                gt = FocusOnFace()({'img_info': gt})['img_info']
+                pred = res_kpt
+                gt_keypoints = gt['ann']['keypoints']
+                nme_batch = compute_nme(pred, gt_keypoints, normalize=True)
+                nme_batch_sum = nme_batch_sum + np.sum(nme_batch)
+                nme_count = nme_count + pred.shape[0]
+            eval_results = {'keypoints': nme_batch_sum / nme_count}
+        return eval_results
+
+
+if __name__ == '__main__':
+    pass

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -108,6 +108,7 @@ class TwoStageDetector(BaseDetector):
                       gt_bboxes,
                       gt_labels,
                       gt_bboxes_ignore=None,
+                      gt_keypoints=None,
                       gt_masks=None,
                       proposals=None,
                       **kwargs):
@@ -160,7 +161,8 @@ class TwoStageDetector(BaseDetector):
 
         roi_losses = self.roi_head.forward_train(x, img_metas, proposal_list,
                                                  gt_bboxes, gt_labels,
-                                                 gt_bboxes_ignore, gt_masks,
+                                                 gt_bboxes_ignore,
+                                                 gt_keypoints, gt_masks,
                                                  **kwargs)
         losses.update(roi_losses)
 
@@ -172,7 +174,7 @@ class TwoStageDetector(BaseDetector):
                                 proposals=None,
                                 rescale=False):
         """Async test without augmentation."""
-        assert self.with_bbox, 'Bbox head must be implemented.'
+        # assert self.with_bbox, 'Bbox head must be implemented.'
         x = self.extract_feat(img)
 
         if proposals is None:
@@ -186,7 +188,7 @@ class TwoStageDetector(BaseDetector):
 
     def simple_test(self, img, img_metas, proposals=None, rescale=False):
         """Test without augmentation."""
-        assert self.with_bbox, 'Bbox head must be implemented.'
+        # assert self.with_bbox, 'Bbox head must be implemented.'
 
         x = self.extract_feat(img)
 

--- a/mmdet/models/roi_heads/__init__.py
+++ b/mmdet/models/roi_heads/__init__.py
@@ -6,6 +6,8 @@ from .double_roi_head import DoubleHeadRoIHead
 from .dynamic_roi_head import DynamicRoIHead
 from .grid_roi_head import GridRoIHead
 from .htc_roi_head import HybridTaskCascadeRoIHead
+from .keypoint_heads import HRNetKeypointHead
+from .keypoint_roi_head import KeypointRoIHead
 from .mask_heads import (CoarseMaskHead, FCNMaskHead, FusedSemanticHead,
                          GridHead, HTCMaskHead, MaskIoUHead, MaskPointHead)
 from .mask_scoring_roi_head import MaskScoringRoIHead
@@ -20,5 +22,6 @@ __all__ = [
     'ConvFCBBoxHead', 'Shared2FCBBoxHead', 'Shared4Conv1FCBBoxHead',
     'DoubleConvFCBBoxHead', 'FCNMaskHead', 'HTCMaskHead', 'FusedSemanticHead',
     'GridHead', 'MaskIoUHead', 'SingleRoIExtractor', 'PISARoIHead',
-    'PointRendRoIHead', 'MaskPointHead', 'CoarseMaskHead', 'DynamicRoIHead'
+    'PointRendRoIHead', 'MaskPointHead', 'CoarseMaskHead', 'DynamicRoIHead',
+    'HRNetKeypointHead', 'KeypointRoIHead'
 ]

--- a/mmdet/models/roi_heads/base_roi_head.py
+++ b/mmdet/models/roi_heads/base_roi_head.py
@@ -11,6 +11,8 @@ class BaseRoIHead(nn.Module, metaclass=ABCMeta):
     def __init__(self,
                  bbox_roi_extractor=None,
                  bbox_head=None,
+                 keypoint_roi_extractor=None,
+                 keypoint_head=None,
                  mask_roi_extractor=None,
                  mask_head=None,
                  shared_head=None,
@@ -25,6 +27,9 @@ class BaseRoIHead(nn.Module, metaclass=ABCMeta):
         if bbox_head is not None:
             self.init_bbox_head(bbox_roi_extractor, bbox_head)
 
+        if keypoint_head is not None:
+            self.init_keypoint_head(keypoint_roi_extractor, keypoint_head)
+
         if mask_head is not None:
             self.init_mask_head(mask_roi_extractor, mask_head)
 
@@ -34,6 +39,11 @@ class BaseRoIHead(nn.Module, metaclass=ABCMeta):
     def with_bbox(self):
         """bool: whether the RoI head contains a `bbox_head`"""
         return hasattr(self, 'bbox_head') and self.bbox_head is not None
+
+    @property
+    def with_keypoint(self):
+        return hasattr(self,
+                       'keypoint_head') and self.keypoint_head is not None
 
     @property
     def with_mask(self):
@@ -60,6 +70,12 @@ class BaseRoIHead(nn.Module, metaclass=ABCMeta):
         """Initialize ``bbox_head``"""
         pass
 
+    # TODO: Restore after it has been overwritten in every single head
+    # The `abstractmethod` make it crash if not implemented in child obj
+    # @abstractmethod
+    # def init_keypoint_head(self):
+    #     pass
+
     @abstractmethod
     def init_mask_head(self):
         """Initialize ``mask_head``"""
@@ -78,6 +94,7 @@ class BaseRoIHead(nn.Module, metaclass=ABCMeta):
                       gt_bboxes,
                       gt_labels,
                       gt_bboxes_ignore=None,
+                      gt_keypoints=None,
                       gt_masks=None,
                       **kwargs):
         """Forward function during training."""

--- a/mmdet/models/roi_heads/cascade_roi_head.py
+++ b/mmdet/models/roi_heads/cascade_roi_head.py
@@ -207,7 +207,9 @@ class CascadeRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
                       gt_bboxes,
                       gt_labels,
                       gt_bboxes_ignore=None,
-                      gt_masks=None):
+                      gt_keypoints=None,
+                      gt_masks=None,
+                      heatmaps=None):
         """
         Args:
             x (list[Tensor]): list of multi-level img features.
@@ -228,6 +230,8 @@ class CascadeRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         Returns:
             dict[str, Tensor]: a dictionary of loss components
         """
+        if gt_keypoints or heatmaps:
+            raise NotImplementedError
         losses = dict()
         for i in range(self.num_stages):
             self.current_stage = i

--- a/mmdet/models/roi_heads/keypoint_heads/__init__.py
+++ b/mmdet/models/roi_heads/keypoint_heads/__init__.py
@@ -1,0 +1,4 @@
+from .hrnet_keypoint_head import HRNetKeypointHead
+from .max_heatmap_decoder import HeatmapDecodeOneKeypoint
+
+__all__ = ['HRNetKeypointHead', 'HeatmapDecodeOneKeypoint']

--- a/mmdet/models/roi_heads/keypoint_heads/hrnet_keypoint_head.py
+++ b/mmdet/models/roi_heads/keypoint_heads/hrnet_keypoint_head.py
@@ -1,0 +1,113 @@
+import torch
+import torch.nn as nn
+from mmcv.cnn import build_upsample_layer
+from torch.nn import functional as fn
+
+from mmdet.core import auto_fp16, force_fp32
+from mmdet.models.builder import HEADS, build_loss
+
+
+@HEADS.register_module()
+class HRNetKeypointHead(nn.Module):
+
+    def __init__(self,
+                 num_convs=8,
+                 features_size=[],
+                 in_channels=256,
+                 conv_kernel_size=3,
+                 conv_out_channels=256,
+                 num_keypoints=17,
+                 upsample_cfg=dict(type='deconv', scale_factor=2),
+                 up_scale=2,
+                 conv_cfg=None,
+                 norm_cfg=None,
+                 loss_keypoint=dict(type='MSELoss', loss_weight=1.0)):
+        super(HRNetKeypointHead, self).__init__()
+        self.upsample_cfg = upsample_cfg.copy()
+        if self.upsample_cfg['type'] not in [
+                None, 'deconv', 'nearest', 'bilinear', 'carafe'
+        ]:
+            raise ValueError(
+                'Invalid upsample method {}, accepted methods '
+                'are "deconv", "nearest", "bilinear", "carafe"'.format(
+                    self.upsample_cfg['type']))
+        self.num_convs = num_convs
+        self.features_size = features_size
+        self.in_channels = in_channels
+        self.conv_kernel_size = conv_kernel_size
+        self.conv_out_channels = conv_out_channels
+        self.upsample_method = self.upsample_cfg.get('type')
+        self.scale_factor = self.upsample_cfg.pop('scale_factor')
+
+        self.num_keypoints = num_keypoints
+        self.fp16_enabled = False
+        self.loss_keypoint = build_loss(loss_keypoint)
+
+        final_conv_kernel = 1
+        self.up_scale = up_scale
+        bn_momentum = 0.02
+        final_inp_channels = sum(self.features_size)
+
+        self.conv = nn.Sequential(
+            nn.Conv2d(
+                in_channels=final_inp_channels,
+                out_channels=final_inp_channels,
+                kernel_size=1,
+                stride=1,
+                padding=1 if final_conv_kernel == 3 else 0),
+            nn.BatchNorm2d(final_inp_channels, momentum=bn_momentum),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(
+                in_channels=final_inp_channels,
+                out_channels=self.num_keypoints,
+                kernel_size=final_conv_kernel,
+                stride=1,
+                padding=1 if final_conv_kernel == 3 else 0))
+
+        upsample_in_channels = (
+            self.conv_out_channels if self.num_convs > 0 else in_channels)
+        upsample_cfg_ = self.upsample_cfg.copy()
+        upsample_cfg_.update(
+            in_channels=upsample_in_channels,
+            out_channels=num_keypoints,
+            kernel_size=self.scale_factor * 2,
+            stride=self.scale_factor,
+            padding=1)
+        self.upsample = build_upsample_layer(upsample_cfg_)
+
+    def init_weights(self):
+        for m in [self.upsample]:
+            if m is None:
+                continue
+            else:
+                nn.init.kaiming_normal_(
+                    m.weight, mode='fan_out', nonlinearity='relu')
+                nn.init.constant_(m.bias, 0)
+
+    @auto_fp16()
+    def forward(self, x):
+        """HR-Net keypoints head, upsampling and convolution.
+
+        Args:
+            x ([type]): [description]
+
+        Returns:
+            [type]: [description]
+        """
+        height, width = x[0].size(2), x[0].size(3)
+
+        x = torch.cat([
+            fn.interpolate(
+                x[i],
+                size=(height, width),
+                mode='bilinear',
+                align_corners=False) for i in range(4)
+        ], 1)
+
+        x = self.conv(x)
+        return x
+
+    @force_fp32(apply_to=('keypoint_pred', 'heatmap_targets'))
+    def loss(self, heatmap_pred, heatmap_targets, valids):
+        loss = self.loss_keypoint(heatmap_pred, heatmap_targets)
+        return {'loss_keypoints': loss}

--- a/mmdet/models/roi_heads/keypoint_heads/max_heatmap_decoder.py
+++ b/mmdet/models/roi_heads/keypoint_heads/max_heatmap_decoder.py
@@ -1,0 +1,88 @@
+import math
+from collections.abc import Sequence
+
+import torch
+
+from mmdet.models.builder import HEADS
+
+
+@HEADS.register_module()
+class HeatmapDecodeOneKeypoint():
+    """Decodes a heatmap to return a keypoint Only consider the highest
+    intensity value, does not handle a 2 keypoints case."""
+
+    def __init__(self, upscale=4, score_th=-1):
+        if not isinstance(upscale, Sequence):
+            upscale = [upscale]
+        if len(upscale) == 1:
+            upscale = [upscale[0], upscale[0]]
+        self.upscale = torch.tensor(upscale)
+        self.score_th = score_th
+
+    def init_weights(self):
+        pass
+
+    def __call__(self, x):
+        return self.forward(x)
+
+    def forward(self, x):
+        return self._decode_heatmap(x)
+
+    def _decode_heatmap(self, output):
+        coords = self._get_preds(output)  # float type
+        coords = coords.cpu()
+        confs = torch.zeros_like(coords[:, :, 0])
+        res = output.size()[2:]
+        # post-processing
+        for n in range(coords.size(0)):
+            for p in range(coords.size(1)):
+                hm = output[n][p]
+                px = int(math.floor(coords[n][p][0]))
+                py = int(math.floor(coords[n][p][1]))
+                if (px >= 0) and (px < res[1]) and (py >= 0) and (py < res[0]):
+                    px_m, px_p = max(0, px - 1), min(res[0] - 1, px + 1)
+                    py_m, py_p = max(0, py - 1), min(res[1] - 1, py + 1)
+                    diff = torch.Tensor([
+                        hm[py][px_p] - hm[py][px_m],
+                        hm[py_p][px] - hm[py_m][px]
+                    ])
+                    coords[n][p] += (diff * self.upscale).abs().ceil(
+                    ) * diff.sign() / self.upscale
+                    confs[n][p] = hm[py, px]
+                    for c in range(2):
+                        coords[n, p, c] = torch.clamp(coords[n, p, c], 0,
+                                                      res[c])
+        preds = coords.clone()
+
+        # Transform back
+        for i in range(coords.size(0)):
+            preds[i] = self._transform_preds(coords[i])
+
+        if preds.dim() < 3:
+            preds = preds.view(1, preds.size())
+
+        low_conf = confs < self.score_th
+        confs[low_conf] = 0.
+        confs_shape = (n + 1, p + 1, 1)
+        low_conf = low_conf.reshape(confs_shape).repeat(1, 1, 2)
+        preds[low_conf] = -1
+        preds = torch.cat((preds, confs.reshape(confs_shape)), axis=2)
+        return preds
+
+    def _get_preds(self, scores, min_conf=0):
+        """get predictions from score maps in torch Tensor."""
+        assert scores.dim() == 4, 'Score maps should be 4-dim'
+        maxval, idx = torch.max(
+            scores.view(scores.size(0), scores.size(1), -1), 2)
+        maxval = maxval.view(scores.size(0), scores.size(1), 1)
+        idx = idx.view(scores.size(0), scores.size(1), 1) + 1
+        preds = idx.repeat(1, 1, 2).float()
+        preds[:, :, 0] = (preds[:, :, 0] - 1) % scores.size(3)
+        preds[:, :, 1] = torch.floor((preds[:, :, 1] - 1) / scores.size(3))
+        pred_mask = maxval.gt(min_conf).repeat(1, 1, 2).float()
+        preds *= pred_mask
+        return preds
+
+    def _transform_preds(self, coords):
+        coords[:, 0:2] = coords[:, 0:2] * self.upscale
+        return coords

--- a/mmdet/models/roi_heads/keypoint_roi_head.py
+++ b/mmdet/models/roi_heads/keypoint_roi_head.py
@@ -1,0 +1,322 @@
+import numpy as np
+import torch
+
+from mmdet.core import bbox2result
+from ..builder import HEADS, build_head
+from .standard_roi_head import StandardRoIHead
+
+
+@HEADS.register_module()
+class KeypointRoIHead(StandardRoIHead):
+    """Simplest base roi head including one bbox head and one mask head."""
+
+    def __init__(self, output_heatmaps=False, keypoint_decoder=None, **kwargs):
+        super().__init__(**kwargs)
+        self.output_heatmaps = output_heatmaps
+        if keypoint_decoder:
+            self.keypoint_decoder = build_head(keypoint_decoder)
+        else:
+            assert output_heatmaps is True
+            self.keypoint_decoder = None
+
+    def init_keypoint_head(self, keypoint_roi_extractor, keypoint_head):
+        self.share_roi_extractor = False
+        # if keypoint_roi_extractor is not None:
+        #     self.keypoint_roi_extractor = build_roi_extractor(
+        # keypoint_roi_extractor)
+        #     self.share_roi_extractor = False
+        # else:
+        #     self.share_roi_extractor = True
+        #     self.keypoint_roi_extractor = self.bbox_roi_extractor
+        self.keypoint_head = build_head(keypoint_head)
+
+    def init_weights(self, pretrained):
+        super().init_weights(pretrained)
+        if self.with_keypoint and self.keypoint_head:
+            self.keypoint_head.init_weights()
+
+    def forward_dummy(self, x, proposals):
+        outs = super().forward_dummy(x, proposals)
+        # keypoints head
+        if self.with_keypoint:
+            pass
+
+        return outs
+
+    def forward_train(self,
+                      x,
+                      img_metas,
+                      proposal_list,
+                      gt_bboxes,
+                      gt_labels,
+                      gt_bboxes_ignore=None,
+                      gt_keypoints=None,
+                      gt_masks=None,
+                      heatmaps=None):
+        """
+        Args:
+            x (list[Tensor]): list of multi-level img features.
+
+            img_metas (list[dict]): list of image info dict where each dict
+                has: 'img_shape', 'scale_factor', 'flip', and may also contain
+                'filename', 'ori_shape', 'pad_shape', and 'img_norm_cfg'.
+                For details on the values of these keys see
+                `mmdet/datasets/pipelines/formatting.py:Collect`.
+
+            proposals (list[Tensors]): list of region proposals.
+
+            gt_bboxes (list[Tensor]): each item are the truth boxes for each
+                image in [tl_x, tl_y, br_x, br_y] format.
+
+            gt_labels (list[Tensor]): class indices corresponding to each box
+
+            gt_bboxes_ignore (None | list[Tensor]): specify which bounding
+                boxes can be ignored when computing the loss.
+
+            gt_masks (None | Tensor) : true segmentation masks for each box
+                used if the architecture supports a segmentation task.
+
+        Returns:
+            dict[str, Tensor]: a dictionary of loss components
+        """
+        # assign gts and sample proposals
+        sampling_results = []
+        bbox_results = {'bbox_feats': []}
+        if self.with_bbox or self.with_mask:
+            num_imgs = len(img_metas)
+            if gt_bboxes_ignore is None:
+                gt_bboxes_ignore = [None for _ in range(num_imgs)]
+            for i in range(num_imgs):
+                assign_result = self.bbox_assigner.assign(
+                    proposal_list[i], gt_bboxes[i], gt_bboxes_ignore[i],
+                    gt_labels[i])
+                sampling_result = self.bbox_sampler.sample(
+                    assign_result,
+                    proposal_list[i],
+                    gt_bboxes[i],
+                    gt_labels[i],
+                    feats=[lvl_feat[i][None] for lvl_feat in x])
+                sampling_results.append(sampling_result)
+
+        losses = dict()
+        # bbox head forward and loss
+        if self.with_bbox:
+            bbox_results = self._bbox_forward_train(x, sampling_results,
+                                                    gt_bboxes, gt_labels,
+                                                    img_metas)
+            losses.update(bbox_results['loss_bbox'])
+
+        # mask head forward and loss
+        if self.with_mask:
+            mask_results = self._mask_forward_train(x, sampling_results,
+                                                    bbox_results['bbox_feats'],
+                                                    gt_masks, img_metas)
+            # TODO: Support empty tensor input. #2280
+            if mask_results['loss_mask'] is not None:
+                losses.update(mask_results['loss_mask'])
+
+        if self.with_keypoint:
+            keypoint_results = self._keypoint_forward_train(
+                x, sampling_results, bbox_results['bbox_feats'], gt_keypoints,
+                heatmaps, img_metas)
+            if keypoint_results['loss_keypoint'] is not None:
+                losses.update(keypoint_results['loss_keypoint'])
+
+        return losses
+
+    def _keypoint_forward_train(self, x, sampling_results, bbox_feats,
+                                gt_keypoints, heatmaps, img_metas):
+        if not self.share_roi_extractor:
+            # pos_rois = bbox2roi([res.pos_bboxes for res in sampling_results])
+            # if pos_rois.shape[0] == 0:
+            #     return dict(loss_keypoint=None)
+            keypoint_results = self._keypoint_forward(x)
+        else:
+            pos_inds = []
+            device = bbox_feats.device
+            for res in sampling_results:
+                pos_inds.append(
+                    torch.ones(
+                        res.pos_bboxes.shape[0],
+                        device=device,
+                        dtype=torch.uint8))
+                pos_inds.append(
+                    torch.zeros(
+                        res.neg_bboxes.shape[0],
+                        device=device,
+                        dtype=torch.uint8))
+            pos_inds = torch.cat(pos_inds)
+            if pos_inds.shape[0] == 0:
+                return dict(loss_keypoint=None)
+            keypoint_results = self._keypoint_forward(
+                x, pos_inds=pos_inds, bbox_feats=bbox_feats)
+
+        # keypoint_targets, valids = self.keypoint_head.get_target(
+        #   sampling_results, gt_keypoints, self.train_cfg)
+        heatmap = torch.reshape(
+            torch.cat(heatmaps, dim=0), (-1, *heatmaps[0].shape))
+        loss_keypoint = self.keypoint_head.loss(keypoint_results['heatmaps'],
+                                                heatmap, 0)
+        keypoint_results.update(
+            loss_keypoint=loss_keypoint, keypoint_targets=gt_keypoints)
+        return keypoint_results
+
+    def _keypoint_forward(self, x, rois=None, pos_inds=None, bbox_feats=None):
+        keypoint_pred = self.keypoint_head(x)
+        keypoint_results = dict(heatmaps=keypoint_pred)
+        return keypoint_results
+
+    def simple_test_keypoints(self,
+                              x,
+                              img_metas,
+                              proposals=None,
+                              rcnn_test_cfg=None,
+                              rescale=False):
+        """Test only keypoints without augmentation."""
+        assert self.keypoint_decoder is not None
+        keypoint_results = self._keypoint_forward(x)
+        scale_factor = img_metas[0]['scale_factor']
+
+        # Convert heatmaps to keypoints
+        res = keypoint_results['heatmaps']
+        pred = self.keypoint_decoder(res)
+        keypoint_results['keypoints'] = pred.cpu().numpy()
+        # Upscale keypoints to the original size
+        pred[:, :, 0] /= scale_factor[0]
+        pred[:, :, 1] /= scale_factor[1]
+        if self.output_heatmaps:
+            keypoint_results['heatmaps'] = keypoint_results['heatmaps'].cpu(
+            ).numpy()
+        else:
+            keypoint_results.pop('heatmaps')
+        return keypoint_results
+
+    async def async_test_keypoints(self,
+                                   x,
+                                   img_metas,
+                                   proposals=None,
+                                   rcnn_test_cfg=None,
+                                   rescale=False):
+        """Test only keypoints without augmentation."""
+        assert self.keypoint_decoder is not None
+        keypoint_results = self._keypoint_forward(x)
+        scale_factor = img_metas[0]['scale_factor']
+
+        # Convert heatmaps to keypoints
+        res = keypoint_results['heatmaps']
+        pred = self.keypoint_decoder(res)
+        keypoint_results['keypoints'] = pred.cpu().numpy()
+        # Upscale keypoints to the original size
+        pred[:, :, 0] /= scale_factor[0]
+        pred[:, :, 1] /= scale_factor[1]
+        if self.output_heatmaps:
+            keypoint_results['heatmaps'] = keypoint_results['heatmaps'].cpu(
+            ).numpy()
+        else:
+            keypoint_results.pop('heatmaps')
+        return keypoint_results
+
+    async def async_simple_test(self,
+                                x,
+                                proposal_list,
+                                img_metas,
+                                proposals=None,
+                                rescale=False):
+        """Async test without augmentation."""
+        if self.with_bbox:
+            det_bboxes, det_labels = await self.async_test_bboxes(
+                x, img_metas, proposal_list, self.test_cfg, rescale=rescale)
+            bbox_results = bbox2result(det_bboxes, det_labels,
+                                       self.bbox_head.num_classes)
+        else:
+            bbox_results = np.zeros((1, 0, 5))
+
+        if not self.with_mask:
+            segm_results = None
+        else:
+            segm_results = await self.async_test_mask(
+                x,
+                img_metas,
+                det_bboxes,
+                det_labels,
+                rescale=rescale,
+                mask_test_cfg=self.test_cfg.get('mask'))
+
+        result = {'bbox': bbox_results, 'mask': segm_results}
+        if self.with_keypoint:
+            if self.keypoint_decoder is not None:
+                kpts_results = self.async_test_keypoints(
+                    x, img_metas, rescale=rescale)
+                result.update(kpts_results)
+        else:
+            kpts_results = None
+
+        return result
+
+    def simple_test(self,
+                    x,
+                    proposal_list,
+                    img_metas,
+                    proposals=None,
+                    rescale=False):
+        """Test without augmentation."""
+        # assert self.with_bbox, 'Bbox head must be implemented.'
+
+        if self.with_bbox:
+            det_bboxes, det_labels = self.simple_test_bboxes(
+                x, img_metas, proposal_list, self.test_cfg, rescale=rescale)
+            bbox_results = bbox2result(det_bboxes, det_labels,
+                                       self.bbox_head.num_classes)
+        else:
+            bbox_results = np.zeros((1, 0, 5))
+
+        if self.with_mask:
+            segm_results = self.simple_test_mask(
+                x, img_metas, det_bboxes, det_labels, rescale=rescale)
+        else:
+            segm_results = None
+
+        result = {'bbox': bbox_results, 'mask': segm_results}
+        if self.with_keypoint:
+            # if self.with_bbox:
+            #     kpts_results = self.simple_test_keypoints(
+            #         x, img_metas, det_bboxes, det_labels, rescale=rescale)
+            # else:
+            #     kpts_results = self.simple_test_keypoints(x, img_metas,
+            #         rescale=rescale)
+            if self.keypoint_decoder is not None:
+                kpts_results = self.simple_test_keypoints(
+                    x, img_metas, rescale=rescale)
+                result.update(kpts_results)
+        else:
+            kpts_results = None
+
+        return result
+
+    def aug_test(self, x, proposal_list, img_metas, rescale=False):
+        """Test with augmentations.
+
+        If rescale is False, then returned bboxes and masks will fit the scale
+        of imgs[0].
+        """
+        # recompute feats to save memory
+        det_bboxes, det_labels = self.aug_test_bboxes(x, img_metas,
+                                                      proposal_list,
+                                                      self.test_cfg)
+
+        if rescale:
+            _det_bboxes = det_bboxes
+        else:
+            _det_bboxes = det_bboxes.clone()
+            _det_bboxes[:, :4] *= det_bboxes.new_tensor(
+                img_metas[0][0]['scale_factor'])
+        bbox_results = bbox2result(_det_bboxes, det_labels,
+                                   self.bbox_head.num_classes)
+
+        # det_bboxes always keep the original scale
+        if self.with_mask:
+            segm_results = self.aug_test_mask(x, img_metas, det_bboxes,
+                                              det_labels)
+            return bbox_results, segm_results
+        else:
+            return bbox_results

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -74,7 +74,9 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
                       gt_bboxes,
                       gt_labels,
                       gt_bboxes_ignore=None,
-                      gt_masks=None):
+                      gt_keypoints=None,
+                      gt_masks=None,
+                      heatmaps=None):
         """
         Args:
             x (list[Tensor]): list of multi-level img features.
@@ -95,6 +97,8 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         Returns:
             dict[str, Tensor]: a dictionary of loss components
         """
+        if gt_keypoints or heatmaps:
+            raise NotImplementedError
         # assign gts and sample proposals
         if self.with_bbox or self.with_mask:
             num_imgs = len(img_metas)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = PIL,asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pycocotools,pytest,robustness_eval,seaborn,six,terminaltables,torch,torchvision
+known_third_party = PIL,asynctest,cityscapesscripts,cv2,matplotlib,mmcv,numpy,onnx,pandas,pycocotools,pytest,robustness_eval,seaborn,six,terminaltables,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,11 +62,13 @@ def test_config_build_detector():
         if 'roi_head' in config_mod.model.keys():
             # for two stage detector
             # detectors must have bbox head
-            assert detector.roi_head.with_bbox and detector.with_bbox
+            assert (detector.roi_head.with_bbox
+                    and detector.with_bbox) or detector.roi_head.with_keypoint
             assert detector.roi_head.with_mask == detector.with_mask
 
             head_config = config_mod.model['roi_head']
-            _check_roi_head(head_config, detector.roi_head)
+            if detector.with_bbox:
+                _check_roi_head(head_config, detector.roi_head)
         # else:
         #     # for single stage detector
         #     # detectors must have bbox head

--- a/tests/test_models/test_heatmaps.py
+++ b/tests/test_models/test_heatmaps.py
@@ -1,0 +1,116 @@
+import numpy as np
+import torch
+
+from mmdet.datasets.pipelines import KeypointsToHeatmaps
+from mmdet.models.builder import build_head
+
+
+def test_all_inner_keypoints():
+    """Tests whether keypoints can be converted to heatmaps and
+    to keypoints back again
+    NOTE: Heatmap is smaller than original image, and keypoints
+    might be slightly shifted afte decoding the heatmaps
+    This unit test might be a little too strict
+    """
+    dividers = [4, 4]
+    sigma = 1.5
+    label_type = 'Gaussian'
+    to_heatmap = KeypointsToHeatmaps(
+        dividers=dividers, sigma=sigma, label_type=label_type)
+    pad_shape = [256, 256]
+
+    to_keypoints = build_head(
+        dict(type='HeatmapDecodeOneKeypoint', upscale=dividers))
+
+    kpts = []
+    for x_pos in range(2, 250, 1):
+        for y_pos in range(2, 250, 1):
+            kpts.append([x_pos, y_pos, 2])
+    kpts = np.array(kpts).reshape(1, -1, 3)
+    results = {'gt_keypoints': kpts, 'pad_shape': pad_shape}
+    heatmaps = to_heatmap(results)['heatmaps']
+    heatmaps = torch.Tensor(heatmaps).unsqueeze(0)
+    keypoints = to_keypoints(heatmaps)
+
+    for gt, pred, heatmap in zip(kpts[0], keypoints[0], heatmaps[0]):
+        gtx, gty, v = gt
+        pdx, pdy, predicted = pred
+        assert pdx == gtx
+        assert pdy == gty
+
+
+def _process_inner_keypoints(dividers, sigmas, label_type, pad_shapes):
+    """Creates a heatmap for every keypoint and convert to keypoint back again
+    Allows some errors since the heatmap is smaller than the original image.
+
+    Args:
+        dividers ([type]): [description]
+        sigmas ([type]): [description]
+        label_type ([type]): [description]
+        pad_shapes ([type]): [description]
+    """
+    for sigma in sigmas:
+        for pad_shape in pad_shapes:
+            to_heatmap = KeypointsToHeatmaps(
+                dividers=dividers, sigma=sigma, label_type=label_type)
+            to_keypoints = build_head(
+                dict(type='HeatmapDecodeOneKeypoint', upscale=dividers))
+
+            kpts = []
+            for x_pos in range(10, pad_shape[1] - 10, 1):
+                for y_pos in range(10, pad_shape[0] - 10, 1):
+                    kpts.append([x_pos, y_pos, 2])
+            kpts = np.array(kpts).reshape(1, -1, 3)
+            results = {'gt_keypoints': kpts, 'pad_shape': pad_shape}
+            heatmaps = to_heatmap(results)['heatmaps']
+            heatmaps = torch.Tensor(heatmaps).unsqueeze(0)
+            keypoints = to_keypoints(heatmaps)
+
+            for gt, pred in zip(kpts[0], keypoints[0]):
+                gtx, gty, v = gt
+                pdx, pdy, predicted = pred
+                assert np.abs(pdx - gtx) <= dividers[0]
+                assert np.abs(pdy - gty) <= dividers[1]
+
+
+def test_large_heatmaps():
+    dividers = [4, 4]
+    sigmas = [3]
+    label_type = 'Gaussian'
+    pad_shapes = [[384, 384], [512, 512], [768, 768]]
+    _process_inner_keypoints(dividers, sigmas, label_type, pad_shapes)
+
+
+def test_sigmas():
+    dividers = [4, 4]
+    sigmas = [1.5, 3, 4.5]
+    label_type = 'Gaussian'
+    pad_shapes = [[256, 256]]
+    _process_inner_keypoints(dividers, sigmas, label_type, pad_shapes)
+
+
+def test_boundary_keypoints():
+    dividers = [4, 4]
+    sigma = 1.5
+    label_type = 'Gaussian'
+    to_heatmap = KeypointsToHeatmaps(
+        dividers=dividers, sigma=sigma, label_type=label_type)
+    pad_shape = [256, 256]
+
+    to_keypoints = build_head(
+        dict(type='HeatmapDecodeOneKeypoint', upscale=dividers))
+
+    kpts = []
+    for y_pos in range(dividers[1], 250, dividers[1]):
+        kpts.append([249, y_pos, 2])
+    kpts = np.array(kpts).reshape(1, -1, 3)
+    results = {'gt_keypoints': kpts, 'pad_shape': pad_shape}
+    heatmaps = to_heatmap(results)['heatmaps']
+    heatmaps = torch.Tensor(heatmaps).unsqueeze(0)
+    keypoints = to_keypoints(heatmaps)
+
+    for gt, pred in zip(kpts[0], keypoints[0]):
+        gtx, gty, v = gt
+        pdx, pdy, predicted = pred
+        assert pdx == gtx
+        assert pdy == gty


### PR DESCRIPTION
This PR is a re implementation of HR Net keypoints detection (Facial landmarks): https://github.com/HRNet/HRNet-Facial-Landmark-Detection
Some ideas from Mask RCNN tentative: https://github.com/powerlic/mmdetection/commit/e7773ca738c2ff35cf7d38af117464d445a6edbc?diff=unified

The MSE loss is calculated on the heatmaps
Outputs should be a N*3 vector for N keypoints, with 2 coordinates and the confidence level for each keypoint

## Current status

Trained and tested on WFLW dataset: https://wywu.github.io/projects/LAB/WFLW.html
Note that a small sigma (on the heatmap) will make it more difficult to adapt
COCO dataset has a visibility flag for each keypoint, we added this possibility and the input data should be a N*3 array similar to MSCOCO input

## TODO

- [x] Keypoints head
- [x] Check results on non square images, non square heatmaps
- [x] Double check heatmaps decoding, we may have a 1 or 2 pixels errors when going back to the original image
- [x] Data augmentation
- [x] Output confidence level
- [x] Visibility flag
- [ ] Test on CPU, see: https://github.com/open-mmlab/mmdetection/issues/3048
- [x] Unit tests
- [x] Asyncio interface
- [ ] Unit tests for data augmenters
- [x] Normalize keypoints errors, interocular distance similar to HRNet paper

## Ideas

- [x] Heeatmaps: We can add more flexibility and specify a decoding function in the config file
- [ ] BBox RoI extractor is not used in the original repo of HRNet facial landmarks, but we might need it in another project, can be added here following some ROI extractors already implemented
- [x] Re use necks, similarly to the implementation of other HRNets in mmdetection, different from the original implementation
- [ ] Use MS COCO dataset (could be used to test RoI extractor and allow comparison with more methods)
- [ ] Dataset WFLW: Similar to the original HRNet paper, we focus on a small area of the image. This is done by calling `CenterOnFace` pipeline. What we can do is convert the dataset and load a small image already centered on the face, with the proper annotation.
- [ ] RetinaFace: Which combines 5 keypoints and face bbox: https://github.com/deepinsight/insightface/tree/master/RetinaFace

## Notes

- The network used in HRNet keypoints detection does not have any neck, while the one used in for bboxes and masks has. (I included 2 examples, with and without neck under `config` folder, accuracy is similar) The original ones is available here: https://github.com/HRNet/HRNet-Object-Detection/blob/master/mmdet/models/backbones/hrnet.py#L442
- This model does not output any bbox, few changes had to be made in the global structure:
    - Some assertions have been removed to allow a model without any keypoint
    - The output can be either a dictionary with the following keys (`bbox`, `mask`, `keypoints`, `heatmaps`), or the original format: a numpy array (bboxes only) or a tuple (np.array, list of dicts) for masks
    - Test function in `mmdet/apis/test.py` had to be modified accordingly to handle and display keypoints (TODO: Check whether mmcv can handle keypoints directly)
- The WFLW dataset has 98 keypoints per image. This number is a bit high and it may be slow to converge especially if you train from scratch (although it eventually converges). You can reduce the number of keypoints to get faster convergence. This should be done both in the config file (`model/roi_head/keypoint_head/num_keypoints`) and the `WflwDataset` code under `load_annotations`
- At train time, heatmaps are generated in the dataloader to speedup. However you need to use `keep_ratio=False` if the batch size is > 1, or it might create errors due to the concatenation of heatmaps of different sizes (depends on your original image size)
- I noticed you guys recently started a new `mmpose` project, but we started working on that some time ago. Feel free to move it to `mmpose` if you think it should go there. 