### PR TITLE
move mmpycocotools version check to when it is used

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 import mmcv
 import numpy as np
+import pycocotools
 from mmcv.utils import print_log
 from pycocotools.coco import COCO
 from pycocotools.cocoeval import COCOeval
@@ -14,16 +15,6 @@ from terminaltables import AsciiTable
 from mmdet.core import eval_recalls
 from .builder import DATASETS
 from .custom import CustomDataset
-
-try:
-    import pycocotools
-    if not hasattr(pycocotools, '__sphinx_mock__'):  # for doc generation
-        assert pycocotools.__version__ >= '12.0.2'
-except AssertionError:
-    raise AssertionError('Incompatible version of pycocotools is installed. '
-                         'Run pip uninstall pycocotools first. Then run pip '
-                         'install mmpycocotools to install open-mmlab forked '
-                         'pycocotools.')
 
 
 @DATASETS.register_module()
@@ -53,6 +44,12 @@ class CocoDataset(CustomDataset):
         Returns:
             list[dict]: Annotation info from COCO api.
         """
+        if not getattr(pycocotools, '__version__', '0') >= '12.0.2':
+            raise AssertionError(
+                'Incompatible version of pycocotools is installed. '
+                'Run pip uninstall pycocotools first. Then run pip '
+                'install mmpycocotools to install open-mmlab forked '
+                'pycocotools.')
 
         self.coco = COCO(ann_file)
         self.cat_ids = self.coco.get_cat_ids(cat_names=self.CLASSES)


### PR DESCRIPTION
Only check when it is used - this helps with #4565.

The rest of mmdet can still work with official pycocotools.