### PR TITLE
Fix bc break of fp16

### DIFF
--- a/.dev_scripts/batch_test.py
+++ b/.dev_scripts/batch_test.py
@@ -18,10 +18,10 @@ import mmcv
 import torch
 from mmcv import Config, get_logger
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import get_dist_info, init_dist, load_checkpoint
+from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
+                         wrap_fp16_model)
 
 from mmdet.apis import multi_gpu_test, single_gpu_test
-from mmdet.core import wrap_fp16_model
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
 from mmdet.models import build_detector

--- a/mmdet/core/__init__.py
+++ b/mmdet/core/__init__.py
@@ -1,6 +1,7 @@
 from .anchor import *  # noqa: F401, F403
 from .bbox import *  # noqa: F401, F403
 from .evaluation import *  # noqa: F401, F403
+from .fp16 import *  # noqa: F401, F403
 from .mask import *  # noqa: F401, F403
 from .post_processing import *  # noqa: F401, F403
 from .utils import *  # noqa: F401, F403

--- a/mmdet/core/fp16/__init__.py
+++ b/mmdet/core/fp16/__init__.py
@@ -1,6 +1,8 @@
-from .deprecated_fp16_utils import Depr_Fp16OptimizerHook as Fp16OptimizerHook
-from .deprecated_fp16_utils import depr_auto_fp16 as auto_fp16
-from .deprecated_fp16_utils import depr_force_fp32 as force_fp32
-from .deprecated_fp16_utils import depr_wrap_fp16_model as wrap_fp16_model
+from .deprecated_fp16_utils import \
+    DeprecatedFp16OptimizerHook as Fp16OptimizerHook
+from .deprecated_fp16_utils import deprecated_auto_fp16 as auto_fp16
+from .deprecated_fp16_utils import deprecated_force_fp32 as force_fp32
+from .deprecated_fp16_utils import \
+    deprecated_wrap_fp16_model as wrap_fp16_model
 
 __all__ = ['auto_fp16', 'force_fp32', 'Fp16OptimizerHook', 'wrap_fp16_model']

--- a/mmdet/core/fp16/__init__.py
+++ b/mmdet/core/fp16/__init__.py
@@ -1,10 +1,6 @@
-import warnings
-
-from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
-                         wrap_fp16_model)
-
-warnings.warn(
-    'Importing from "mmdet.core.fp16" will be deprecated in'
-    ' the future. Please import them from "mmcv.runner" instead', UserWarning)
+from .deprecated_fp16_utils import Depr_Fp16OptimizerHook as Fp16OptimizerHook
+from .deprecated_fp16_utils import depr_auto_fp16 as auto_fp16
+from .deprecated_fp16_utils import depr_force_fp32 as force_fp32
+from .deprecated_fp16_utils import depr_wrap_fp16_model as wrap_fp16_model
 
 __all__ = ['auto_fp16', 'force_fp32', 'Fp16OptimizerHook', 'wrap_fp16_model']

--- a/mmdet/core/fp16/__init__.py
+++ b/mmdet/core/fp16/__init__.py
@@ -1,0 +1,10 @@
+import warnings
+
+from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
+                         wrap_fp16_model)
+
+warnings.warn(
+    'Importing from "mmdet.core.fp16" will be deprecated in'
+    ' the future. Please import them from "mmcv.runner" instead', UserWarning)
+
+__all__ = ['auto_fp16', 'force_fp32', 'Fp16OptimizerHook', 'wrap_fp16_model']

--- a/mmdet/core/fp16/deprecated_fp16_utils.py
+++ b/mmdet/core/fp16/deprecated_fp16_utils.py
@@ -6,10 +6,10 @@ from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
 
 class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
     """A wrapper class for the FP16 optimizer hook. This class wraps
-    Fp16OptimizerHook in "mmcv.runner" and shows a warning that the
-    Fp16OptimizerHook from "mmdet.core" will be deprecated.
+    :class:`Fp16OptimizerHook` in `mmcv.runner` and shows a warning that the
+    :class:`Fp16OptimizerHook` from `mmdet.core` will be deprecated.
 
-    Refer to Fp16OptimizerHook in mmcv.runner for more details.
+    Refer to :class:`Fp16OptimizerHook` in `mmcv.runner` for more details.
 
     Args:
         loss_scale (float): Scale factor multiplied with loss.

--- a/mmdet/core/fp16/deprecated_fp16_utils.py
+++ b/mmdet/core/fp16/deprecated_fp16_utils.py
@@ -1,0 +1,38 @@
+import warnings
+
+from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
+                         wrap_fp16_model)
+
+
+class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
+
+    def __init__(*args, **kwargs):
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            'Importing Fp16OptimizerHook from "mmdet.core" will be '
+            'deprecated in the future. Please import them from "mmcv.runner" '
+            'instead')
+
+
+def depr_auto_fp16(*args, **kwargs):
+    warnings.warn(
+        'Importing auto_fp16 from "mmdet.core" will be '
+        'deprecated in the future. Please import them from "mmcv.runner" '
+        'instead')
+    return auto_fp16(*args, **kwargs)
+
+
+def depr_force_fp32(*args, **kwargs):
+    warnings.warn(
+        'Importing force_fp32 from "mmdet.core" will be '
+        'deprecated in the future. Please import them from "mmcv.runner" '
+        'instead')
+    return force_fp32(*args, **kwargs)
+
+
+def depr_wrap_fp16_model(*args, **kwargs):
+    warnings.warn(
+        'Importing wrap_fp16_model from "mmdet.core" will be '
+        'deprecated in the future. Please import them from "mmcv.runner" '
+        'instead')
+    wrap_fp16_model(*args, **kwargs)

--- a/mmdet/core/fp16/deprecated_fp16_utils.py
+++ b/mmdet/core/fp16/deprecated_fp16_utils.py
@@ -5,9 +5,9 @@ from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
 
 
 class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
-    """A wrapper class for the FP16 optimizer hook.
-    This class wraps Fp16OptimizerHook in "mmcv.runner" and shows a warning
-    that the Fp16OptimizerHook from "mmdet.core" will be deprecated.
+    """A wrapper class for the FP16 optimizer hook. This class wraps
+    Fp16OptimizerHook in "mmcv.runner" and shows a warning that the
+    Fp16OptimizerHook from "mmdet.core" will be deprecated.
 
     Refer to Fp16OptimizerHook in mmcv.runner for more details.
 

--- a/mmdet/core/fp16/deprecated_fp16_utils.py
+++ b/mmdet/core/fp16/deprecated_fp16_utils.py
@@ -4,7 +4,7 @@ from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
                          wrap_fp16_model)
 
 
-class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
+class DeprecatedFp16OptimizerHook(Fp16OptimizerHook):
     """A wrapper class for the FP16 optimizer hook. This class wraps
     :class:`Fp16OptimizerHook` in `mmcv.runner` and shows a warning that the
     :class:`Fp16OptimizerHook` from `mmdet.core` will be deprecated.
