### PR TITLE
Clean outdated comments

### DIFF
--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -204,7 +204,6 @@ class TwoStageDetector(BaseDetector):
         If rescale is False, then returned bboxes and masks will fit the scale
         of imgs[0].
         """
-        # recompute feats to save memory
         x = self.extract_feats(imgs)
         proposal_list = self.rpn_head.aug_test_rpn(x, img_metas)
         return self.roi_head.aug_test(

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -270,7 +270,6 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         If rescale is False, then returned bboxes and masks will fit the scale
         of imgs[0].
         """
-        # recompute feats to save memory
         det_bboxes, det_labels = self.aug_test_bboxes(x, img_metas,
                                                       proposal_list,
                                                       self.test_cfg)

--- a/mmdet/models/roi_heads/test_mixins.py
+++ b/mmdet/models/roi_heads/test_mixins.py
@@ -102,7 +102,6 @@ class BBoxTestMixin(object):
             proposals = bbox_mapping(proposal_list[0][:, :4], img_shape,
                                      scale_factor, flip, flip_direction)
             rois = bbox2roi([proposals])
-            # recompute feature maps to save GPU memory
             bbox_results = self._bbox_forward(x, rois)
             bboxes, scores = self.bbox_head.get_bboxes(
                 rois,


### PR DESCRIPTION
The comments like `# recompute feats to save memory` are so confusing.
What does `recompute feats` mean?

Old codes before the commit below recompute feats by calling `self.extract_feats(imgs)` 2-3 times.
https://github.com/open-mmlab/mmdetection/commit/c29a789c46014cc1ae181f1bbb2e8ec01c44a01c#diff-37358d90bcb60a9f015ed7c0ffcf6dd1