### PR TITLE
Fetch COCO class names from label file

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -29,21 +29,6 @@ except AssertionError:
 @DATASETS.register_module()
 class CocoDataset(CustomDataset):
 
-    CLASSES = ('person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus',
-               'train', 'truck', 'boat', 'traffic light', 'fire hydrant',
-               'stop sign', 'parking meter', 'bench', 'bird', 'cat', 'dog',
-               'horse', 'sheep', 'cow', 'elephant', 'bear', 'zebra', 'giraffe',
-               'backpack', 'umbrella', 'handbag', 'tie', 'suitcase', 'frisbee',
-               'skis', 'snowboard', 'sports ball', 'kite', 'baseball bat',
-               'baseball glove', 'skateboard', 'surfboard', 'tennis racket',
-               'bottle', 'wine glass', 'cup', 'fork', 'knife', 'spoon', 'bowl',
-               'banana', 'apple', 'sandwich', 'orange', 'broccoli', 'carrot',
-               'hot dog', 'pizza', 'donut', 'cake', 'chair', 'couch',
-               'potted plant', 'bed', 'dining table', 'toilet', 'tv', 'laptop',
-               'mouse', 'remote', 'keyboard', 'cell phone', 'microwave',
-               'oven', 'toaster', 'sink', 'refrigerator', 'book', 'clock',
-               'vase', 'scissors', 'teddy bear', 'hair drier', 'toothbrush')
-
     def load_annotations(self, ann_file):
         """Load annotation from COCO style annotation file.
 
@@ -55,6 +40,7 @@ class CocoDataset(CustomDataset):
         """
 
         self.coco = COCO(ann_file)
+        self.CLASSES = [v['name'] for _, v in self.coco.cats.items()]
         self.cat_ids = self.coco.get_cat_ids(cat_names=self.CLASSES)
         self.cat2label = {cat_id: i for i, cat_id in enumerate(self.cat_ids)}
         self.img_ids = self.coco.get_img_ids()


### PR DESCRIPTION
This looks like a better alternative to hard coding all COCO class names in the class. In addition, since it is recommended to convert custom datasets to the COCO format [here](https://github.com/open-mmlab/mmdetection/blob/6c1347d7c0fa220a7be99cb19d1a9e8b6cbf7544/docs/tutorials/customize_dataset.md), I think fetching the class names from the label file is handy especially for a very diverse custom dataset (>300 classes). 