### PR TITLE
Speedup expand when meets large image

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -854,9 +854,13 @@ class Expand(object):
 
         h, w, c = img.shape
         ratio = random.uniform(self.min_ratio, self.max_ratio)
-        expand_img = np.full((int(h * ratio), int(w * ratio), c),
-                             self.mean,
-                             dtype=img.dtype)
+        if self.mean[0] == self.mean[1] and self.mean[1] == self.mean[2]:
+            expand_img = np.empty((int(h * ratio), int(w * ratio), c), img.dtype)
+            expand_img.fill(self.mean[0])
+        else:
+            expand_img = np.full((int(h * ratio), int(w * ratio), c),
+                                 self.mean,
+                                 dtype=img.dtype)
         left = int(random.uniform(0, w * ratio - w))
         top = int(random.uniform(0, h * ratio - h))
         expand_img[top:top + h, left:left + w] = img

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -855,7 +855,8 @@ class Expand(object):
         h, w, c = img.shape
         ratio = random.uniform(self.min_ratio, self.max_ratio)
         if self.mean[0] == self.mean[1] and self.mean[1] == self.mean[2]:
-            expand_img = np.empty((int(h * ratio), int(w * ratio), c), img.dtype)
+            expand_img = np.empty((int(h * ratio), int(w * ratio), c),
+                                  img.dtype)
             expand_img.fill(self.mean[0])
         else:
             expand_img = np.full((int(h * ratio), int(w * ratio), c),

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -854,7 +854,8 @@ class Expand(object):
 
         h, w, c = img.shape
         ratio = random.uniform(self.min_ratio, self.max_ratio)
-        if self.mean[0] == self.mean[1] and self.mean[1] == self.mean[2]:
+        # speedup expand when meets large image
+        if np.all(self.mean == self.mean[0]):
             expand_img = np.empty((int(h * ratio), int(w * ratio), c),
                                   img.dtype)
             expand_img.fill(self.mean[0])


### PR DESCRIPTION
ref: https://github.com/numpy/numpy/issues/13001
```python
%%timeit
a = np.full((4000, 2000, 3), [0.0, 0.0, 0.0], np.float32)
76.9 ms ± 346 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%%timeit
a = np.full((4000, 2000, 3), [0, 0, 0], np.float32)
71.4 ms ± 516 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%%timeit
a = np.full((4000, 2000, 3), 0.0, np.float32)
47.2 ms ± 1.21 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
%%timeit
a = np.full((4000, 2000, 3), 0, np.float32)
47 ms ± 139 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%%timeit
a = np.empty((4000, 2000, 3), np.float32)
a.fill(0.0)
46.3 ms ± 278 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
%%timeit
a = np.empty((4000, 2000, 3), np.float32)
a.fill(0)
46.3 ms ± 184 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```