### PR TITLE
add a abvious import

### DIFF
--- a/mmdet/datasets/__init__.py
+++ b/mmdet/datasets/__init__.py
@@ -7,7 +7,8 @@ from .dataset_wrappers import (ClassBalancedDataset, ConcatDataset,
 from .deepfashion import DeepFashionDataset
 from .lvis import LVISDataset, LVISV1Dataset, LVISV05Dataset
 from .samplers import DistributedGroupSampler, DistributedSampler, GroupSampler
-from .utils import get_loading_pipeline, replace_ImageToTensor
+from .utils import (NumClassCheckHook, get_loading_pipeline,
+                    replace_ImageToTensor)
 from .voc import VOCDataset
 from .wider_face import WIDERFaceDataset
 from .xml_style import XMLDataset
@@ -18,5 +19,6 @@ __all__ = [
     'LVISV1Dataset', 'GroupSampler', 'DistributedGroupSampler',
     'DistributedSampler', 'build_dataloader', 'ConcatDataset', 'RepeatDataset',
     'ClassBalancedDataset', 'WIDERFaceDataset', 'DATASETS', 'PIPELINES',
-    'build_dataset', 'replace_ImageToTensor', 'get_loading_pipeline'
+    'build_dataset', 'replace_ImageToTensor', 'get_loading_pipeline',
+    'NumClassCheckHook'
 ]


### PR DESCRIPTION
According to the code specification of MMDetection, I add an obvious `import` for `NumClassCheckHook`, although this is not necessary