### PR TITLE
fix bug: PAFPN has no attribute extra_convs_on_inputs

### DIFF
--- a/mmdet/models/necks/pafpn.py
+++ b/mmdet/models/necks/pafpn.py
@@ -128,7 +128,8 @@ class PAFPN(FPN):
                     orig = inputs[self.backbone_end_level - 1]
                     outs.append(self.fpn_convs[used_backbone_levels](orig))
                 elif self.add_extra_convs == 'on_lateral':
-                    outs.append(self.fpn_convs[used_backbone_levels](laterals[-1]))
+                    outs.append(
+                        self.fpn_convs[used_backbone_levels](laterals[-1]))
                 elif self.add_extra_convs == 'on_output':
                     outs.append(self.fpn_convs[used_backbone_levels](outs[-1]))
                 else:

--- a/mmdet/models/necks/pafpn.py
+++ b/mmdet/models/necks/pafpn.py
@@ -127,6 +127,8 @@ class PAFPN(FPN):
                 if self.add_extra_convs == 'on_input':
                     orig = inputs[self.backbone_end_level - 1]
                     outs.append(self.fpn_convs[used_backbone_levels](orig))
+                elif self.add_extra_convs == 'on_lateral':
+                    outs.append(self.fpn_convs[used_backbone_levels](laterals[-1]))
                 elif self.add_extra_convs == 'on_output':
                     outs.append(self.fpn_convs[used_backbone_levels](outs[-1]))
                 else:

--- a/mmdet/models/necks/pafpn.py
+++ b/mmdet/models/necks/pafpn.py
@@ -128,8 +128,8 @@ class PAFPN(FPN):
                     orig = inputs[self.backbone_end_level - 1]
                     outs.append(self.fpn_convs[used_backbone_levels](orig))
                 elif self.add_extra_convs == 'on_lateral':
-                    outs.append(
-                        self.fpn_convs[used_backbone_levels](laterals[-1]))
+                    outs.append(self.fpn_convs[used_backbone_levels](
+                        laterals[-1]))
                 elif self.add_extra_convs == 'on_output':
                     outs.append(self.fpn_convs[used_backbone_levels](outs[-1]))
                 else:

--- a/mmdet/models/necks/pafpn.py
+++ b/mmdet/models/necks/pafpn.py
@@ -124,11 +124,13 @@ class PAFPN(FPN):
                     outs.append(F.max_pool2d(outs[-1], 1, stride=2))
             # add conv layers on top of original feature maps (RetinaNet)
             else:
-                if self.extra_convs_on_inputs:
+                if self.add_extra_convs == 'on_input':
                     orig = inputs[self.backbone_end_level - 1]
                     outs.append(self.fpn_convs[used_backbone_levels](orig))
-                else:
+                elif self.add_extra_convs == 'on_output':
                     outs.append(self.fpn_convs[used_backbone_levels](outs[-1]))
+                else:
+                    raise NotImplementedError
                 for i in range(used_backbone_levels + 1, self.num_outs):
                     if self.relu_before_extra_convs:
                         outs.append(self.fpn_convs[i](F.relu(outs[-1])))


### PR DESCRIPTION
PAFPN has no attribute extra_convs_on_inputs

retinanet-like detectors can use PAFPN