### PR TITLE
[Enhance]: Convert mask to bool before using it as img's index for robustness and speedup

### DIFF
--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -316,6 +316,7 @@ class BaseDetector(nn.Module, metaclass=ABCMeta):
                 i = int(i)
                 color_mask = color_masks[labels[i]]
                 mask = segms[i]
+                mask = mask if mask.dtype == np.bool else np.array(mask, dtype=bool)
                 img[mask] = img[mask] * 0.5 + color_mask * 0.5
         # if out_file specified, do not show image in window
         if out_file is not None:

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -316,7 +316,8 @@ class BaseDetector(nn.Module, metaclass=ABCMeta):
                 i = int(i)
                 color_mask = color_masks[labels[i]]
                 mask = segms[i]
-                mask = mask if mask.dtype == np.bool else np.array(mask, dtype=bool)
+                if mask.dtype != np.bool:
+                    mask = np.array(mask, dtype=bool)
                 img[mask] = img[mask] * 0.5 + color_mask * 0.5
         # if out_file specified, do not show image in window
         if out_file is not None:

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -315,9 +315,7 @@ class BaseDetector(nn.Module, metaclass=ABCMeta):
             for i in inds:
                 i = int(i)
                 color_mask = color_masks[labels[i]]
-                mask = segms[i]
-                if mask.dtype != np.bool:
-                    mask = np.array(mask, dtype=bool)
+                mask = segms[i].astype(bool)
                 img[mask] = img[mask] * 0.5 + color_mask * 0.5
         # if out_file specified, do not show image in window
         if out_file is not None:


### PR DESCRIPTION
The mask returned by YOLACT has dtype 'uint8', which will extremely slow down the speed when using the mask as image's index.
``` bash
python tools/test.py configs/yolact/yolact_r101_1x8_coco.py checkpoints/yolact_r101_1x8_coco_20200908-4cbe9101.pth --show-dir ./result/

[                                                  ] 4/5000, 0.1 task/s, elapsed: 72s, ETA: 90141s
```

Requesting all models to return masks with dtype 'bool' is another way to solve this problem, but this PR is the easiest way to fix it, and gives more robustness to BaseDetector.show_result().