### PR TITLE
[Fix]: fix mask AP of small/medium/large

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -2,10 +2,10 @@
 
 ## Mask AP Evaluation since MMDetection 2.12.0
 
-Before [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) and V2.13.0, the mask AP of small, medium, and large instances is calculated based on the bounding box area rather than the real mask area. This leads to higher APs and APm but lower APl but will not affect the overall mask AP. 
+Before [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) and V2.12.0, the mask AP of small, medium, and large instances is calculated based on the bounding box area rather than the real mask area. This leads to higher APs and APm but lower APl but will not affect the overall mask AP.
 [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) change it to use mask areas by deleting `bbox` in mask AP calculation.
 The new calculation is consistent with [Detectron2](https://github.com/facebookresearch/detectron2/).
- 
+
 ## Compatibility with MMDetection 1.x
 
 MMDetection 2.0 goes through a big refactoring and addresses many legacy issues. It is not compatible with the 1.x version, i.e., running inference with the same model weights in these two versions will produce different results. Thus, MMDetection 2.0 re-benchmarks all the models and provides their links and logs in the model zoo.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,10 +1,18 @@
-# Compatibility with MMDetection 1.x
+# Compatibility of MMDetection 2.x
+
+## Mask AP Evaluation
+
+Before [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898), the mask AP of small, medium, and large instances is calculated based on the bounding box area rather than the real mask area. This leads to higher APs and APm but lower APl but will not affect the overall mask AP. 
+[PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) change it to use mask areas by deleting `bbox` in mask AP calculation.
+The new calculation is consistent with [Detectron2](https://github.com/facebookresearch/detectron2/).
+ 
+## Compatibility with MMDetection 1.x
 
 MMDetection 2.0 goes through a big refactoring and addresses many legacy issues. It is not compatible with the 1.x version, i.e., running inference with the same model weights in these two versions will produce different results. Thus, MMDetection 2.0 re-benchmarks all the models and provides their links and logs in the model zoo.
 
 The major differences are in four folds: coordinate system, codebase conventions, training hyperparameters, and modular design.
 
-## Coordinate System
+### Coordinate System
 
 The new coordinate system is consistent with [Detectron2](https://github.com/facebookresearch/detectron2/) and treats the center of the most left-top pixel as (0, 0) rather than the left-top corner of that pixel.
 Accordingly, the system interprets the coordinates in COCO bounding box and segmentation annotations as coordinates in range `[0, width]` or `[0, height]`.
@@ -33,7 +41,7 @@ which is more natural and accurate.
 
   2. In MMDetection 2.0, the "`paste_mask()`" function is different and should be more accurate than those in previous versions. This change follows the modification in [Detectron2](https://github.com/facebookresearch/detectron2/blob/master/detectron2/structures/masks.py) and can improve mask AP on COCO by ~0.5% absolute.
 
-## Codebase Conventions
+### Codebase Conventions
 
 - MMDetection 2.0 changes the order of class labels to reduce unused parameters in regression and mask branch more naturally (without +1 and -1).
   This effect all the classification layers of the model to have a different ordering of class labels. The final layers of regression branch and mask head no longer keep K+1 channels for K categories, and their class orders are consistent with the classification branch.
@@ -59,7 +67,7 @@ which is more natural and accurate.
 
 - MMDetection V2.0 uses new ResNet Caffe backbones to reduce warnings when loading pre-trained models. Most of the new backbones' weights are the same as the former ones but do not have `conv.bias`, except that they use a different `img_norm_cfg`. Thus, the new backbone will not cause warning of unexpected keys.
 
-## Training Hyperparameters
+### Training Hyperparameters
 
 The change in training hyperparameters does not affect
 model-level compatibility but slightly improves the performance. The major ones are:
@@ -75,7 +83,7 @@ model-level compatibility but slightly improves the performance. The major ones 
 
 - The default warmup ratio is changed from 1/3 to 0.001 for a more smooth warming up process since the gradient clipping is usually not used. The effect is found negligible during our re-benchmarking, though.
 
-## Upgrade Models from 1.x to 2.0
+### Upgrade Models from 1.x to 2.0
 
 To convert the models trained by MMDetection V1.x to MMDetection V2.0, the users can use the script `tools/model_converters/upgrade_model_version.py` to convert
 their models. The converted models can be run in MMDetection V2.0 with slightly dropped performance (less than 1% AP absolute).

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,8 +1,8 @@
 # Compatibility of MMDetection 2.x
 
-## Mask AP Evaluation
+## Mask AP Evaluation since MMDetection 2.12.0
 
-Before [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898), the mask AP of small, medium, and large instances is calculated based on the bounding box area rather than the real mask area. This leads to higher APs and APm but lower APl but will not affect the overall mask AP. 
+Before [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) and V2.13.0, the mask AP of small, medium, and large instances is calculated based on the bounding box area rather than the real mask area. This leads to higher APs and APm but lower APl but will not affect the overall mask AP. 
 [PR 4898](https://github.com/open-mmlab/mmdetection/pull/4898) change it to use mask areas by deleting `bbox` in mask AP calculation.
 The new calculation is consistent with [Detectron2](https://github.com/facebookresearch/detectron2/).
  

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 import logging
 import os.path as osp
 import tempfile
@@ -445,10 +446,16 @@ class CocoDataset(CustomDataset):
                     # When evaluating mask AP, if the results contain bbox,
                     # cocoapi will use the box area instead of the mask area
                     # for calculating the instance area. Though the overall AP
-                    # is not affected, this leads to different small/medium/large
-                    # mask AP results.
+                    # is not affected, this leads to different
+                    # small/medium/large mask AP results.
                     for x in predictions:
                         x.pop('bbox')
+                    warnings.simplefilter('once')
+                    warnings.warn(
+                        'The key "bbox" is deleted for more accurate mask AP '
+                        'of small/medium/large instances since v2.13.0. This '
+                        'does not change the overall mAP calculation.',
+                        UserWarning)
                 cocoDt = cocoGt.loadRes(predictions)
             except IndexError:
                 print_log(

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -447,6 +447,16 @@ class CocoDataset(CustomDataset):
                 break
 
             iou_type = 'bbox' if metric == 'proposal' else metric
+            if iou_type == 'segm':
+                # Refer to https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/coco.py#L331  # noqa
+                # When evaluating mask AP, if the results contain bbox,
+                # cocoapi will use the box area instead of the mask area
+                # for calculating the instance area. Though the overall AP
+                # is not affected, this leads to different small/medium/large
+                # mask AP results.
+                for x in cocoDt['annotations']:
+                    x.pop('bbox', None)
+
             cocoEval = COCOeval(cocoGt, cocoDt, iou_type)
             cocoEval.params.catIds = self.cat_ids
             cocoEval.params.imgIds = self.img_ids

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -448,7 +448,7 @@ class CocoDataset(CustomDataset):
                     # is not affected, this leads to different small/medium/large
                     # mask AP results.
                     for x in predictions:
-                        x.pop('bbox', None)
+                        x.pop('bbox')
                 cocoDt = cocoGt.loadRes(predictions)
             except IndexError:
                 print_log(

--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -1,8 +1,8 @@
 import itertools
-import warnings
 import logging
 import os.path as osp
 import tempfile
+import warnings
 from collections import OrderedDict
 
 import mmcv


### PR DESCRIPTION
This PR delete the key `bbox` in the prediction results when calculating the mask AP of predictions.
When calculating `segm AP`, if key `bbox` is in the prediction, the area of instance will be calculated by the box area rather than the mask area, which will not affect the overall mask AP but will lead to a different mask APs of small/medium/large instances. A comparison is as below

|model|modification|mask AP|AP50|AP75|APs|APm|APl|
|:------:|:------:|:------:|:------:|:------:|:------:|:------:|:------:|
|[Mask R-CNN ms3x](https://github.com/open-mmlab/mmdetection/blob/master/configs/mask_rcnn/mask_rcnn_r50_caffe_fpn_mstrain-poly_3x_coco.py) ([ckpt](http://download.openmmlab.com/mmdetection/v2.0/mask_rcnn/mask_rcnn_r50_caffe_fpn_mstrain-poly_3x_coco/mask_rcnn_r50_caffe_fpn_mstrain-poly_3x_coco_bbox_mAP-0.408__segm_mAP-0.37_20200504_163245-42aa3d00.pth))|before|0.370 |0.584| 0.393| 0.205| 0.402 |0.497|
||after|0.370 |0.584| 0.393|0.182|0.395|0.520|
|[Cascade Mask R-CNN 1x](https://github.com/open-mmlab/mmdetection/blob/master/configs/cascade_rcnn/cascade_mask_rcnn_r50_caffe_fpn_1x_coco.py) ([ckpt](http://download.openmmlab.com/mmdetection/v2.0/cascade_rcnn/cascade_mask_rcnn_r50_caffe_fpn_1x_coco/cascade_mask_rcnn_r50_caffe_fpn_1x_coco_bbox_mAP-0.412__segm_mAP-0.36_20200504_174659-5004b251.pth))|before|0.360 |0.564 |0.387 |0.185 |0.387 |0.494|
||after|0.360 |0.564 |0.387|0.163|0.382|0.529|