### PR TITLE
Update ATSS for PyTorch 1.6+

### DIFF
--- a/mmdet/models/dense_heads/atss_head.py
+++ b/mmdet/models/dense_heads/atss_head.py
@@ -269,7 +269,8 @@ class ATSSHead(AnchorHead):
          bbox_weights_list, num_total_pos, num_total_neg) = cls_reg_targets
 
         num_total_samples = reduce_mean(
-            torch.tensor(num_total_pos).cuda()).item()
+            torch.tensor(num_total_pos, dtype=torch.float,
+                         device=device)).item()
         num_total_samples = max(num_total_samples, 1.0)
 
         losses_cls, losses_bbox, loss_centerness,\


### PR DESCRIPTION
The same fix as GFL. https://github.com/open-mmlab/mmdetection/pull/4210
I haven't checked AP difference caused by eliminating rounding error.