### PR TITLE
Re-implements RandomCrop to support different crop_type

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -604,6 +604,8 @@ class RandomCrop(object):
         ], f'Invalid crop_type {crop_type}.'
         if crop_type in ['absolute', 'absolute_range']:
             assert crop_size[0] > 0 and crop_size[1] > 0
+            assert isinstance(crop_size[0], int) and isinstance(
+                crop_size[1], int)
         else:
             assert 0 < crop_size[0] <= 1 and 0 < crop_size[1] <= 1
         self.crop_size = crop_size

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -574,18 +574,19 @@ class RandomCrop(object):
             height and width.
         allow_negative_crop (bool, optional): Whether to allow a crop that does
             not contain any bbox area. Default False.
-        crop_type (str, optional): one of "relative_range", "relative", "absolute",
-            "absolute_range". "relative" randomly crops (h * crop_size[0],
-            w * crop_size[1]) part from an input of size (h, w).
-            "relative_range" uniformly samples relative crop size from range
-            [crop_size[0], 1] and [crop_size[1], 1] for height and width
+        crop_type (str, optional): one of "relative_range", "relative",
+            "absolute", "absolute_range". "relative" randomly crops
+            (h * crop_size[0], w * crop_size[1]) part from an input of size
+            (h, w). "relative_range" uniformly samples relative crop size from
+            range [crop_size[0], 1] and [crop_size[1], 1] for height and width
             respectively. "absolute" crops from an input with absolute size
             (crop_size[0], crop_size[1]). "absolute_range" uniformly samples
             crop_h in range [crop_size[0], min(h, crop_size[1])] and crop_w
             in range [crop_size[0], min(w, crop_size[1])]. Default "absolute".
 
     Note:
-        - If the image is smaller than the absolute crop size, return the original image
+        - If the image is smaller than the absolute crop size, return the
+            original image.
         - The keys for bboxes, labels and masks must be aligned. That is,
           `gt_bboxes` corresponds to `gt_labels` and `gt_masks`, and
           `gt_bboxes_ignore` corresponds to `gt_labels_ignore` and
@@ -594,12 +595,17 @@ class RandomCrop(object):
           `allow_negative_crop` is set to False, skip this image.
     """
 
-    def __init__(self, crop_size, allow_negative_crop=False, crop_type='absolute'):
+    def __init__(self,
+                 crop_size,
+                 allow_negative_crop=False,
+                 crop_type='absolute'):
         assert crop_type in [
             'relative_range', 'relative', 'absolute', 'absolute_range'
         ], f'Invalid crop_type {crop_type}.'
         if crop_type in ['absolute', 'absolute_range']:
             assert crop_size[0] > 0 and crop_size[1] > 0
+        else:
+            assert 0 < crop_size[0] <= 1 and 0 < crop_size[1] <= 1
         self.crop_size = crop_size
         self.allow_negative_crop = allow_negative_crop
         self.crop_type = crop_type
@@ -615,8 +621,8 @@ class RandomCrop(object):
         }
 
     def _crop_data(self, results, crop_size, allow_negative_crop):
-        """Function to randomly crop images, bounding boxes, masks,
-        semantic segmentation maps.
+        """Function to randomly crop images, bounding boxes, masks, semantic
+        segmentation maps.
 
         Args:
             results (dict): Result dict from loading pipeline.
@@ -679,12 +685,12 @@ class RandomCrop(object):
         return results
 
     def _get_crop_size(self, image_size):
-        """Randomly generates the absolute crop size based on `crop_type`
-        and `image_size`.
+        """Randomly generates the absolute crop size based on `crop_type` and
+        `image_size`.
 
         Args:
             image_size (tuple): (h, w).
-        
+
         Returns:
             crop_size (tuple): (crop_h, crop_w) in absolute pixels.
         """

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -566,13 +566,26 @@ class Normalize(object):
 class RandomCrop(object):
     """Random crop the image & bboxes & masks.
 
+    The absolute `crop_size` is sampled based on `crop_type` and `image_size`,
+    then the cropped results are generated.
+
     Args:
-        crop_size (tuple): Expected size after cropping, (h, w).
-        allow_negative_crop (bool): Whether to allow a crop that does not
-            contain any bbox area. Default to False.
+        crop_size (tuple): The relative ratio or absolute pixels of
+            height and width.
+        allow_negative_crop (bool, optional): Whether to allow a crop that does
+            not contain any bbox area. Default False.
+        crop_type (str, optional): one of "relative_range", "relative", "absolute",
+            "absolute_range". "relative" randomly crops (h * crop_size[0],
+            w * crop_size[1]) part from an input of size (h, w).
+            "relative_range" uniformly samples relative crop size from range
+            [crop_size[0], 1] and [crop_size[1], 1] for height and width
+            respectively. "absolute" crops from an input with absolute size
+            (crop_size[0], crop_size[1]). "absolute_range" uniformly samples
+            crop_h in range [crop_size[0], min(h, crop_size[1])] and crop_w
+            in range [crop_size[0], min(w, crop_size[1])]. Default "absolute".
 
     Note:
-        - If the image is smaller than the crop size, return the original image
+        - If the image is smaller than the absolute crop size, return the original image
         - The keys for bboxes, labels and masks must be aligned. That is,
           `gt_bboxes` corresponds to `gt_labels` and `gt_masks`, and
           `gt_bboxes_ignore` corresponds to `gt_labels_ignore` and
@@ -581,10 +594,16 @@ class RandomCrop(object):
           `allow_negative_crop` is set to False, skip this image.
     """
 
