### PR TITLE
doc(quickrun): minor syntax typo fix

### DIFF
--- a/docs/1_exist_data_model.md
+++ b/docs/1_exist_data_model.md
@@ -332,7 +332,7 @@ Assume that you have already downloaded the checkpoints to the directory `checkp
        configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py \
        checkpoints/mask_rcnn_r50_fpn_1x_coco_20200205-d4b0c5d6.pth \
        8 \
-       -format-only \
+       --format-only \
        --options "jsonfile_prefix=./mask_rcnn_test-dev_results"
    ```
 


### PR DESCRIPTION
tiny PR... found a typo when going through examples