### PR TITLE
fix res2net+dcn test bug

### DIFF
--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,5 +1,4 @@
 import math
-
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,5 +1,4 @@
 import math
-
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
@@ -312,7 +311,7 @@ class Res2Net(ResNet):
             base_width=self.base_width,
             base_channels=self.base_channels,
             **kwargs)
-    
+
     def init_weights(self, pretrained=None):
         """Initialize the weights in backbone.
         Args:

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -338,7 +338,7 @@ class Res2Net(ResNet):
             if self.dcn is not None:
                 for m in self.modules():
                     if isinstance(m, Bottle2neck):
-                        # dcn in Res2Net bottle2neck is in ModuleList  
+                        # dcn in Res2Net bottle2neck is in ModuleList
                         for n in m.convs:
                             if hasattr(n, 'conv_offset'):
                                 constant_init(n.conv_offset, 0)

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
@@ -311,7 +312,7 @@ class Res2Net(ResNet):
             base_width=self.base_width,
             base_channels=self.base_channels,
             **kwargs)
-
+    
     def init_weights(self, pretrained=None):
         """Initialize the weights in backbone.
         Args:

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
@@ -25,7 +26,6 @@ class Bottle2neck(_Bottleneck):
                  stage_type='normal',
                  **kwargs):
         """Bottle2neck block for Res2Net.
-
         If style is "pytorch", the stride-two layer is the 3x3 conv layer, if
         it is "caffe", the stride-two layer is the first 1x1 conv layer.
         """
@@ -163,7 +163,6 @@ class Bottle2neck(_Bottleneck):
 
 class Res2Layer(nn.Sequential):
     """Res2Layer to build Res2Net style backbone.
-
     Args:
         block (nn.Module): block used to build ResLayer.
         inplanes (int): inplanes of block.
@@ -243,7 +242,6 @@ class Res2Layer(nn.Sequential):
 @BACKBONES.register_module()
 class Res2Net(ResNet):
     """Res2Net backbone.
-
     Args:
         scales (int): Scales used in Res2Net. Default: 4
         base_width (int): Basic width of each scale. Default: 26
@@ -266,7 +264,6 @@ class Res2Net(ResNet):
             freeze running stats (mean and var). Note: Effect on Batch Norm
             and its variants only.
         plugins (list[dict]): List of plugins for stages, each dict contains:
-
             - cfg (dict, required): Cfg dict to build plugin.
             - position (str, required): Position inside block to insert
               plugin, options are 'after_conv1', 'after_conv2', 'after_conv3'.
@@ -276,7 +273,6 @@ class Res2Net(ResNet):
             memory while slowing down the training speed.
         zero_init_residual (bool): Whether to use zero init for last norm layer
             in resblocks to let them behave as identity.
-
     Example:
         >>> from mmdet.models import Res2Net
         >>> import torch
@@ -319,7 +315,6 @@ class Res2Net(ResNet):
 
     def init_weights(self, pretrained=None):
         """Initialize the weights in backbone.
-
         Args:
             pretrained (str, optional): Path to pre-trained weights.
                 Defaults to None.

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,10 +1,13 @@
 import math
-
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
-from mmcv.cnn import build_conv_layer, build_norm_layer
+from mmcv.cnn import (build_conv_layer, build_norm_layer, constant_init,
+                      kaiming_init)
+from mmcv.runner import load_checkpoint
+from torch.nn.modules.batchnorm import _BatchNorm
 
+from mmdet.utils import get_root_logger
 from ..builder import BACKBONES
 from .resnet import Bottleneck as _Bottleneck
 from .resnet import ResNet
@@ -313,3 +316,34 @@ class Res2Net(ResNet):
             base_width=self.base_width,
             base_channels=self.base_channels,
             **kwargs)
+
+    def init_weights(self, pretrained=None):
+        """Initialize the weights in backbone.
+
+        Args:
+            pretrained (str, optional): Path to pre-trained weights.
+                Defaults to None.
+        """
+        if isinstance(pretrained, str):
+            logger = get_root_logger()
+            load_checkpoint(self, pretrained, strict=False, logger=logger)
+        elif pretrained is None:
+            for m in self.modules():
+                if isinstance(m, nn.Conv2d):
+                    kaiming_init(m)
+                elif isinstance(m, (_BatchNorm, nn.GroupNorm)):
+                    constant_init(m, 1)
+
+            if self.dcn is not None:
+                for m in self.modules():
+                    if isinstance(m, Bottle2neck):
+                        for n in m.convs:
+                            if hasattr(n, 'conv_offset'):
+                                constant_init(n.conv_offset, 0)
+
+            if self.zero_init_residual:
+                for m in self.modules():
+                    if isinstance(m, Bottle2neck):
+                        constant_init(m.norm3, 0)
+        else:
+            raise TypeError('pretrained must be a str or None')

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
@@ -25,6 +26,7 @@ class Bottle2neck(_Bottleneck):
                  stage_type='normal',
                  **kwargs):
         """Bottle2neck block for Res2Net.
+
         If style is "pytorch", the stride-two layer is the 3x3 conv layer, if
         it is "caffe", the stride-two layer is the first 1x1 conv layer.
         """
@@ -162,6 +164,7 @@ class Bottle2neck(_Bottleneck):
 
 class Res2Layer(nn.Sequential):
     """Res2Layer to build Res2Net style backbone.
+
     Args:
         block (nn.Module): block used to build ResLayer.
         inplanes (int): inplanes of block.
@@ -241,6 +244,7 @@ class Res2Layer(nn.Sequential):
 @BACKBONES.register_module()
 class Res2Net(ResNet):
     """Res2Net backbone.
+
     Args:
         scales (int): Scales used in Res2Net. Default: 4
         base_width (int): Basic width of each scale. Default: 26
@@ -263,6 +267,7 @@ class Res2Net(ResNet):
             freeze running stats (mean and var). Note: Effect on Batch Norm
             and its variants only.
         plugins (list[dict]): List of plugins for stages, each dict contains:
+
             - cfg (dict, required): Cfg dict to build plugin.
             - position (str, required): Position inside block to insert
               plugin, options are 'after_conv1', 'after_conv2', 'after_conv3'.
@@ -272,6 +277,7 @@ class Res2Net(ResNet):
             memory while slowing down the training speed.
         zero_init_residual (bool): Whether to use zero init for last norm layer
             in resblocks to let them behave as identity.
+
     Example:
         >>> from mmdet.models import Res2Net
         >>> import torch
@@ -314,6 +320,7 @@ class Res2Net(ResNet):
 
     def init_weights(self, pretrained=None):
         """Initialize the weights in backbone.
+
         Args:
             pretrained (str, optional): Path to pre-trained weights.
                 Defaults to None.

--- a/mmdet/models/backbones/res2net.py
+++ b/mmdet/models/backbones/res2net.py
@@ -338,6 +338,7 @@ class Res2Net(ResNet):
             if self.dcn is not None:
                 for m in self.modules():
                     if isinstance(m, Bottle2neck):
+                        # dcn in Res2Net bottle2neck is in ModuleList  
                         for n in m.convs:
                             if hasattr(n, 'conv_offset'):
                                 constant_init(n.conv_offset, 0)


### PR DESCRIPTION
I rewrite init_weights in the res2net.py to fix the test bug(AttributeError: 'Bottle2neck' object has no attribute 'conv2')