### PR TITLE
Add mask_soft config option to allow non-binary masks

### DIFF
--- a/mmdet/core/mask/mask_target.py
+++ b/mmdet/core/mask/mask_target.py
@@ -43,6 +43,7 @@ def mask_target_single(pos_proposals, pos_assigned_gt_inds, gt_masks, cfg):
     """
     device = pos_proposals.device
     mask_size = _pair(cfg.mask_size)
+    mask_soft = cfg.get('mask_soft', False)
     num_pos = pos_proposals.size(0)
     if num_pos > 0:
         proposals_np = pos_proposals.cpu().numpy()
@@ -53,7 +54,7 @@ def mask_target_single(pos_proposals, pos_assigned_gt_inds, gt_masks, cfg):
 
         mask_targets = gt_masks.crop_and_resize(
             proposals_np, mask_size, device=device,
-            inds=pos_assigned_gt_inds).to_ndarray()
+            inds=pos_assigned_gt_inds, rounded=not mask_soft).to_ndarray()
 
         mask_targets = torch.from_numpy(mask_targets).float().to(device)
     else:


### PR DESCRIPTION
Closes #4606

When using mmdetection as a library for MaskRCNN there is almost nothing preventing the ground truth masks from being fractional labels instead of hard binary labels. The only issue seemed to be in `BitmapMasks.crop_and_resize` where after a resize the interpolated values were always rounded to 0 or 1.

To prevent this I simply added a keyword argument `rounded=True`, which if set to `False` will prevent this rounding step. I also added a small bit of logic to `mask_target` such that it looks for the configuration option `mask_soft` (defaulted to `False`), and it sets `rounded = not mask_soft`.

In the case for mask Polygons I do expose the `rounded` parameter for API consistency, but I raise a ValueError if it is false because soft masks don't make much sense for Polygon targets.

Thus I was able to simply add `roi_head.train_cfg['mask_soft'] = True` to my MaskRCNN training configuration and the mask loss seems to be computed correctly against these soft targets.

Again, I'm using mmdetection as a library to define models (i.e. I'm not using my own training loop and data loading scripts), so I don't think this feature would be exposed to mmdet script users without further changes, but this should be the core fundamental change necessary to add soft mask targets to MaskHeads.