### PR TITLE
Fix dynamic clip error in box coder for TensorRT

### DIFF
--- a/mmdet/core/export/onnx_helper.py
+++ b/mmdet/core/export/onnx_helper.py
@@ -21,19 +21,19 @@ def dynamic_clip_for_onnx(x1, y1, x2, y2, max_shape):
     assert isinstance(
         max_shape,
         torch.Tensor), '`max_shape` should be tensor of (h,w) for onnx'
-    h = max_shape[0].to(x1)
-    w = max_shape[1].to(x1)
-    zero = x1.new_tensor(0)
-    # clip by 0
-    x1 = torch.where(x1 < zero, zero, x1)
-    y1 = torch.where(y1 < zero, zero, y1)
-    x2 = torch.where(x2 < zero, zero, x2)
-    y2 = torch.where(y2 < zero, zero, y2)
-    # clip by h and w
-    x1 = torch.where(x1 > w, w, x1)
-    y1 = torch.where(y1 > h, h, y1)
-    x2 = torch.where(x2 > w, w, x2)
-    y2 = torch.where(y2 > h, h, y2)
+
+    x1 = x1 / max_shape[1]
+    y1 = y1 / max_shape[0]
+    x2 = x2 / max_shape[1]
+    y2 = y2 / max_shape[0]
+    x1 = torch.clamp(x1, 0, 1)
+    y1 = torch.clamp(y1, 0, 1)
+    x2 = torch.clamp(x2, 0, 1)
+    y2 = torch.clamp(y2, 0, 1)
+    x1 = x1 * max_shape[1]
+    y1 = y1 * max_shape[0]
+    x2 = x2 * max_shape[1]
+    y2 = y2 * max_shape[0]
     return x1, y1, x2, y2
 
 

--- a/mmdet/core/export/onnx_helper.py
+++ b/mmdet/core/export/onnx_helper.py
@@ -6,8 +6,8 @@ import torch
 def dynamic_clip_for_onnx(x1, y1, x2, y2, max_shape):
     """Clip boxes dynamically for onnx.
 
-    Since torch.clamp cannot have dynamic
-    `min` and `max`, we have to use torch.where to workaround.
+    Since torch.clamp cannot have dynamic `min` and `max`, we scale the
+      boxes by 1/max_shape and clamp in the range [0, 1].
 
     Args:
         x1 (Tensor): The x1 for bounding boxes.
@@ -22,14 +22,19 @@ def dynamic_clip_for_onnx(x1, y1, x2, y2, max_shape):
         max_shape,
         torch.Tensor), '`max_shape` should be tensor of (h,w) for onnx'
 
+    # scale by 1/max_shape
     x1 = x1 / max_shape[1]
     y1 = y1 / max_shape[0]
     x2 = x2 / max_shape[1]
     y2 = y2 / max_shape[0]
+
+    # clamp [0, 1]
     x1 = torch.clamp(x1, 0, 1)
     y1 = torch.clamp(y1, 0, 1)
     x2 = torch.clamp(x2, 0, 1)
     y2 = torch.clamp(y2, 0, 1)
+
+    # scale back
     x1 = x1 * max_shape[1]
     y1 = y1 * max_shape[0]
     x2 = x2 * max_shape[1]


### PR DESCRIPTION
Hi
This PR use `Tensor.clamp(0, 1)` instead of `torch.where` to fix the conversion error on two-stage detection models such as Faster-RCNN.