### PR TITLE
[Fix]: reshape error of yolov3 in onnxruntime

### DIFF
--- a/mmdet/models/dense_heads/yolo_head.py
+++ b/mmdet/models/dense_heads/yolo_head.py
@@ -269,8 +269,11 @@ class YOLOV3Head(BaseDenseHead, BBoxTestMixin):
             conf_thr = cfg.get('conf_thr', -1)
             if conf_thr > 0:
                 # add as_tuple=False for compatibility in Pytorch 1.6
+                # flatten would create a Reshape op with constant values,
+                # and raise RuntimeError when doing inference in ONNX Runtime
+                # with a different input image (#4221).
                 conf_inds = conf_pred.ge(conf_thr).nonzero(
-                    as_tuple=False).flatten()
+                    as_tuple=False).squeeze(1)
                 bbox_pred = bbox_pred[conf_inds, :]
                 cls_pred = cls_pred[conf_inds, :]
                 conf_pred = conf_pred[conf_inds]


### PR DESCRIPTION
Hi,
Change `flatten`  to `squeeze`  in `yolo_head`.  
`flatten` would create a Reshape op with constant shape values while exporting to ONNX with Pytorch==1.6.0, which results in an incorrect ONNX model and would raise Runtime Error when doing inference in ONNX Runtime.
Root causes are unknown.
Normally, `flatten` and `squeeze` are functionally equal, but the tracing may be different in Pytorch.