### PR TITLE
[Docker] fix cv2 import error of ligGL.so.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 
-RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
+RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
When I train a faster_rcnn network with the current docker script I get the following error:
```
Traceback (most recent call last):
  File "tools/train.py", line 8, in <module>
    import mmcv
  File "/opt/conda/lib/python3.7/site-packages/mmcv/__init__.py", line 4, in <module>
    from .fileio import *
  File "/opt/conda/lib/python3.7/site-packages/mmcv/fileio/__init__.py", line 4, in <module>
    from .io import dump, load, register_handler
  File "/opt/conda/lib/python3.7/site-packages/mmcv/fileio/io.py", line 4, in <module>
    from ..utils import is_list_of, is_str
  File "/opt/conda/lib/python3.7/site-packages/mmcv/utils/__init__.py", line 29, in <module>
    from .env import collect_env
  File "/opt/conda/lib/python3.7/site-packages/mmcv/utils/env.py", line 8, in <module>
    import cv2
  File "/opt/conda/lib/python3.7/site-packages/cv2/__init__.py", line 5, in <module>
    from .cv2 import *
ImportError: libGL.so.1: cannot open shared object file: No such file or directory
```
If found a solution to this problem [at stackoverflow](https://stackoverflow.com/a/63377623)

In the pull request I added the listed packages in the stackoverflow thread linked above into the existing list of packages.

With the fix I can train models as expected.