### PR TITLE
speed up and improve stable paa

### DIFF
--- a/mmdet/models/dense_heads/paa_head.py
+++ b/mmdet/models/dense_heads/paa_head.py
@@ -154,7 +154,9 @@ class PAAHead(ATSSHead):
             & (labels < self.background_label)).nonzero().reshape(-1)
 
         losses_cls = self.loss_cls(
-            cls_scores, labels, labels_weight,
+            cls_scores,
+            labels,
+            labels_weight,
             avg_factor=np.max([num_pos, len(img_metas)]))
         if num_pos:
             pos_bbox_pred = self.bbox_coder.decode(


### PR DESCRIPTION
1) Speed up ~ 30% fitting gmm
2) Avoid falling in case of all gts have no at least two assigned anchors
3) Speed up loss calculate in case of no positive anchors