### PR TITLE
[Feature]:add dynamic shape support for two_stage func

### DIFF
--- a/mmdet/models/detectors/single_stage.py
+++ b/mmdet/models/detectors/single_stage.py
@@ -113,6 +113,7 @@ class SingleStageDetector(BaseDetector):
         outs = self.bbox_head(x)
         # get origin input shape to support onnx dynamic shape
         if torch.onnx.is_in_onnx_export():
+            # get shape as tensor
             img_shape = torch._shape_as_tensor(img)[2:]
             img_metas[0]['img_shape_for_onnx'] = img_shape
         bbox_list = self.bbox_head.get_bboxes(

--- a/mmdet/models/detectors/single_stage.py
+++ b/mmdet/models/detectors/single_stage.py
@@ -113,7 +113,7 @@ class SingleStageDetector(BaseDetector):
         outs = self.bbox_head(x)
         # get origin input shape to support onnx dynamic shape
         if torch.onnx.is_in_onnx_export():
-            img_shape = torch._shape_as_tensor(img[2:])
+            img_shape = torch._shape_as_tensor(img)[2:]
             img_metas[0]['img_shape_for_onnx'] = img_shape
         bbox_list = self.bbox_head.get_bboxes(
             *outs, img_metas, rescale=rescale)

--- a/mmdet/models/detectors/single_stage.py
+++ b/mmdet/models/detectors/single_stage.py
@@ -113,7 +113,8 @@ class SingleStageDetector(BaseDetector):
         outs = self.bbox_head(x)
         # get origin input shape to support onnx dynamic shape
         if torch.onnx.is_in_onnx_export():
-            img_metas[0]['img_shape_for_onnx'] = img.shape[2:]
+            img_shape = torch._shape_as_tensor(img[2:])
+            img_metas[0]['img_shape_for_onnx'] = img_shape
         bbox_list = self.bbox_head.get_bboxes(
             *outs, img_metas, rescale=rescale)
         # skip post-processing when exporting to ONNX

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -192,7 +192,7 @@ class TwoStageDetector(BaseDetector):
 
         # get origin input shape to onnx dynamic input shape
         if torch.onnx.is_in_onnx_export():
-            img_shape = torch._shape_as_tensor(img[2:])
+            img_shape = torch._shape_as_tensor(img)[2:]
             img_metas[0]['img_shape_for_onnx'] = img_shape
 
         if proposals is None:

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -190,6 +190,10 @@ class TwoStageDetector(BaseDetector):
 
         x = self.extract_feat(img)
 
+        # get origin input shape to onnx dynamic input shape
+        if torch.onnx.is_in_onnx_export():
+            img_metas[0]['img_shape_for_onnx'] = img.shape[2:]
+
         if proposals is None:
             proposal_list = self.rpn_head.simple_test_rpn(x, img_metas)
         else:

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -192,7 +192,8 @@ class TwoStageDetector(BaseDetector):
 
         # get origin input shape to onnx dynamic input shape
         if torch.onnx.is_in_onnx_export():
-            img_metas[0]['img_shape_for_onnx'] = img.shape[2:]
+            img_shape = torch._shape_as_tensor(img[2:])
+            img_metas[0]['img_shape_for_onnx'] = img_shape
 
         if proposals is None:
             proposal_list = self.rpn_head.simple_test_rpn(x, img_metas)


### PR DESCRIPTION
this pr was useful for exported onnx model support dynamic input shapes, there are four changes in total:
1. rpn_head.py, modify topk's attribute K, which was used to keep topk op for dynamic K in onnx model, use                           
    
     ```python
         nms_pre = torch.where(scores_shape[0] < cfg.nms_pre, scores_shape[0], cfg.nms_pre)
     ```

     to replace                                                          
 
    ```python
       if scores.shape[0] > cfg.nms_pre: 
           nms_pre = scores.shape[0] 
       else:
           nms_pre = cfg.nms_pre
    ```
                                                                                                  
2. two_stage.py, add code
    ```python
        if torch.onnx.is_in_onnx_export():
            img_shape = torch._shape_as_tensor(img)[2:]
            img_metas[0]['img_shape_for_onnx'] = img_shape
    ```
    keep the original input shape for Post-processing which was related to calculation of dynamic shapes
3. single_stage.py, same as above
4. test_mixins.py, add code
    ````python
        if torch.onnx.is_in_onnx_export():
            img_shapes = tuple(meta['img_shape_for_onnx']
                               for meta in img_metas)
        else:
            img_shapes = tuple(meta['img_shape'] for meta in img_metas)
    ````
    get original input shape to keep dynamic in exporting onnx model and use shape() to replace len()

    ```python
        num_proposals_per_img = tuple(p.shape[0] for p in proposals)
    ```
    to replace

    ```python
        num_proposals_per_img = tuple(len(p) for p in proposals)
    ```

this pr was mainly for ONNX export and only tested on CPU.