### PR TITLE
Change multi_apply to a class method

### DIFF
--- a/mmdet/models/dense_heads/anchor_free_head.py
+++ b/mmdet/models/dense_heads/anchor_free_head.py
@@ -5,7 +5,6 @@ import torch.nn as nn
 from mmcv.cnn import ConvModule, bias_init_with_prob, normal_init
 from mmcv.runner import force_fp32
 
-from mmdet.core import multi_apply
 from ..builder import HEADS, build_loss
 from .base_dense_head import BaseDenseHead
 from .dense_test_mixins import BBoxTestMixin
@@ -194,7 +193,7 @@ class AnchorFreeHead(BaseDenseHead, BBoxTestMixin):
                     level, each is a 4D-tensor, the channel number is
                     num_points * 4.
         """
-        return multi_apply(self.forward_single, feats)[:2]
+        return self.forward_multi_apply_func(self.forward_single, feats)[:2]
 
     def forward_single(self, x):
         """Forward features of a single scale levle.

--- a/mmdet/models/dense_heads/anchor_head.py
+++ b/mmdet/models/dense_heads/anchor_head.py
@@ -5,7 +5,7 @@ from mmcv.runner import force_fp32
 
 from mmdet.core import (anchor_inside_flags, build_anchor_generator,
                         build_assigner, build_bbox_coder, build_sampler,
-                        images_to_levels, multi_apply, multiclass_nms, unmap)
+                        images_to_levels, multiclass_nms, unmap)
 from ..builder import HEADS, build_loss
 from .base_dense_head import BaseDenseHead
 from .dense_test_mixins import BBoxTestMixin
@@ -136,7 +136,7 @@ class AnchorHead(BaseDenseHead, BBoxTestMixin):
                     scale levels, each is a 4D-tensor, the channels number \
                     is num_anchors * 4.
         """
-        return multi_apply(self.forward_single, feats)
+        return self.forward_multi_apply_func(self.forward_single, feats)
 
     def get_anchors(self, featmap_sizes, img_metas, device='cuda'):
         """Get anchors according to feature map sizes.
@@ -333,7 +333,7 @@ class AnchorHead(BaseDenseHead, BBoxTestMixin):
             gt_bboxes_ignore_list = [None for _ in range(num_imgs)]
         if gt_labels_list is None:
             gt_labels_list = [None for _ in range(num_imgs)]
