### PR TITLE
Fix nonzero in NMS for PyTorch 1.6.0

### DIFF
--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -51,7 +51,7 @@ def multiclass_nms(multi_bboxes,
     if score_factors is not None:
         scores = scores * score_factors[:, None]
     scores = torch.masked_select(scores, valid_mask)
-    labels = valid_mask.nonzero()[:, 1]
+    labels = valid_mask.nonzero(as_tuple=False)[:, 1]
 
     if bboxes.numel() == 0:
         bboxes = multi_bboxes.new_zeros((0, 5))


### PR DESCRIPTION
Fix https://github.com/open-mmlab/mmdetection/issues/3865 and https://github.com/open-mmlab/mmdetection/issues/3467

The warning can be ignored, and will [disappear in PyTorch 1.7.0](https://github.com/pytorch/pytorch/pull/45413).
However, the `nonzero` in `multiclass_nms` makes ProgressBar ugly and weird in testing.

```
[                                                  ] 0/5000, elapsed: 0s, ETA:/home/shinya7y/work/mmdetection/mmdet/core/post_processing/bbox_nms.py:54: UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /opt/conda/conda-bld/pytorch_1595629403081/work/torch/csrc/utils/python_arg_parser.cpp:766.)
  labels = valid_mask.nonzero()[:, 1]
/home/shinya7y/work/mmdetection/mmdet/core/post_processing/bbox_nms.py:54: UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /opt/conda/conda-bld/pytorch_1595629403081/work/torch/csrc/utils/python_arg_parser.cpp:766.)
  labels = valid_mask.nonzero()[:, 1]
/home/shinya7y/work/mmdetection/mmdet/core/post_processing/bbox_nms.py:54: UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /opt/conda/conda-bld/pytorch_1595629403081/work/torch/csrc/utils/python_arg_parser.cpp:766.)
  labels = valid_mask.nonzero()[:, 1]
[                                                  ] 4/5000, 0.6 task/s, elapsed: 7s, ETA:  8287s/home/shinya7y/work/mmdetection/mmdet/core/post_processing/bbox_nms.py:54: UserWarning: This overload of nonzero is deprecated:
        nonzero()
Consider using one of the following signatures instead:
        nonzero(*, bool as_tuple) (Triggered internally at  /opt/conda/conda-bld/pytorch_1595629403081/work/torch/csrc/utils/python_arg_parser.cpp:766.)
  labels = valid_mask.nonzero()[:, 1]
[>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] 5000/5000, 34.5 task/s, elapsed: 145s, ETA:     0s
```