### PR TITLE
Do not rescale boxes when their number is 0

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/bbox_head.py
@@ -206,7 +206,7 @@ class BBoxHead(nn.Module):
                 bboxes[:, [0, 2]].clamp_(min=0, max=img_shape[1])
                 bboxes[:, [1, 3]].clamp_(min=0, max=img_shape[0])
 
-        if rescale:
+        if rescale and bboxes.size(0) > 0:
             if isinstance(scale_factor, float):
                 bboxes /= scale_factor
             else:


### PR DESCRIPTION
Before this fix, an attempt to rescale an empty tensor of bounding boxes (i.e. of shape `(0,4)` ) results in the following error:

```
RuntimeError: Cannot reshape tensor of 0 elements into shape [0, -1, -4] because the unspecified dimension size -1 can be any value and is ambiguous.
```
