### PR TITLE
[Enhance]: Avoid crash in empty gt training of GFL

### DIFF
--- a/mmdet/models/dense_heads/gfl_head.py
+++ b/mmdet/models/dense_heads/gfl_head.py
@@ -284,7 +284,7 @@ class GFLHead(AnchorHead):
         else:
             loss_bbox = bbox_pred.sum() * 0
             loss_dfl = bbox_pred.sum() * 0
-            weight_targets = torch.tensor(0.).cuda()
+            weight_targets = bbox_pred.new_tensor(0)
 
         # cls (qfl) loss
         loss_cls = self.loss_cls(
@@ -362,9 +362,7 @@ class GFLHead(AnchorHead):
                 num_total_samples=num_total_samples)
 
         avg_factor = sum(avg_factor)
-        # when avg_factor is 0, it will be an integer rather than a float
-        # so convert it manually to avoid the failure of integer division
-        avg_factor = reduce_mean(avg_factor.float()).item()
+        avg_factor = reduce_mean(avg_factor).item()
         losses_bbox = list(map(lambda x: x / avg_factor, losses_bbox))
         losses_dfl = list(map(lambda x: x / avg_factor, losses_dfl))
         return dict(

--- a/mmdet/models/dense_heads/gfl_head.py
+++ b/mmdet/models/dense_heads/gfl_head.py
@@ -284,7 +284,7 @@ class GFLHead(AnchorHead):
         else:
             loss_bbox = bbox_pred.sum() * 0
             loss_dfl = bbox_pred.sum() * 0
-            weight_targets = torch.tensor(0).cuda()
+            weight_targets = torch.tensor(0.).cuda()
 
         # cls (qfl) loss
         loss_cls = self.loss_cls(
@@ -362,7 +362,9 @@ class GFLHead(AnchorHead):
                 num_total_samples=num_total_samples)
 
         avg_factor = sum(avg_factor)
-        avg_factor = reduce_mean(avg_factor).item()
+        # when avg_factor is 0, it will be an integer rather than a float
+        # so convert it manually to avoid the failure of integer division
+        avg_factor = reduce_mean(avg_factor.float()).item()
         losses_bbox = list(map(lambda x: x / avg_factor, losses_bbox))
         losses_dfl = list(map(lambda x: x / avg_factor, losses_dfl))
         return dict(


### PR DESCRIPTION
Resolves https://github.com/open-mmlab/mmdetection/issues/4623

The real cause of the crash mentioned in #4623 is that the 0 tensor is created by `torch.tensor(0).cuda()`. This is undesirable as it will not only create an integer tensor but also may put the tensor to GPU:0.