### PR TITLE
fix corner case error in loss_bbox function within gfl_head

### DIFF
--- a/mmdet/models/dense_heads/gfl_head.py
+++ b/mmdet/models/dense_heads/gfl_head.py
@@ -272,7 +272,8 @@ class GFLHead(AnchorHead):
             loss_bbox = self.loss_bbox(
                 pos_decode_bbox_pred,
                 pos_decode_bbox_targets,
-                weight=weight_targets,
+                weight=weight_targets if torch.any(
+                    weight_targets > 0) else weight_targets[:, None],
                 avg_factor=1.0)
 
             # dfl loss


### PR DESCRIPTION
`if not torch.any(weight_targets) > 0`
invoke GIoULoss forward function,
`if weight is not None and not torch.any(weight > 0): return (pred * weight).sum()  # 0`

in this situation, weight_targets ndim is 1, and pos_decode_bbox_pred ndim is 2
they can not multiply