-    def __init__(self, crop_size, allow_negative_crop=False):
-        assert crop_size[0] > 0 and crop_size[1] > 0
+    def __init__(self, crop_size, allow_negative_crop=False, crop_type='absolute'):
+        assert crop_type in [
+            'relative_range', 'relative', 'absolute', 'absolute_range'
+        ], f'Invalid crop_type {crop_type}.'
+        if crop_type in ['absolute', 'absolute_range']:
+            assert crop_size[0] > 0 and crop_size[1] > 0
         self.crop_size = crop_size
         self.allow_negative_crop = allow_negative_crop
+        self.crop_type = crop_type
+
         # The key correspondence from bboxes to labels and masks.
         self.bbox2label = {
             'gt_bboxes': 'gt_labels',
@@ -595,26 +614,29 @@ class RandomCrop(object):
             'gt_bboxes_ignore': 'gt_masks_ignore'
         }
 
-    def __call__(self, results):
-        """Call function to randomly crop images, bounding boxes, masks,
+    def _crop_data(self, results, crop_size, allow_negative_crop):
+        """Function to randomly crop images, bounding boxes, masks,
         semantic segmentation maps.
 
         Args:
             results (dict): Result dict from loading pipeline.
+            crop_size (tuple): Expected absolute size after cropping, (h, w).
+            allow_negative_crop (bool): Whether to allow a crop that does not
+                contain any bbox area. Default to False.
 
         Returns:
             dict: Randomly cropped results, 'img_shape' key in result dict is
                 updated according to crop size.
         """
-
+        assert crop_size[0] > 0 and crop_size[1] > 0
         for key in results.get('img_fields', ['img']):
             img = results[key]
-            margin_h = max(img.shape[0] - self.crop_size[0], 0)
-            margin_w = max(img.shape[1] - self.crop_size[1], 0)
+            margin_h = max(img.shape[0] - crop_size[0], 0)
+            margin_w = max(img.shape[1] - crop_size[1], 0)
             offset_h = np.random.randint(0, margin_h + 1)
             offset_w = np.random.randint(0, margin_w + 1)
-            crop_y1, crop_y2 = offset_h, offset_h + self.crop_size[0]
-            crop_x1, crop_x2 = offset_w, offset_w + self.crop_size[1]
+            crop_y1, crop_y2 = offset_h, offset_h + crop_size[0]
+            crop_x1, crop_x2 = offset_w, offset_w + crop_size[1]
 
             # crop the image
             img = img[crop_y1:crop_y2, crop_x1:crop_x2, ...]
@@ -633,9 +655,9 @@ class RandomCrop(object):
             valid_inds = (bboxes[:, 2] > bboxes[:, 0]) & (
                 bboxes[:, 3] > bboxes[:, 1])
             # If the crop does not contain any gt-bbox area and
-            # self.allow_negative_crop is False, skip this image.
+            # allow_negative_crop is False, skip this image.
             if (key == 'gt_bboxes' and not valid_inds.any()
-                    and not self.allow_negative_crop):
+                    and not allow_negative_crop):
                 return None
             results[key] = bboxes[valid_inds, :]
             # label fields. e.g. gt_labels and gt_labels_ignore
@@ -656,8 +678,58 @@ class RandomCrop(object):
 
         return results
 
+    def _get_crop_size(self, image_size):
+        """Randomly generates the absolute crop size based on `crop_type`
+        and `image_size`.
+
+        Args:
+            image_size (tuple): (h, w).
+        
+        Returns:
+            crop_size (tuple): (crop_h, crop_w) in absolute pixels.
+        """
+        h, w = image_size
+        if self.crop_type == 'relative':
+            crop_h, crop_w = self.crop_size
+            return int(h * crop_h + 0.5), int(w * crop_w + 0.5)
+        elif self.crop_type == 'relative_range':
+            crop_size = np.asarray(self.crop_size, dtype=np.float32)
+            crop_h, crop_w = crop_size + np.random.rand(2) * (1 - crop_size)
+            return int(h * crop_h + 0.5), int(w * crop_w + 0.5)
+        elif self.crop_type == 'absolute':
+            return (min(self.crop_size[0], h), min(self.crop_size[1], w))
+        elif self.crop_type == 'absolute_range':
+            assert self.crop_size[0] <= self.crop_size[1]
+            crop_h = np.random.randint(
+                min(h, self.crop_size[0]),
+                min(h, self.crop_size[1]) + 1)
+            crop_w = np.random.randint(
+                min(w, self.crop_size[0]),
+                min(w, self.crop_size[1]) + 1)
+            return crop_h, crop_w
+
+    def __call__(self, results):
+        """Call function to randomly crop images, bounding boxes, masks,
+        semantic segmentation maps.
+
+        Args:
+            results (dict): Result dict from loading pipeline.
+
+        Returns:
+            dict: Randomly cropped results, 'img_shape' key in result dict is
+                updated according to crop size.
+        """
+        image_size = results['img'].shape[:2]
+        crop_size = self._get_crop_size(image_size)
+        results = self._crop_data(results, crop_size, self.allow_negative_crop)
+        return results
+
     def __repr__(self):
-        return self.__class__.__name__ + f'(crop_size={self.crop_size})'
+        repr_str = self.__class__.__name__
+        repr_str += f'(crop_size={self.crop_size}, '
+        repr_str += f'allow_negative_crop={self.allow_negative_crop}, '
+        repr_str += f'crop_type={self.crop_type})'
+        return repr_str
 
 
 @PIPELINES.register_module()

--- a/tests/test_data/test_transform.py
+++ b/tests/test_data/test_transform.py
@@ -230,7 +230,7 @@ def test_random_crop():
     # test assertion for invalid crop_type
     with pytest.raises(AssertionError):
         transform = dict(
-            type='RandomCrop', crop_type='unknow', crop_size=(1, 1))
+            type='RandomCrop', crop_type='unknown', crop_size=(1, 1))
         build_from_cfg(transform, PIPELINES)
 
     # test assertion for invalid crop_size
@@ -259,26 +259,48 @@ def test_random_crop():
     # test crop_type "relative_range"
     results = _construct_toy_data()
     transform = dict(
-        type='RandomCrop', crop_type='relative_range', crop_size=(0.3, 0.7))
+        type='RandomCrop',
+        crop_type='relative_range',
+        crop_size=(0.3, 0.7),
+        allow_negative_crop=True)
     transform_module = build_from_cfg(transform, PIPELINES)
-    transform_module(copy.deepcopy(results))
+    results_transformed = transform_module(copy.deepcopy(results))
+    h, w = results_transformed['img_shape'][:2]
+    assert int(2 * 0.3 + 0.5) <= h <= int(2 * 1 + 0.5)
+    assert int(4 * 0.7 + 0.5) <= w <= int(4 * 1 + 0.5)
 
     # test crop_type "relative"
     transform = dict(
-        type='RandomCrop', crop_type='relative', crop_size=(0.3, 0.7))
+        type='RandomCrop',
+        crop_type='relative',
+        crop_size=(0.3, 0.7),
+        allow_negative_crop=True)
     transform_module = build_from_cfg(transform, PIPELINES)
-    transform_module(copy.deepcopy(results))
+    results_transformed = transform_module(copy.deepcopy(results))
+    h, w = results_transformed['img_shape'][:2]
+    assert h == int(2 * 0.3 + 0.5) and w == int(4 * 0.7 + 0.5)
 
     # test crop_type "absolute"
-    transform = dict(type='RandomCrop', crop_type='absolute', crop_size=(1, 2))
+    transform = dict(
+        type='RandomCrop',
+        crop_type='absolute',
+        crop_size=(1, 2),
+        allow_negative_crop=True)
     transform_module = build_from_cfg(transform, PIPELINES)
-    transform_module(copy.deepcopy(results))
+    results_transformed = transform_module(copy.deepcopy(results))
+    h, w = results_transformed['img_shape'][:2]
+    assert h == 1 and w == 2
 
     # test crop_type "absolute_range"
     transform = dict(
-        type='RandomCrop', crop_type='absolute_range', crop_size=(1, 20))
+        type='RandomCrop',
+        crop_type='absolute_range',
+        crop_size=(1, 20),
+        allow_negative_crop=True)
     transform_module = build_from_cfg(transform, PIPELINES)
-    transform_module(copy.deepcopy(results))
+    results_transformed = transform_module(copy.deepcopy(results))
+    h, w = results_transformed['img_shape'][:2]
+    assert 1 <= h <= 2 and 1 <= w <= 4
 
 
 def test_min_iou_random_crop():

--- a/tests/test_data/test_transform.py
+++ b/tests/test_data/test_transform.py
@@ -227,6 +227,50 @@ def test_random_crop():
     assert (area(results['gt_bboxes']) <= area(gt_bboxes)).all()
     assert (area(results['gt_bboxes_ignore']) <= area(gt_bboxes_ignore)).all()
 
+    # test assertion for invalid crop_type
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='RandomCrop', crop_type='unknow', crop_size=(1, 1))
+        build_from_cfg(transform, PIPELINES)
+
+    def _construct_toy_data():
+        img = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.uint8)
+        img = np.stack([img, img, img], axis=-1)
+        results = dict()
+        # image
+        results['img'] = img
+        results['img_shape'] = img.shape
+        results['img_fields'] = ['img']
+        # bboxes
+        results['bbox_fields'] = ['gt_bboxes', 'gt_bboxes_ignore']
+        results['gt_bboxes'] = np.array([[0., 0., 2., 1.]], dtype=np.float32)
+        results['gt_bboxes_ignore'] = np.array([[2., 0., 3., 1.]],
+                                               dtype=np.float32)
+        # labels
+        results['gt_labels'] = np.array([1], dtype=np.int64)
+        return results
+
+    # test crop_type "relative_range"
+    results = _construct_toy_data()
+    transform = dict(type='RandomCrop', crop_type='relative_range', crop_size=(0.3, 0.7))
+    transform_module = build_from_cfg(transform, PIPELINES)
+    transform_module(copy.deepcopy(results))
+
+    # test crop_type "relative"
+    transform = dict(type='RandomCrop', crop_type='relative', crop_size=(0.3, 0.7))
+    transform_module = build_from_cfg(transform, PIPELINES)
+    transform_module(copy.deepcopy(results))
+
+    # test crop_type "absolute"
+    transform = dict(type='RandomCrop', crop_type='absolute', crop_size=(1, 2))
+    transform_module = build_from_cfg(transform, PIPELINES)
+    transform_module(copy.deepcopy(results))
+
+    # test crop_type "absolute_range"
+    transform = dict(type='RandomCrop', crop_type='absolute_range', crop_size=(1, 20))
+    transform_module = build_from_cfg(transform, PIPELINES)
+    transform_module(copy.deepcopy(results))
+
 
 def test_min_iou_random_crop():
 

--- a/tests/test_data/test_transform.py
+++ b/tests/test_data/test_transform.py
@@ -233,6 +233,12 @@ def test_random_crop():
             type='RandomCrop', crop_type='unknow', crop_size=(1, 1))
         build_from_cfg(transform, PIPELINES)
 
+    # test assertion for invalid crop_size
+    with pytest.raises(AssertionError):
+        transform = dict(
+            type='RandomCrop', crop_type='relative', crop_size=(0, 0))
+        build_from_cfg(transform, PIPELINES)
+
     def _construct_toy_data():
         img = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=np.uint8)
         img = np.stack([img, img, img], axis=-1)
@@ -252,12 +258,14 @@ def test_random_crop():
 
     # test crop_type "relative_range"
     results = _construct_toy_data()
-    transform = dict(type='RandomCrop', crop_type='relative_range', crop_size=(0.3, 0.7))
+    transform = dict(
+        type='RandomCrop', crop_type='relative_range', crop_size=(0.3, 0.7))
     transform_module = build_from_cfg(transform, PIPELINES)
     transform_module(copy.deepcopy(results))
 
     # test crop_type "relative"
-    transform = dict(type='RandomCrop', crop_type='relative', crop_size=(0.3, 0.7))
+    transform = dict(
+        type='RandomCrop', crop_type='relative', crop_size=(0.3, 0.7))
     transform_module = build_from_cfg(transform, PIPELINES)
     transform_module(copy.deepcopy(results))
 
@@ -267,7 +275,8 @@ def test_random_crop():
     transform_module(copy.deepcopy(results))
 
     # test crop_type "absolute_range"
-    transform = dict(type='RandomCrop', crop_type='absolute_range', crop_size=(1, 20))
+    transform = dict(
+        type='RandomCrop', crop_type='absolute_range', crop_size=(1, 20))
     transform_module = build_from_cfg(transform, PIPELINES)
     transform_module(copy.deepcopy(results))
 

--- a/tests/test_data/test_transform.py
+++ b/tests/test_data/test_transform.py
@@ -228,9 +228,9 @@ def test_random_crop():
     assert (area(results['gt_bboxes_ignore']) <= area(gt_bboxes_ignore)).all()
 
     # test assertion for invalid crop_type
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError):
         transform = dict(
-            type='RandomCrop', crop_type='unknown', crop_size=(1, 1))
+            type='RandomCrop', crop_size=(1, 1), crop_type='unknown')
         build_from_cfg(transform, PIPELINES)
 
     # test assertion for invalid crop_size


### PR DESCRIPTION
This PR re-implements RandomCrop to support more crop_type following the official Detectron2.
The original implementation of RandomCrop is a special case when crop_type='absolute'.