### PR TITLE
Fix parse error in XMLDataset

### DIFF
--- a/mmdet/datasets/xml_style.py
+++ b/mmdet/datasets/xml_style.py
@@ -102,7 +102,8 @@ class XMLDataset(CustomDataset):
             if name not in self.CLASSES:
                 continue
             label = self.cat2label[name]
-            difficult = int(obj.find('difficult').text)
+            difficult = obj.find('difficult')
+            difficult = 0 if difficult is None else int(difficult.text)
             bnd_box = obj.find('bndbox')
             # TODO: check whether it is necessary to use int
             # Coordinates may be float type


### PR DESCRIPTION
Some public datasets such as DIOR (https://arxiv.org/abs/1909.00133) use the VOC style annotations but do not contain the 'difficult' tag in their xml files, thus `obj.find('difficult')` may return `None` and raise an error.