### PR TITLE
Fix vfnet and fcos reduce_mean

### DIFF
--- a/mmdet/models/dense_heads/fcos_head.py
+++ b/mmdet/models/dense_heads/fcos_head.py
@@ -226,17 +226,17 @@ class FCOSHead(AnchorFreeHead):
 
         pos_bbox_preds = flatten_bbox_preds[pos_inds]
         pos_centerness = flatten_centerness[pos_inds]
+        pos_bbox_targets = flatten_bbox_targets[pos_inds]
+        pos_centerness_targets = self.centerness_target(pos_bbox_targets)
+        # centerness weighted iou loss
+        centerness_denorm = max(
+            reduce_mean(pos_centerness_targets.sum().detach()), 1e-6)
 
         if len(pos_inds) > 0:
-            pos_bbox_targets = flatten_bbox_targets[pos_inds]
-            pos_centerness_targets = self.centerness_target(pos_bbox_targets)
             pos_points = flatten_points[pos_inds]
             pos_decoded_bbox_preds = distance2bbox(pos_points, pos_bbox_preds)
             pos_decoded_target_preds = distance2bbox(pos_points,
                                                      pos_bbox_targets)
-            # centerness weighted iou loss
-            centerness_denorm = max(
-                reduce_mean(pos_centerness_targets.sum().detach()), 1e-6)
             loss_bbox = self.loss_bbox(
                 pos_decoded_bbox_preds,
                 pos_decoded_target_preds,
@@ -623,7 +623,10 @@ class FCOSHead(AnchorFreeHead):
         # only calculate pos centerness targets, otherwise there may be nan
         left_right = pos_bbox_targets[:, [0, 2]]
         top_bottom = pos_bbox_targets[:, [1, 3]]
-        centerness_targets = (
-            left_right.min(dim=-1)[0] / left_right.max(dim=-1)[0]) * (
-                top_bottom.min(dim=-1)[0] / top_bottom.max(dim=-1)[0])
+        if len(left_right) == 0:
+            centerness_targets = left_right[..., 0]
+        else:
+            centerness_targets = (
+                left_right.min(dim=-1)[0] / left_right.max(dim=-1)[0]) * (
+                    top_bottom.min(dim=-1)[0] / top_bottom.max(dim=-1)[0])
         return torch.sqrt(centerness_targets)

--- a/mmdet/models/dense_heads/vfnet_head.py
+++ b/mmdet/models/dense_heads/vfnet_head.py
@@ -397,21 +397,21 @@ class VFNetHead(ATSSHead, FCOSHead):
         else:
             num_pos_avg_per_gpu = num_pos
 
-        if num_pos > 0:
-            pos_bbox_targets = flatten_bbox_targets[pos_inds]
-            pos_points = flatten_points[pos_inds]
+        pos_bbox_targets = flatten_bbox_targets[pos_inds]
+        pos_points = flatten_points[pos_inds]
 
-            pos_decoded_bbox_preds = distance2bbox(pos_points, pos_bbox_preds)
-            pos_decoded_target_preds = distance2bbox(pos_points,
-                                                     pos_bbox_targets)
-            iou_targets_ini = bbox_overlaps(
-                pos_decoded_bbox_preds,
-                pos_decoded_target_preds.detach(),
-                is_aligned=True).clamp(min=1e-6)
-            bbox_weights_ini = iou_targets_ini.clone().detach()
-            iou_targets_ini_avg_per_gpu = reduce_mean(
-                bbox_weights_ini.sum()).item()
-            bbox_avg_factor_ini = max(iou_targets_ini_avg_per_gpu, 1.0)
+        pos_decoded_bbox_preds = distance2bbox(pos_points, pos_bbox_preds)
+        pos_decoded_target_preds = distance2bbox(pos_points, pos_bbox_targets)
+        iou_targets_ini = bbox_overlaps(
+            pos_decoded_bbox_preds,
+            pos_decoded_target_preds.detach(),
+            is_aligned=True).clamp(min=1e-6)
+        bbox_weights_ini = iou_targets_ini.clone().detach()
+        iou_targets_ini_avg_per_gpu = reduce_mean(
+            bbox_weights_ini.sum()).item()
+        bbox_avg_factor_ini = max(iou_targets_ini_avg_per_gpu, 1.0)
+
+        if num_pos > 0:
             loss_bbox = self.loss_bbox(
                 pos_decoded_bbox_preds,
                 pos_decoded_target_preds.detach(),


### PR DESCRIPTION
resolved: #4724 

After modification and training, the mAP is as follows：


| model                                                        | modification | bbox_mAP | bbox_mAP_50 | bbox_mAP_75 |
| ------------------------------------------------------------ | ------------ | -------- | ----------- | ----------- |
| [FCOS](https://github.com/open-mmlab/mmdetection/tree/master/configs/fcos/fcos_center-normbbox-centeronreg-giou_r50_caffe_fpn_gn-head_dcn_1x_coco.py) | before       | 42.3     | 61.1        | 45.4        |
|                                                              | after        | 42.4     | 61.3        | 45.7        |
| [VFNet](https://github.com/open-mmlab/mmdetection/blob/master/configs/vfnet_r50_fpn_1x_coco.py) | before       | 41.6     | 59.5        | 45          |
|                                                              | after        | 41.6     | 59.5        | 44.7        |

