### PR TITLE
Fix detr config for higher performance

### DIFF
--- a/configs/detr/README.md
+++ b/configs/detr/README.md
@@ -22,4 +22,4 @@ We provide the config files for DETR: [End-to-End Object Detection with Transfor
 
 | Backbone | Model | Lr schd | Mem (GB) | Inf time (fps) | box AP | Config | Download |
 |:------:|:--------:|:-------:|:--------:|:--------------:|:------:|:------:|:--------:|
-| R-50 | DETR  |150e |7.9|  | 40.1 | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/detr/detr_r50_8x4_150e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/detr/detr_r50_8x2_150e_coco/detr_r50_8x2_150e_coco_20201130_194835-2c4b8974.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/detr/detr_r50_8x2_150e_coco/detr_r50_8x2_150e_coco_20201130_194835.log.json) |
+| R-50 | DETR  |150e |7.9|  | 40.1 | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/detr/detr_r50_8x2_150e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/detr/detr_r50_8x2_150e_coco/detr_r50_8x2_150e_coco_20201130_194835-2c4b8974.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/detr/detr_r50_8x2_150e_coco/detr_r50_8x2_150e_coco_20201130_194835.log.json) |

--- a/configs/detr/detr_r50_8x2_150e_coco.py
+++ b/configs/detr/detr_r50_8x2_150e_coco.py
@@ -111,8 +111,8 @@ test_pipeline = [
         ])
 ]
 data = dict(
-    samples_per_gpu=4,
-    workers_per_gpu=4,
+    samples_per_gpu=2,
+    workers_per_gpu=2,
     train=dict(pipeline=train_pipeline),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -383,7 +383,7 @@ def test_yolact_forward():
 
 def test_detr_forward():
     model, train_cfg, test_cfg = _get_detector_cfg(
-        'detr/detr_r50_8x4_150e_coco.py')
+        'detr/detr_r50_8x2_150e_coco.py')
     model['pretrained'] = None
 
     from mmdet.models import build_detector


### PR DESCRIPTION
This PR changes the default config of DETR from 4 images per GPU to 2 images per GPU for higher performance and match the log and checkpoints.