### PR TITLE
add bbox_overlaps for fp16 to save memory and keep speed

### DIFF
--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -72,14 +72,14 @@ class BboxOverlaps2D(object):
 
 
 def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
-    """Calculate overlap between two set of bboxes.    
-    
+    """Calculate overlap between two set of bboxes.
+
     FP16 Contributed by: https://github.com/li-phone
     Prove:
-        Assume bboxes1 is M x 4, bboxes2 is N x 4, when mode is 'iou', 
-        there are some new generated variable when calculating IOU 
-        using bbox_overlaps function: 
-        
+        Assume bboxes1 is M x 4, bboxes2 is N x 4, when mode is 'iou',
+        there are some new generated variable when calculating IOU
+        using bbox_overlaps function:
+
         1) is_aligned is False
             area1: M x 1
             area2: N x 1
@@ -89,34 +89,35 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
             overlap: M x N x 1
             union: M x N x 1
             ious: M x N x 1
-            
-            Total memory: 
-                S  = (9 x N x M + N + M) * 4 Byte, 
+
+            Total memory:
+                S = (9 x N x M + N + M) * 4 Byte,
                 9 x N x M large than N + M is always true when N and M >= 1.
-            
-            When using FP16, we can reduce: 
+
+            When using FP16, we can reduce:
                 R = (9 x N x M + N + M) * 4 / 2 Byte
-                
-            Given M = 40 (ground truth), N = 400000 (three anchor boxes in per grid, FPN, R-CNNs),
+
+            Given M = 40 (ground truth), N = 400000 (three anchor boxes
+            in per grid, FPN, R-CNNs),
                 R = 275 MB (one times)
-                
+
             A special case (dense detection), M = 512 (ground truth),
                 R = 3516 MB = 3.43 GB
-                
+
             When the batch size is B, reduce:
-                B x R 
-                
+                B x R
+
             Therefore, CUDA memory runs out frequently.
-            
+
             Experiments on GeForce RTX 2080Ti (11019 MiB):
-                        
+
             |   dtype   |   M   |   N   |   Use    |   Real   |   Ideal   |
             |:----:|:----:|:----:|:----:|:----:|:----:|
-            |   FP32   |   512   |   400000   |   8020 MiB    |   --   |   --   |
-            |   FP16   |   512   |   400000   |   4504 MiB    |   3516 MiB   | 3516 MiB |
-            |   FP32   |   40   |   400000   |   1540 MiB    |   --   |   --   |
-            |   FP16   |   40   |   400000   |   1264 MiB    |   276MiB   | 275 MiB |
-            
+            |   FP32   |   512 | 400000 | 8020 MiB |   --   |   --   |
+            |   FP16   |   512 | 400000 |   4504 MiB | 3516 MiB | 3516 MiB |
+            |   FP32   |   40 | 400000 |   1540 MiB |   --   |   --   |
+            |   FP16   |   40 | 400000 |   1264 MiB |   276MiB   | 275 MiB |
+
         2) is_aligned is True
             area1: N x 1
             area2: N x 1
@@ -126,20 +127,21 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
             overlap: N x 1
             union: N x 1
             ious: N x 1
-            
-            Total memory: 
+
+            Total memory:
                 S = 11 x N * 4 Byte
 
-            When using FP16, we can reduce: 
+            When using FP16, we can reduce:
                 R = 11 x N * 4 / 2 Byte
-        
+
         So do the 'giou' (large than 'iou').
-        
-        Time-wise, FP16 is generally faster than FP32.           
-        
-        When gpu_assign_thr is not -1, it takes more time on cpu but not reduce memory.
-        There, we can reduce half the memory and keep the speed.            
-                
+
+        Time-wise, FP16 is generally faster than FP32.
+
+        When gpu_assign_thr is not -1, it takes more time on cpu
+        but not reduce memory.
+        There, we can reduce half the memory and keep the speed.
+
     If ``is_aligned `` is ``False``, then calculate the overlaps between each
     bbox of bboxes1 and bboxes2, otherwise the overlaps between each aligned
     pair of bboxes1 and bboxes2.