-        results = multi_apply(
+        results = self.get_targets_multi_apply_func(
             self._get_targets_single,
             concat_anchor_list,
             concat_valid_flag_list,
@@ -474,7 +474,7 @@ class AnchorHead(BaseDenseHead, BBoxTestMixin):
         all_anchor_list = images_to_levels(concat_anchor_list,
                                            num_level_anchors)
 
-        losses_cls, losses_bbox = multi_apply(
+        losses_cls, losses_bbox = self.loss_multi_apply_func(
             self.loss_single,
             cls_scores,
             bbox_preds,

--- a/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdet/models/dense_heads/base_dense_head.py
@@ -2,6 +2,8 @@ from abc import ABCMeta, abstractmethod
 
 import torch.nn as nn
 
+from mmdet.core import multi_apply
+
 
 class BaseDenseHead(nn.Module, metaclass=ABCMeta):
     """Base class for DenseHeads."""
@@ -13,6 +15,21 @@ class BaseDenseHead(nn.Module, metaclass=ABCMeta):
     def loss(self, **kwargs):
         """Compute losses of the head."""
         pass
+
+    def forward_multi_apply_func(self, func, *args, **kwargs):
+        """The function used in the forward function to deal with multi-level
+        feature maps."""
+        return multi_apply(func, *args, **kwargs)
+
+    def get_targets_multi_apply_func(self, func, *args, **kwargs):
+        """The function used in the get_targets function to deal with multi-
+        level feature maps."""
+        return multi_apply(func, *args, **kwargs)
+
+    def loss_multi_apply_func(self, func, *args, **kwargs):
+        """The function used in the loss function to deal with multi-level
+        feature maps."""
+        return multi_apply(func, *args, **kwargs)
 
     @abstractmethod
     def get_bboxes(self, **kwargs):

--- a/mmdet/models/dense_heads/centripetal_head.py
+++ b/mmdet/models/dense_heads/centripetal_head.py
@@ -2,7 +2,6 @@ import torch.nn as nn
 from mmcv.cnn import ConvModule, normal_init
 from mmcv.ops import DeformConv2d
 
-from mmdet.core import multi_apply
 from ..builder import HEADS, build_loss
 from .corner_head import CornerHead
 
@@ -261,11 +260,11 @@ class CentripetalHead(CornerHead):
             with_guiding_shift=True,
             with_centripetal_shift=True)
         mlvl_targets = [targets for _ in range(self.num_feat_levels)]
-        [det_losses, off_losses, guiding_losses, centripetal_losses
-         ] = multi_apply(self.loss_single, tl_heats, br_heats, tl_offs,
-                         br_offs, tl_guiding_shifts, br_guiding_shifts,
-                         tl_centripetal_shifts, br_centripetal_shifts,
-                         mlvl_targets)
+        [det_losses, off_losses, guiding_losses,
+         centripetal_losses] = self.loss_multi_apply_func(
+             self.loss_single, tl_heats, br_heats, tl_offs, br_offs,
+             tl_guiding_shifts, br_guiding_shifts, tl_centripetal_shifts,
+             br_centripetal_shifts, mlvl_targets)
         loss_dict = dict(
             det_loss=det_losses,
             off_loss=off_losses,

--- a/mmdet/models/dense_heads/fcos_head.py
+++ b/mmdet/models/dense_heads/fcos_head.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from mmcv.cnn import Scale, normal_init
 from mmcv.runner import force_fp32
 
-from mmdet.core import distance2bbox, multi_apply, multiclass_nms
+from mmdet.core import distance2bbox, multiclass_nms
 from ..builder import HEADS, build_loss
 from .anchor_free_head import AnchorFreeHead
 
@@ -119,8 +119,8 @@ class FCOSHead(AnchorFreeHead):
                 centernesses (list[Tensor]): Centerss for each scale level, \
                     each is a 4D-tensor, the channel number is num_points * 1.
         """
-        return multi_apply(self.forward_single, feats, self.scales,
-                           self.strides)
+        return self.forward_multi_apply_func(self.forward_single, feats,
+                                             self.scales, self.strides)
 
     def forward_single(self, x, scale, stride):
         """Forward features of a single scale levle.
@@ -443,7 +443,7 @@ class FCOSHead(AnchorFreeHead):
         num_points = [center.size(0) for center in points]
 
         # get labels and bbox_targets of each image
-        labels_list, bbox_targets_list = multi_apply(
+        labels_list, bbox_targets_list = self.get_targets_multi_apply_func(
             self._get_target_single,
             gt_bboxes_list,
             gt_labels_list,

--- a/mmdet/models/dense_heads/fovea_head.py
+++ b/mmdet/models/dense_heads/fovea_head.py
@@ -3,7 +3,7 @@ import torch.nn as nn
 from mmcv.cnn import ConvModule, normal_init
 from mmcv.ops import DeformConv2d
 
-from mmdet.core import multi_apply, multiclass_nms
+from mmdet.core import multiclass_nms
 from ..builder import HEADS
 from .anchor_free_head import AnchorFreeHead
 
@@ -175,7 +175,7 @@ class FoveaHead(AnchorFreeHead):
         return dict(loss_cls=loss_cls, loss_bbox=loss_bbox)
 
     def get_targets(self, gt_bbox_list, gt_label_list, featmap_sizes, points):
-        label_list, bbox_target_list = multi_apply(
+        label_list, bbox_target_list = self.get_targets_multi_apply_func(
             self._get_target_single,
             gt_bbox_list,
             gt_label_list,

--- a/mmdet/models/dense_heads/fsaf_head.py
+++ b/mmdet/models/dense_heads/fsaf_head.py
@@ -231,7 +231,7 @@ class FSAFHead(RetinaHead):
             concat_anchor_list.append(torch.cat(anchor_list[i]))
         all_anchor_list = images_to_levels(concat_anchor_list,
                                            num_level_anchors)
-        losses_cls, losses_bbox = multi_apply(
+        losses_cls, losses_bbox = self.loss_multi_apply_func(
             self.loss_single,
             cls_scores,
             bbox_preds,

--- a/mmdet/models/dense_heads/guided_anchor_head.py
+++ b/mmdet/models/dense_heads/guided_anchor_head.py
@@ -231,7 +231,7 @@ class GuidedAnchorHead(AnchorHead):
         return cls_score, bbox_pred, shape_pred, loc_pred
 
     def forward(self, feats):
-        return multi_apply(self.forward_single, feats)
+        return self.forward_multi_apply_func(self.forward_single, feats)
 
     def get_sampled_approxs(self, featmap_sizes, img_metas, device='cuda'):
         """Get sampled approxs and inside flags according to feature map sizes.
@@ -700,7 +700,7 @@ class GuidedAnchorHead(AnchorHead):
                                            num_level_anchors)
 
         # get classification and bbox regression losses
-        losses_cls, losses_bbox = multi_apply(
+        losses_cls, losses_bbox = self.loss_multi_apply_func(
             self.loss_single,
             cls_scores,
             bbox_preds,

--- a/mmdet/models/dense_heads/paa_head.py
+++ b/mmdet/models/dense_heads/paa_head.py
@@ -121,10 +121,9 @@ class PAAHead(ATSSHead):
         bbox_preds = [item.reshape(-1, 4) for item in bbox_preds]
         iou_preds = levels_to_images(iou_preds)
         iou_preds = [item.reshape(-1, 1) for item in iou_preds]
-        pos_losses_list, = multi_apply(self.get_pos_loss, anchor_list,
-                                       cls_scores, bbox_preds, labels,
-                                       labels_weight, bboxes_target,
-                                       bboxes_weight, pos_inds)
+        pos_losses_list, = self.loss_multi_apply_func(
+            self.get_pos_loss, anchor_list, cls_scores, bbox_preds, labels,
+            labels_weight, bboxes_target, bboxes_weight, pos_inds)
 
         with torch.no_grad():
             labels, label_weights, bbox_weights, num_pos = multi_apply(
@@ -439,7 +438,7 @@ class PAAHead(ATSSHead):
             gt_bboxes_ignore_list = [None for _ in range(num_imgs)]
         if gt_labels_list is None:
             gt_labels_list = [None for _ in range(num_imgs)]
-        results = multi_apply(
+        results = self.get_targets_multi_apply_func(
             self._get_targets_single,
             concat_anchor_list,
             concat_valid_flag_list,

--- a/mmdet/models/dense_heads/pisa_ssd_head.py
+++ b/mmdet/models/dense_heads/pisa_ssd_head.py
@@ -1,6 +1,5 @@
 import torch
 
-from mmdet.core import multi_apply
 from ..builder import HEADS
 from ..losses import CrossEntropyLoss, SmoothL1Loss, carl_loss, isr_p
 from .ssd_head import SSDHead
@@ -123,7 +122,7 @@ class PISASSDHead(SSDHead):
         assert torch.isfinite(all_bbox_preds).all().item(), \
             'bbox predications become infinite or NaN!'
 
-        losses_cls, losses_bbox = multi_apply(
+        losses_cls, losses_bbox = self.loss_multi_apply_func(
             self.loss_single,
             all_cls_scores,
             all_bbox_preds,

--- a/mmdet/models/dense_heads/ssd_head.py
+++ b/mmdet/models/dense_heads/ssd_head.py
@@ -4,7 +4,7 @@ import torch.nn.functional as F
 from mmcv.cnn import xavier_init
 
 from mmdet.core import (build_anchor_generator, build_assigner,
-                        build_bbox_coder, build_sampler, multi_apply)
+                        build_bbox_coder, build_sampler)
 from ..builder import HEADS
 from ..losses import smooth_l1_loss
 from .anchor_head import AnchorHead
@@ -243,7 +243,7 @@ class SSDHead(AnchorHead):
         assert torch.isfinite(all_bbox_preds).all().item(), \
             'bbox predications become infinite or NaN!'
 
-        losses_cls, losses_bbox = multi_apply(
+        losses_cls, losses_bbox = self.loss_multi_apply_func(
             self.loss_single,
             all_cls_scores,
             all_bbox_preds,

--- a/mmdet/models/dense_heads/yolact_head.py
+++ b/mmdet/models/dense_heads/yolact_head.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from mmcv.cnn import ConvModule, xavier_init
 from mmcv.runner import force_fp32
 
-from mmdet.core import build_sampler, fast_nms, images_to_levels, multi_apply
+from mmdet.core import build_sampler, fast_nms, images_to_levels
 from ..builder import HEADS, build_loss
 from .anchor_head import AnchorHead
 
@@ -220,7 +220,7 @@ class YOLACTHead(AnchorHead):
             assert torch.isfinite(all_bbox_preds).all().item(), \
                 'bbox predications become infinite or NaN!'
 
-            losses_cls, losses_bbox = multi_apply(
+            losses_cls, losses_bbox = self.loss_multi_apply_func(
                 self.loss_single_OHEM,
                 all_cls_scores,
                 all_bbox_preds,
@@ -243,7 +243,7 @@ class YOLACTHead(AnchorHead):
                 concat_anchor_list.append(torch.cat(anchor_list[i]))
             all_anchor_list = images_to_levels(concat_anchor_list,
                                                num_level_anchors)
-            losses_cls, losses_bbox = multi_apply(
+            losses_cls, losses_bbox = self.loss_multi_apply_func(
                 self.loss_single,
                 cls_scores,
                 bbox_preds,


### PR DESCRIPTION
The three usage scenarios of `multi_apply` in a detector head are changed to a class method, so that users can change the behavior of `multi_apply` after inheriting this class.