### PR TITLE
add scipy for Dockerfile

### DIFF
--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,4 @@
 # These must be installed before building mmdetection
 cython
 numpy
+scipy


### PR DESCRIPTION
Dockerfile lack scipy module, docker image build:
`from mmdet.apis import init_detector, inference_detector`
`ModuleNotFoundError: No module named 'scipy'`