### PR TITLE
Clamp neg probability in freeanchor

### DIFF
--- a/mmdet/models/dense_heads/free_anchor_retina_head.py
+++ b/mmdet/models/dense_heads/free_anchor_retina_head.py
@@ -5,6 +5,8 @@ from mmdet.core import bbox_overlaps
 from ..builder import HEADS
 from .retina_head import RetinaHead
 
+EPS = 1e-12
+
 
 @HEADS.register_module()
 class FreeAnchorRetinaHead(RetinaHead):
@@ -260,10 +262,9 @@ class FreeAnchorRetinaHead(RetinaHead):
             Tensor: Negative bag loss in shape (num_img, num_anchors, num_classes).
         """  # noqa: E501, W605
         prob = cls_prob * (1 - box_prob)
-        neg_prob = 1 - prob
         # There are some cases when neg_prob = 0.
         # This will cause the neg_prob.log() to be inf without clamp.
-        neg_prob = torch.clamp(neg_prob, min=1e-12)
-        negative_bag_loss = -prob**self.gamma * neg_prob.log()
-        negative_bag_loss = (1 - self.alpha) * negative_bag_loss
-        return negative_bag_loss
+        prob = prob.clamp(min=EPS, max=1 - EPS)
+        negative_bag_loss = prob**self.gamma * F.binary_cross_entropy(
+            prob, torch.zeros_like(prob), reduction='none')
+        return (1 - self.alpha) * negative_bag_loss

--- a/mmdet/models/dense_heads/free_anchor_retina_head.py
+++ b/mmdet/models/dense_heads/free_anchor_retina_head.py
@@ -264,6 +264,6 @@ class FreeAnchorRetinaHead(RetinaHead):
         # There are some cases when neg_prob = 0.
         # This will cause the neg_prob.log() to be inf without clamp.
         neg_prob = torch.clamp(neg_prob, min=1e-12)
-        negative_bag_loss = prob**self.gamma * neg_prob.log()
-        negative_bag_loss = -(1 - self.alpha) * negative_bag_loss
+        negative_bag_loss = -prob**self.gamma * neg_prob.log()
+        negative_bag_loss = (1 - self.alpha) * negative_bag_loss
         return negative_bag_loss


### PR DESCRIPTION
This PR tries to resolve the training instability of FreeAnchor when the probabilities are very close to 1 or 0.