### PR TITLE
fix bug of gaussian_target, update unittest of heatmap

### DIFF
--- a/configs/cornernet/cornernet_hourglass104_mstest_10x5_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_10x5_210e_coco.py
@@ -23,8 +23,8 @@ model = dict(
             type='GaussianFocalLoss', alpha=2.0, gamma=4.0, loss_weight=1),
         loss_embedding=dict(
             type='AssociativeEmbeddingLoss',
-            pull_weight=0.25,
-            push_weight=0.25),
+            pull_weight=0.10,
+            push_weight=0.10),
         loss_offset=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1)))
 # data settings
 img_norm_cfg = dict(

--- a/configs/cornernet/cornernet_hourglass104_mstest_32x3_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_32x3_210e_coco.py
@@ -23,8 +23,8 @@ model = dict(
             type='GaussianFocalLoss', alpha=2.0, gamma=4.0, loss_weight=1),
         loss_embedding=dict(
             type='AssociativeEmbeddingLoss',
-            pull_weight=0.25,
-            push_weight=0.25),
+            pull_weight=0.10,
+            push_weight=0.10),
         loss_offset=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1)))
 # data settings
 img_norm_cfg = dict(

--- a/configs/cornernet/cornernet_hourglass104_mstest_8x6_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_8x6_210e_coco.py
@@ -23,8 +23,8 @@ model = dict(
             type='GaussianFocalLoss', alpha=2.0, gamma=4.0, loss_weight=1),
         loss_embedding=dict(
             type='AssociativeEmbeddingLoss',
-            pull_weight=0.25,
-            push_weight=0.25),
+            pull_weight=0.10,
+            push_weight=0.10),
         loss_offset=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1)))
 # data settings
 img_norm_cfg = dict(

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -216,8 +216,14 @@ class CornerHead(BaseDenseHead):
         """Initialize weights of the head."""
         bias_init = bias_init_with_prob(0.1)
         for i in range(self.num_feat_levels):
+            self.tl_heat[i][-1].conv.reset_parameters()
             self.tl_heat[i][-1].conv.bias.data.fill_(bias_init)
+            self.br_heat[i][-1].conv.reset_parameters()
             self.br_heat[i][-1].conv.bias.data.fill_(bias_init)
+            self.tl_emb[i][-1].conv.reset_parameters()
+            self.br_emb[i][-1].conv.reset_parameters()
+            self.tl_off[i][-1].conv.reset_parameters()
+            self.br_off[i][-1].conv.reset_parameters()
 
     def forward(self, feats):
         """Forward features from the upstream network.

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -218,7 +218,7 @@ class CornerHead(BaseDenseHead):
         for i in range(self.num_feat_levels):
             # The initialization of parameters are different between nn.Conv2d
             # and ConvModule. Our experiments show that using the original
-            # initialization of nn.Conv2d increases the final mAP by about 0.2%.
+            # initialization of nn.Conv2d increases the final mAP by about 0.2%
             self.tl_heat[i][-1].conv.reset_parameters()
             self.tl_heat[i][-1].conv.bias.data.fill_(bias_init)
             self.br_heat[i][-1].conv.reset_parameters()

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -216,9 +216,9 @@ class CornerHead(BaseDenseHead):
         """Initialize weights of the head."""
         bias_init = bias_init_with_prob(0.1)
         for i in range(self.num_feat_levels):
-            # Due to the initial parameters are different between nn.Conv2d and
-            # ConvModule, and our experiment shows using the initial parameter
-            # from nn.Conv2d could increase the final mAP about 0.2%.
+            # The initialization of parameters are different between nn.Conv2d
+            # and ConvModule. Our experiments show that using the original
+            # initialization of nn.Conv2d increases the final mAP by about 0.2%.
             self.tl_heat[i][-1].conv.reset_parameters()
             self.tl_heat[i][-1].conv.bias.data.fill_(bias_init)
             self.br_heat[i][-1].conv.reset_parameters()
@@ -909,9 +909,9 @@ class CornerHead(BaseDenseHead):
         br_scores, br_inds, br_clses, br_ys, br_xs = self._topk(br_heat, k=k)
 
         # We use repeat instead of expand here because expand is a
-        # shallow-copy method, and in that way the testing result would be
-        # unexpected sometimes. According to our experiment, using expand will
-        # decrease testing mAP about 10% compared to using repeat.
+        # shallow-copy function. Thus it could cause unexpected testing result
+        # sometimes. Using expand will decrease about 10% mAP during testing
+        # compared to repeat.
         tl_ys = tl_ys.view(batch, k, 1).repeat(1, 1, k)
         tl_xs = tl_xs.view(batch, k, 1).repeat(1, 1, k)
         br_ys = br_ys.view(batch, 1, k).repeat(1, k, 1)

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -768,7 +768,7 @@ class CornerHead(BaseDenseHead):
             feat (Tensor): Gathered feature.
         """
         dim = feat.size(2)
-        ind = ind.unsqueeze(2).expand(ind.size(0), ind.size(1), dim)
+        ind = ind.unsqueeze(2).repeat(1, 1, dim)
         feat = feat.gather(1, ind)
         if mask is not None:
             mask = mask.unsqueeze(2).expand_as(feat)
@@ -898,10 +898,10 @@ class CornerHead(BaseDenseHead):
         tl_scores, tl_inds, tl_clses, tl_ys, tl_xs = self._topk(tl_heat, k=k)
         br_scores, br_inds, br_clses, br_ys, br_xs = self._topk(br_heat, k=k)
 
-        tl_ys = tl_ys.view(batch, k, 1).expand(batch, k, k)
-        tl_xs = tl_xs.view(batch, k, 1).expand(batch, k, k)
-        br_ys = br_ys.view(batch, 1, k).expand(batch, k, k)
-        br_xs = br_xs.view(batch, 1, k).expand(batch, k, k)
+        tl_ys = tl_ys.view(batch, k, 1).repeat(1, 1, k)
+        tl_xs = tl_xs.view(batch, k, 1).repeat(1, 1, k)
+        br_ys = br_ys.view(batch, 1, k).repeat(1, k, 1)
+        br_xs = br_xs.view(batch, 1, k).repeat(1, k, 1)
 
         tl_off = self._transpose_and_gather_feat(tl_off, tl_inds)
         tl_off = tl_off.view(batch, k, 1, 2)
@@ -1002,14 +1002,14 @@ class CornerHead(BaseDenseHead):
             br_emb = br_emb.view(batch, 1, k)
             dists = torch.abs(tl_emb - br_emb)
 
-        tl_scores = tl_scores.view(batch, k, 1).expand(batch, k, k)
-        br_scores = br_scores.view(batch, 1, k).expand(batch, k, k)
+        tl_scores = tl_scores.view(batch, k, 1).repeat(1, 1, k)
+        br_scores = br_scores.view(batch, 1, k).repeat(1, k, 1)
 
         scores = (tl_scores + br_scores) / 2  # scores for all possible boxes
 
         # tl and br should have same class
-        tl_clses = tl_clses.view(batch, k, 1).expand(batch, k, k)
-        br_clses = br_clses.view(batch, 1, k).expand(batch, k, k)
+        tl_clses = tl_clses.view(batch, k, 1).repeat(1, 1, k)
+        br_clses = br_clses.view(batch, 1, k).repeat(1, k, 1)
         cls_inds = (tl_clses != br_clses)
 
         # reject boxes based on distances

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -223,10 +223,11 @@ class CornerHead(BaseDenseHead):
             self.tl_heat[i][-1].conv.bias.data.fill_(bias_init)
             self.br_heat[i][-1].conv.reset_parameters()
             self.br_heat[i][-1].conv.bias.data.fill_(bias_init)
-            self.tl_emb[i][-1].conv.reset_parameters()
-            self.br_emb[i][-1].conv.reset_parameters()
             self.tl_off[i][-1].conv.reset_parameters()
             self.br_off[i][-1].conv.reset_parameters()
+            if self.with_corner_emb:
+                self.tl_emb[i][-1].conv.reset_parameters()
+                self.br_emb[i][-1].conv.reset_parameters()
 
     def forward(self, feats):
         """Forward features from the upstream network.

--- a/mmdet/models/utils/gaussian_target.py
+++ b/mmdet/models/utils/gaussian_target.py
@@ -54,7 +54,7 @@ def gen_gaussian_target(heatmap, center, radius, k=1):
     masked_heatmap = heatmap[y - top:y + bottom, x - left:x + right]
     masked_gaussian = gaussian_kernel[radius - top:radius + bottom,
                                       radius - left:radius + right]
-    out_heatmap = torch.zeros_like(heatmap)
+    out_heatmap = heatmap
     torch.max(
         masked_heatmap,
         masked_gaussian * k,


### PR DESCRIPTION
1.  Fixed the bug in `gen_gaussian_target` while multiple gts in one class but only got one peak in the heat map.
2. Expand to 3 gt_bboxes in `test_corner_head_encode_and_decode_heatmap` and two of them are the same class.
3. Replace `expand` with `repeat` in `corner_head.py` to avoid shallow-copy cases, which may generate unexpected results in `2.`


| codebase | batchsize | mAP |
| :-: | :-: | :-: |
| Current | 16 x 6 | 41.2 |
| Current | 10 x 5 | still running |
| Last benchmark | 16 x 6 | 41.1 |
| Last benchmark | 10 x 5 | 41.3 |
| Paper | 10 x 5 | 40.5 |