@@ -23,7 +23,7 @@ class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
             'instead')
 
 
-def depr_auto_fp16(*args, **kwargs):
+def deprecated_auto_fp16(*args, **kwargs):
     warnings.warn(
         'Importing auto_fp16 from "mmdet.core" will be '
         'deprecated in the future. Please import them from "mmcv.runner" '
@@ -31,7 +31,7 @@ def depr_auto_fp16(*args, **kwargs):
     return auto_fp16(*args, **kwargs)
 
 
-def depr_force_fp32(*args, **kwargs):
+def deprecated_force_fp32(*args, **kwargs):
     warnings.warn(
         'Importing force_fp32 from "mmdet.core" will be '
         'deprecated in the future. Please import them from "mmcv.runner" '
@@ -39,7 +39,7 @@ def depr_force_fp32(*args, **kwargs):
     return force_fp32(*args, **kwargs)
 
 
-def depr_wrap_fp16_model(*args, **kwargs):
+def deprecated_wrap_fp16_model(*args, **kwargs):
     warnings.warn(
         'Importing wrap_fp16_model from "mmdet.core" will be '
         'deprecated in the future. Please import them from "mmcv.runner" '

--- a/mmdet/core/fp16/deprecated_fp16_utils.py
+++ b/mmdet/core/fp16/deprecated_fp16_utils.py
@@ -5,6 +5,15 @@ from mmcv.runner import (Fp16OptimizerHook, auto_fp16, force_fp32,
 
 
 class Depr_Fp16OptimizerHook(Fp16OptimizerHook):
+    """A wrapper class for the FP16 optimizer hook.
+    This class wraps Fp16OptimizerHook in "mmcv.runner" and shows a warning
+    that the Fp16OptimizerHook from "mmdet.core" will be deprecated.
+
+    Refer to Fp16OptimizerHook in mmcv.runner for more details.
+
+    Args:
+        loss_scale (float): Scale factor multiplied with loss.
+    """
 
     def __init__(*args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -5,8 +5,7 @@ import torch
 from mmcv import Config
 from mmcv.cnn import fuse_conv_bn
 from mmcv.parallel import MMDataParallel
-from mmcv.runner import load_checkpoint
-from mmcv.runner.fp16_utils import wrap_fp16_model
+from mmcv.runner import load_checkpoint, wrap_fp16_model
 
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)

--- a/tools/test.py
+++ b/tools/test.py
@@ -7,17 +7,13 @@ import torch
 from mmcv import Config, DictAction
 from mmcv.cnn import fuse_conv_bn
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import get_dist_info, init_dist, load_checkpoint
+from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
+                         wrap_fp16_model)
 
 from mmdet.apis import multi_gpu_test, single_gpu_test
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
 from mmdet.models import build_detector
-
-try:
-    from mmcv.runner import wrap_fp16_model
-except ImportError:
-    from mmcv.runner.fp16_utils import wrap_fp16_model
 
 
 def parse_args():

--- a/tools/test_robustness.py
+++ b/tools/test_robustness.py
@@ -9,7 +9,8 @@ import mmcv
 import torch
 import torch.distributed as dist
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import get_dist_info, init_dist, load_checkpoint
+from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
+                         wrap_fp16_model)
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
 from robustness_eval import get_results
@@ -19,11 +20,6 @@ from mmdet.apis import set_random_seed
 from mmdet.core import encode_mask_results, eval_map
 from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.models import build_detector
-
-try:
-    from mmcv.runner import wrap_fp16_model
-except ImportError:
-    from mmcv.runner.fp16_utils import wrap_fp16_model
 
 
 def coco_eval_with_return(result_files,


### PR DESCRIPTION
This PR:
- Fix bc break of fp16
- Added warning for importing deprecated mmdet version of fp16 utils
- refactored some import of fp16 utils now that mmcv 1.1.3 is up(and required by mmdet)