### PR TITLE
Fix: change DefaultFormatBundle to ImageToTensor in test_pipline

### DIFF
--- a/configs/vfnet/vfnet_r50_fpn_1x_coco.py
+++ b/configs/vfnet/vfnet_r50_fpn_1x_coco.py
@@ -84,7 +84,7 @@ test_pipeline = [
             dict(type='RandomFlip'),
             dict(type='Normalize', **img_norm_cfg),
             dict(type='Pad', size_divisor=32),
-            dict(type='DefaultFormatBundle'),
+            dict(type='ImageToTensor', keys=['img']),
             dict(type='Collect', keys=['img']),
         ])
 ]

--- a/configs/vfnet/vfnet_r50_fpn_mstrain_2x_coco.py
+++ b/configs/vfnet/vfnet_r50_fpn_mstrain_2x_coco.py
@@ -26,7 +26,7 @@ test_pipeline = [
             dict(type='RandomFlip'),
             dict(type='Normalize', **img_norm_cfg),
             dict(type='Pad', size_divisor=32),
-            dict(type='DefaultFormatBundle'),
+            dict(type='ImageToTensor', keys=['img']),
             dict(type='Collect', keys=['img']),
         ])
 ]


### PR DESCRIPTION
fix vfnet test_pipline, this bug caused the issue: https://github.com/open-mmlab/mmdetection/issues/4146#issue-747026796