### PR TITLE
fix yolo neck issue

### DIFF
--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -102,11 +102,13 @@ class YOLOV3Neck(nn.Module):
         # Better solution is welcomed.
         self.detect1 = DetectionBlock(in_channels[0], out_channels[0], **cfg)
         for i in range(1, self.num_scales):
-            in_c, out_c = self.in_channels[i], self.out_channels[i]
+            in_c, out_c = self.out_channels[i - 1], self.out_channels[i]
             self.add_module(f'conv{i}', ConvModule(in_c, out_c, 1, **cfg))
-            # in_c + out_c : High-lvl feats will be cat with low-lvl feats
-            self.add_module(f'detect{i+1}',
-                            DetectionBlock(in_c + out_c, out_c, **cfg))
+            # self.in_channels[i] + out_c :
+            # High-lvl feats will be cat with low-lvl feats
+            self.add_module(
+                f'detect{i+1}',
+                DetectionBlock(self.in_channels[i] + out_c, out_c, **cfg))
 
     def forward(self, feats):
         assert len(feats) == self.num_scales


### PR DESCRIPTION
1. module "conv{i}" input channels is out_channels[i-1], not in_channels[i]
    based on the code: tmp = conv(out) in forward function.
2. module "detect1" input channels is in_channels[0], whichi is correct.
    module "detect{i+1}" input channels should be in_channels[i] + out_c