### PR TITLE
add bn buffer sync in eval_hook

### DIFF
--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -3,7 +3,9 @@ import warnings
 from math import inf
 
 import mmcv
+import torch.distributed as dist
 from mmcv.runner import Hook
+from torch.nn.modules.batchnorm import _BatchNorm
 from torch.utils.data import DataLoader
 
 from mmdet.utils import get_root_logger
@@ -199,6 +201,10 @@ class DistEvalHook(EvalHook):
             ``CheckpointHook`` should device EvalHook. Default: None.
         rule (str | None): Comparison rule for best score. If set to None,
             it will infer a reasonable rule. Default: 'None'.
+         (str | None): Comparison rule for best score. If set to None,
+        broadcast_bn_buffer (bool): Whether to broadcast the
+            buffer(running_mean and running_var) of rank 0 to other rank
+            before evaluation. Default: True.
         **eval_kwargs: Evaluation arguments fed into the evaluate function of
             the dataset.
     """
@@ -211,6 +217,7 @@ class DistEvalHook(EvalHook):
                  gpu_collect=False,
                  save_best=None,
                  rule=None,
+                 broadcast_bn_buffer=True,
                  **eval_kwargs):
         super().__init__(
             dataloader,
@@ -219,10 +226,20 @@ class DistEvalHook(EvalHook):
             save_best=save_best,
             rule=rule,
             **eval_kwargs)
+        self.broadcast_bn_buffer = broadcast_bn_buffer
         self.tmpdir = tmpdir
         self.gpu_collect = gpu_collect
 
     def after_train_epoch(self, runner):
+
+        if self.broadcast_bn_buffer:
+            model = runner.model
+            for name, module in model.named_modules():
+                if isinstance(module,
+                              _BatchNorm) and module.track_running_stats:
+                    dist.broadcast(module.running_var, 0)
+                    dist.broadcast(module.running_mean, 0)
+
         if not self.evaluation_flag(runner):
             return
 

--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -201,7 +201,6 @@ class DistEvalHook(EvalHook):
             ``CheckpointHook`` should device EvalHook. Default: None.
         rule (str | None): Comparison rule for best score. If set to None,
             it will infer a reasonable rule. Default: 'None'.
-         (str | None): Comparison rule for best score. If set to None,
         broadcast_bn_buffer (bool): Whether to broadcast the
             buffer(running_mean and running_var) of rank 0 to other rank
             before evaluation. Default: True.


### PR DESCRIPTION
I modified the eval_hook.py to support broadcast the buffer of batch_norm in rank 0 to other ranks , so as to ensure that the test results in the log can be consistent with individual test results with the saved checkpoint. 