### PR TITLE
add parameter check

### DIFF
--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -25,7 +25,7 @@ class BBoxTestMixin(object):
             scale_factor = img_info[0]['scale_factor']
             flip = img_info[0]['flip']
             flip_direction = (img_info[0]['flip_direction']
-                                if 'flip_direction' in img_info[0] else None)
+                              if 'flip_direction' in img_info[0] else None)
             bboxes = bbox_mapping_back(bboxes, img_shape, scale_factor, flip,
                                        flip_direction)
             recovered_bboxes.append(bboxes)

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -24,8 +24,8 @@ class BBoxTestMixin(object):
             img_shape = img_info[0]['img_shape']
             scale_factor = img_info[0]['scale_factor']
             flip = img_info[0]['flip']
-            flip_direction = img_info[0]['flip_direction']\
-                                if 'flip_direction' in img_info[0] else None
+            flip_direction = (img_info[0]['flip_direction']
+                                if 'flip_direction' in img_info[0] else None)
             bboxes = bbox_mapping_back(bboxes, img_shape, scale_factor, flip,
                                        flip_direction)
             recovered_bboxes.append(bboxes)

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -24,7 +24,7 @@ class BBoxTestMixin(object):
             img_shape = img_info[0]['img_shape']
             scale_factor = img_info[0]['scale_factor']
             flip = img_info[0]['flip']
-            flip_direction = img_info[0]['flip_direction']
+            flip_direction = img_info[0]['flip_direction'] if 'flip_direction' in img_info[0] else None
             bboxes = bbox_mapping_back(bboxes, img_shape, scale_factor, flip,
                                        flip_direction)
             recovered_bboxes.append(bboxes)

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -24,8 +24,9 @@ class BBoxTestMixin(object):
             img_shape = img_info[0]['img_shape']
             scale_factor = img_info[0]['scale_factor']
             flip = img_info[0]['flip']
-            flip_direction = (img_info[0]['flip_direction']
-                              if 'flip_direction' in img_info[0] else None)
+            flip_direction = (
+                img_info[0]['flip_direction']
+                if 'flip_direction' in img_info[0] else None)
             bboxes = bbox_mapping_back(bboxes, img_shape, scale_factor, flip,
                                        flip_direction)
             recovered_bboxes.append(bboxes)

--- a/mmdet/models/dense_heads/dense_test_mixins.py
+++ b/mmdet/models/dense_heads/dense_test_mixins.py
@@ -24,7 +24,8 @@ class BBoxTestMixin(object):
             img_shape = img_info[0]['img_shape']
             scale_factor = img_info[0]['scale_factor']
             flip = img_info[0]['flip']
-            flip_direction = img_info[0]['flip_direction'] if 'flip_direction' in img_info[0] else None
+            flip_direction = img_info[0]['flip_direction']\
+                                if 'flip_direction' in img_info[0] else None
             bboxes = bbox_mapping_back(bboxes, img_shape, scale_factor, flip,
                                        flip_direction)
             recovered_bboxes.append(bboxes)


### PR DESCRIPTION
add parameter check in BBoxTestMixin->merge_aug_bboxes()
when img_meta do not have 'flip_direction' the program will crash，and the default parameter in bbox_mapping_back（flip_direction='horizontal'） will not be used。