### PR TITLE
Fix script to install ruby

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -54,7 +54,7 @@ If you are facing issue when installing markdown lint, you may install ruby for 
 # install rvm
 curl -L https://get.rvm.io | bash -s -- --autolibs=read-fail
 # set up environment
-echo 'source $HOME/.bash_profile' >> ~/.bashrc
+# Note that you might need to edit ~/.bashrc, ~/.bash_profile, and ~/.profile
 source ~/.profile
 rvm autolibs disable
 # install ruby


### PR DESCRIPTION
`echo 'source $HOME/.bash_profile' >> ~/.bashrc` may cause an infinite loop.
Flowchart examples:
https://www.solipsys.co.uk/images/BashStartupFiles1.png
https://cdn-ak.f.st-hatena.com/images/fotolife/N/Naotsugu/20191110/20191110015450.png