### PR TITLE
Add parser argument 'cfg-options' for some tools

### DIFF
--- a/mmdet/core/export/pytorch2onnx.py
+++ b/mmdet/core/export/pytorch2onnx.py
@@ -6,7 +6,10 @@ import torch
 from mmcv.runner import load_checkpoint
 
 
-def generate_inputs_and_wrap_model(config_path, checkpoint_path, input_config):
+def generate_inputs_and_wrap_model(config_path,
+                                   checkpoint_path,
+                                   input_config,
+                                   cfg_options=None):
     """Prepare sample input and wrap model for ONNX export.
 
     The ONNX export API only accept args, and all inputs should be
@@ -37,7 +40,8 @@ def generate_inputs_and_wrap_model(config_path, checkpoint_path, input_config):
             the model while exporting.
     """
 
-    model = build_model_from_cfg(config_path, checkpoint_path)
+    model = build_model_from_cfg(
+        config_path, checkpoint_path, cfg_options=cfg_options)
     one_img, one_meta = preprocess_example_input(input_config)
     tensor_data = [one_img]
     model.forward = partial(
@@ -57,7 +61,7 @@ def generate_inputs_and_wrap_model(config_path, checkpoint_path, input_config):
     return model, tensor_data
 
 
-def build_model_from_cfg(config_path, checkpoint_path):
+def build_model_from_cfg(config_path, checkpoint_path, cfg_options=None):
     """Build a model from config and load the given checkpoint.
 
     Args:
@@ -71,10 +75,15 @@ def build_model_from_cfg(config_path, checkpoint_path):
     from mmdet.models import build_detector
 
     cfg = mmcv.Config.fromfile(config_path)
+    if cfg_options is not None:
+        cfg.merge_from_dict(cfg_options)
     # import modules from string list.
     if cfg.get('custom_imports', None):
         from mmcv.utils import import_modules_from_strings
         import_modules_from_strings(**cfg['custom_imports'])
+    # set cudnn_benchmark
+    if cfg.get('cudnn_benchmark', False):
+        torch.backends.cudnn.benchmark = True
     cfg.model.pretrained = None
     cfg.data.test.test_mode = True
 

--- a/tools/analysis_tools/benchmark.py
+++ b/tools/analysis_tools/benchmark.py
@@ -2,7 +2,7 @@ import argparse
 import time
 
 import torch
-from mmcv import Config
+from mmcv import Config, DictAction
 from mmcv.cnn import fuse_conv_bn
 from mmcv.parallel import MMDataParallel
 from mmcv.runner import load_checkpoint, wrap_fp16_model
@@ -23,6 +23,16 @@ def parse_args():
         action='store_true',
         help='Whether to fuse conv and bn, this will slightly increase'
         'the inference speed')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
     return args
 
@@ -31,6 +41,12 @@ def main():
     args = parse_args()
 
     cfg = Config.fromfile(args.config)
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/analysis_tools/eval_metric.py
+++ b/tools/analysis_tools/eval_metric.py
@@ -55,6 +55,10 @@ def main():
 
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
     cfg.data.test.test_mode = True
 
     dataset = build_dataset(cfg.data.test)

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -1,7 +1,7 @@
 import argparse
 
 import torch
-from mmcv import Config
+from mmcv import Config, DictAction
 
 from mmdet.models import build_detector
 
@@ -20,6 +20,16 @@ def parse_args():
         nargs='+',
         default=[1280, 800],
         help='input image size')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
     return args
 
@@ -36,6 +46,12 @@ def main():
         raise ValueError('invalid input shape')
 
     cfg = Config.fromfile(args.config)
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
 
     model = build_detector(
         cfg.model,

--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -5,6 +5,7 @@ import os.path as osp
 
 import mmcv
 import torch
+from mmcv import DictAction
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
                          wrap_fp16_model)
@@ -160,6 +161,16 @@ def parse_args():
         choices=['all', 'benchmark'],
         default='benchmark',
         help='aggregate all results or only those for benchmark corruptions')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)
@@ -177,6 +188,12 @@ def main():
         raise ValueError('The output file must be a pkl file.')
 
     cfg = mmcv.Config.fromfile(args.config)
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -6,6 +6,7 @@ import numpy as np
 import onnx
 import onnxruntime as rt
 import torch
+from mmcv import DictAction
 
 from mmdet.core import (build_model_from_cfg, generate_inputs_and_wrap_model,
                         preprocess_example_input)
@@ -22,7 +23,8 @@ def pytorch2onnx(config_path,
                  normalize_cfg=None,
                  dataset='coco',
                  test_img=None,
-                 do_simplify=False):
+                 do_simplify=False,
+                 cfg_options=None):
 
     input_config = {
         'input_shape': input_shape,
@@ -31,10 +33,11 @@ def pytorch2onnx(config_path,
     }
 
     # prepare original model and meta for verifying the onnx model
-    orig_model = build_model_from_cfg(config_path, checkpoint_path)
+    orig_model = build_model_from_cfg(
+        config_path, checkpoint_path, cfg_options=cfg_options)
     one_img, one_meta = preprocess_example_input(input_config)
     model, tensor_data = generate_inputs_and_wrap_model(
-        config_path, checkpoint_path, input_config)
+        config_path, checkpoint_path, input_config, cfg_options=cfg_options)
     output_names = ['boxes']
     if model.with_bbox:
         output_names.append('labels')
@@ -189,6 +192,16 @@ def parse_args():
         nargs='+',
         default=[58.395, 57.12, 57.375],
         help='variance value used for preprocess input data')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
     return args
 
@@ -227,4 +240,5 @@ if __name__ == '__main__':
         normalize_cfg=normalize_cfg,
         dataset=args.dataset,
         test_img=args.test_img,
-        do_simplify=args.simplify)
+        do_simplify=args.simplify,
+        cfg_options=args.cfg_options)

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 import mmcv
-from mmcv import Config
+from mmcv import Config, DictAction
 
 from mmdet.core.utils import mask2ndarray
 from mmdet.core.visualization import imshow_det_bboxes
@@ -30,12 +30,28 @@ def parse_args():
         type=float,
         default=2,
         help='the interval of show (s)')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
     return args
 
 
-def retrieve_data_cfg(config_path, skip_type):
+def retrieve_data_cfg(config_path, skip_type, cfg_options):
     cfg = Config.fromfile(config_path)
+    if cfg_options is not None:
+        cfg.merge_from_dict(cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
     train_data_cfg = cfg.data.train
     train_data_cfg['pipeline'] = [
         x for x in train_data_cfg.pipeline if x['type'] not in skip_type
@@ -46,7 +62,7 @@ def retrieve_data_cfg(config_path, skip_type):
 
 def main():
     args = parse_args()
-    cfg = retrieve_data_cfg(args.config, args.skip_type)
+    cfg = retrieve_data_cfg(args.config, args.skip_type, args.cfg_options)
 
     dataset = build_dataset(cfg.data.train)
 

--- a/tools/misc/print_config.py
+++ b/tools/misc/print_config.py
@@ -1,4 +1,5 @@
 import argparse
+import warnings
 
 from mmcv import Config, DictAction
 
@@ -7,8 +8,31 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Print the whole config')
     parser.add_argument('config', help='config file path')
     parser.add_argument(
-        '--options', nargs='+', action=DictAction, help='arguments in dict')
+        '--options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file (deprecate), '
+        'change to --cfg-options instead.')
+    parser.add_argument(
+        '--cfg-options',
+        nargs='+',
+        action=DictAction,
+        help='override some settings in the used config, the key-value pair '
+        'in xxx=yyy format will be merged into config file. If the value to '
+        'be overwritten is a list, it should be like key="[a,b]" or key=a,b '
+        'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
+        'Note that the quotation marks are necessary and that no white space '
+        'is allowed.')
     args = parser.parse_args()
+
+    if args.options and args.cfg_options:
+        raise ValueError(
+            '--options and --cfg-options cannot be both '
+            'specified, --options is deprecated in favor of --cfg-options')
+    if args.options:
+        warnings.warn('--options is deprecated in favor of --cfg-options')
+        args.cfg_options = args.options
 
     return args
 
@@ -17,8 +41,12 @@ def main():
     args = parse_args()
 
     cfg = Config.fromfile(args.config)
-    if args.options is not None:
-        cfg.merge_from_dict(args.options)
+    if args.cfg_options is not None:
+        cfg.merge_from_dict(args.cfg_options)
+    # import modules from string list.
+    if cfg.get('custom_imports', None):
+        from mmcv.utils import import_modules_from_strings
+        import_modules_from_strings(**cfg['custom_imports'])
     print(f'Config:\n{cfg.pretty_text}')
 
 


### PR DESCRIPTION
It is necessary to override some settings in the used config. But I find it is not containing parser argument 'cfg-options' in some tools. So I add it.