### PR TITLE
use isinstance method to get loading pipeline

### DIFF
--- a/mmdet/datasets/utils.py
+++ b/mmdet/datasets/utils.py
@@ -101,9 +101,8 @@ def get_loading_pipeline(pipeline):
     loading_pipeline_cfg = []
     for cfg in pipeline:
         obj_cls = PIPELINES.get(cfg['type'])
-        if obj_cls is None:
-            continue
-        if isinstance(obj_cls, (LoadImageFromFile, LoadAnnotations)):
+        # TODO：use more elegant way to distinguish loading modules
+        if obj_cls is not None and obj_cls in (LoadImageFromFile, LoadAnnotations):
             loading_pipeline_cfg.append(cfg)
     assert len(loading_pipeline_cfg) == 2, \
         'The data pipeline in your config file must include ' \

--- a/mmdet/datasets/utils.py
+++ b/mmdet/datasets/utils.py
@@ -4,6 +4,8 @@ import warnings
 from mmcv.cnn import VGG
 from mmcv.runner.hooks import HOOKS, Hook
 
+from mmdet.datasets.builder import PIPELINES
+from mmdet.datasets.pipelines import LoadAnnotations, LoadImageFromFile
 from mmdet.models.dense_heads import GARPNHead, RPNHead
 from mmdet.models.roi_heads.mask_heads import FusedSemanticHead
 
@@ -98,7 +100,10 @@ def get_loading_pipeline(pipeline):
     """
     loading_pipeline_cfg = []
     for cfg in pipeline:
-        if cfg['type'].startswith('Load'):
+        obj_cls = PIPELINES.get(cfg['type'])
+        if obj_cls is None:
+            continue
+        if isinstance(obj_cls, (LoadImageFromFile, LoadAnnotations)):
             loading_pipeline_cfg.append(cfg)
     assert len(loading_pipeline_cfg) == 2, \
         'The data pipeline in your config file must include ' \

--- a/mmdet/datasets/utils.py
+++ b/mmdet/datasets/utils.py
@@ -102,7 +102,8 @@ def get_loading_pipeline(pipeline):
     for cfg in pipeline:
         obj_cls = PIPELINES.get(cfg['type'])
         # TODO：use more elegant way to distinguish loading modules
-        if obj_cls is not None and obj_cls in (LoadImageFromFile, LoadAnnotations):
+        if obj_cls is not None and obj_cls in (LoadImageFromFile,
+                                               LoadAnnotations):
             loading_pipeline_cfg.append(cfg)
     assert len(loading_pipeline_cfg) == 2, \
         'The data pipeline in your config file must include ' \

--- a/tests/test_data/test_utils.py
+++ b/tests/test_data/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mmdet.datasets import replace_ImageToTensor, get_loading_pipeline
+from mmdet.datasets import get_loading_pipeline, replace_ImageToTensor
 
 
 def test_replace_ImageToTensor():

--- a/tests/test_data/test_utils.py
+++ b/tests/test_data/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mmdet.datasets import replace_ImageToTensor
+from mmdet.datasets import replace_ImageToTensor, get_loading_pipeline
 
 
 def test_replace_ImageToTensor():
@@ -59,3 +59,21 @@ def test_replace_ImageToTensor():
     ]
     with pytest.warns(UserWarning):
         assert expected_pipelines == replace_ImageToTensor(pipelines)
+
+
+def test_get_loading_pipeline():
+    pipelines = [
+        dict(type='LoadImageFromFile'),
+        dict(type='LoadAnnotations', with_bbox=True),
+        dict(type='Resize', img_scale=(1333, 800), keep_ratio=True),
+        dict(type='RandomFlip', flip_ratio=0.5),
+        dict(type='Pad', size_divisor=32),
+        dict(type='DefaultFormatBundle'),
+        dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels'])
+    ]
+    expected_pipelines = [
+        dict(type='LoadImageFromFile'),
+        dict(type='LoadAnnotations', with_bbox=True)
+    ]
+    assert expected_pipelines == \
+           get_loading_pipeline(pipelines)


### PR DESCRIPTION
Original code:
```python
loading_pipeline_cfg = []
for cfg in pipeline:
    if cfg['type'].startswith('Load'):
        loading_pipeline_cfg.append(cfg)
```

It is not suitable for getting loading pipeline to use `startswith` method. It is possible to exist a pipeline whose string start with 'Load' but which isn't a loading pipeline. It is also possible to exist a pipeline inherited from `LoadImageFromFile` class or `LoadAnnotations` class whose string is not start with 'Load', such as `AnimalLoadImageFromFile`.

New code:
```python
loading_pipeline_cfg = []
for cfg in pipeline:
    obj_cls = PIPELINES.get(cfg['type'])
    if obj_cls is not None and isinstance(obj_cls, (LoadImageFromFile, LoadAnnotations)):
        loading_pipeline_cfg.append(cfg)
```
