### PR TITLE
fix `RuntimeError` due to two tensor are not on the same device

### DIFF
--- a/mmdet/models/dense_heads/anchor_head.py
+++ b/mmdet/models/dense_heads/anchor_head.py
@@ -646,7 +646,7 @@ class AnchorHead(BaseDenseHead, BBoxTestMixin):
                                        or scores.shape[-2] > nms_pre_tensor):
                 from torch import _shape_as_tensor
                 # keep shape as tensor and get k
-                num_anchor = _shape_as_tensor(scores)[-2]
+                num_anchor = _shape_as_tensor(scores)[-2].to(nms_pre_tensor)
                 nms_pre = torch.where(nms_pre_tensor < num_anchor,
                                       nms_pre_tensor, num_anchor)
                 # Get maximum scores for foreground classes.


### PR DESCRIPTION
This PR fix `RuntimeError` due to two tensor are not on the same device.

test scripts:
```
python demo/image_demo.py demo/demo.jpg configs/retinanet/retinanet_r50_fpn_1x_coco.py checkpoints/retinanet/retinanet_r50_fpn_1x_coco.pth
```
Trace info :
```
Traceback (most recent call last):
  File "demo/image_demo.py", line 26, in <module>
    main()
  File "demo/image_demo.py", line 20, in main
    result = inference_detector(model, args.img)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/apis/inference.py", line 141, in inference_detector
    results = model(return_loss=False, rescale=True, **data)
  File "/home/SENSETIME/maningsheng/anaconda3/envs/pt1.6/lib/python3.7/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmcv/mmcv/runner/fp16_utils.py", line 84, in new_func
    return old_func(*args, **kwargs)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/models/detectors/base.py", line 183, in forward
    return self.forward_test(img, img_metas, **kwargs)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/models/detectors/base.py", line 160, in forward_test
    return self.simple_test(imgs[0], img_metas[0], **kwargs)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/models/detectors/single_stage.py", line 118, in simple_test
    *outs, img_metas, rescale=rescale)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmcv/mmcv/runner/fp16_utils.py", line 164, in new_func
    return old_func(*args, **kwargs)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/models/dense_heads/anchor_head.py", line 581, in get_bboxes
    scale_factor, cfg, rescale)
  File "/home/SENSETIME/maningsheng/projects/open-mmlab/mmdetection/mmdet/models/dense_heads/anchor_head.py", line 651, in _get_bboxes_single
    nms_pre_tensor, num_anchor)
RuntimeError: Expected condition, x and y to be on the same device, but condition is on cuda:0 and x and y are on cuda:0 and cpu respectively
```