--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -72,8 +72,74 @@ class BboxOverlaps2D(object):
 
 
 def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
-    """Calculate overlap between two set of bboxes.
+    """Calculate overlap between two set of bboxes.    
+    
+    FP16 Contributed by: https://github.com/li-phone
+    Prove:
+        Assume bboxes1 is M x 4, bboxes2 is N x 4, when mode is 'iou', 
+        there are some new generated variable when calculating IOU 
+        using bbox_overlaps function: 
+        
+        1) is_aligned is False
+            area1: M x 1
+            area2: N x 1
+            lt: M x N x 2
+            rb: M x N x 2
+            wh: M x N x 2
+            overlap: M x N x 1
+            union: M x N x 1
+            ious: M x N x 1
+            
+            Total memory: 
+                S  = (9 x N x M + N + M) * 4 Byte, 
+                9 x N x M large than N + M is always true when N and M >= 1.
+            
+            When using FP16, we can reduce: 
+                R = (9 x N x M + N + M) * 4 / 2 Byte
+                
+            Given M = 40 (ground truth), N = 400000 (three anchor boxes in per grid, FPN, R-CNNs),
+                R = 275 MB (one times)
+                
+            A special case (dense detection), M = 512 (ground truth),
+                R = 3516 MB = 3.43 GB
+                
+            When the batch size is B, reduce:
+                B x R 
+                
+            Therefore, CUDA memory runs out frequently.
+            
+            Experiments on GeForce RTX 2080Ti (11019 MiB):
+                        
+            |   dtype   |   M   |   N   |   Use    |   Real   |   Ideal   |
+            |:----:|:----:|:----:|:----:|:----:|:----:|
+            |   FP32   |   512   |   400000   |   8020 MiB    |   --   |   --   |
+            |   FP16   |   512   |   400000   |   4504 MiB    |   3516 MiB   | 3516 MiB |
+            |   FP32   |   40   |   400000   |   1540 MiB    |   --   |   --   |
+            |   FP16   |   40   |   400000   |   1264 MiB    |   276MiB   | 275 MiB |
+            
+        2) is_aligned is True
+            area1: N x 1
+            area2: N x 1
+            lt: N x 2
+            rb: N x 2
+            wh: N x 2
+            overlap: N x 1
+            union: N x 1
+            ious: N x 1
+            
+            Total memory: 
+                S = 11 x N * 4 Byte
 
+            When using FP16, we can reduce: 
+                R = 11 x N * 4 / 2 Byte
+        
+        So do the 'giou' (large than 'iou').
+        
+        Time-wise, FP16 is generally faster than FP32.           
+        
+        When gpu_assign_thr is not -1, it takes more time on cpu but not reduce memory.
+        There, we can reduce half the memory and keep the speed.            
+                
     If ``is_aligned `` is ``False``, then calculate the overlaps between each
     bbox of bboxes1 and bboxes2, otherwise the overlaps between each aligned
     pair of bboxes1 and bboxes2.

--- a/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
+++ b/mmdet/core/bbox/iou_calculators/iou2d_calculator.py
@@ -92,10 +92,12 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
 
             Total memory:
                 S = (9 x N x M + N + M) * 4 Byte,
-                9 x N x M large than N + M is always true when N and M >= 1.
 
             When using FP16, we can reduce:
                 R = (9 x N x M + N + M) * 4 / 2 Byte
+                R large than (N + M) * 4 * 2 is always true when N and M >= 1.
+                Obviously, N + M <= N * M < 3 * N * M, when N >=2 and M >=2,
+                           N + 1 < 3 * N, when N or M is 1.
 
             Given M = 40 (ground truth), N = 400000 (three anchor boxes
             in per grid, FPN, R-CNNs),


### PR DESCRIPTION
In GPU and CPU environments with limited hardware resources, bbox_overlaps often has CUDA memory allocation errors (there are a large number of anchor boxes when calculating IOU). To do this, we added bbox_overlaps on FP16 to save memory and keep speed at the same time. 
TO DO: 
all IOU calculation on fp16 including NMS.