### PR TITLE
[Fix] Discard bboxes with sizes equals to min_bbox_size

### DIFF
--- a/mmdet/models/dense_heads/cascade_rpn_head.py
+++ b/mmdet/models/dense_heads/cascade_rpn_head.py
@@ -624,12 +624,12 @@ class StageCascadeRPNHead(RPNHead):
         ids = torch.cat(level_ids)
 
         # Skip nonzero op while exporting to ONNX
-        if cfg.min_bbox_size > 0 and (not torch.onnx.is_in_onnx_export()):
+        if cfg.min_bbox_size >= 0 and (not torch.onnx.is_in_onnx_export()):
             w = proposals[:, 2] - proposals[:, 0]
             h = proposals[:, 3] - proposals[:, 1]
             valid_inds = torch.nonzero(
-                (w >= cfg.min_bbox_size)
-                & (h >= cfg.min_bbox_size),
+                (w > cfg.min_bbox_size)
+                & (h > cfg.min_bbox_size),
                 as_tuple=False).squeeze()
             if valid_inds.sum().item() != len(proposals):
                 proposals = proposals[valid_inds, :]

--- a/mmdet/models/dense_heads/ga_rpn_head.py
+++ b/mmdet/models/dense_heads/ga_rpn_head.py
@@ -145,11 +145,11 @@ class GARPNHead(RPNTestMixin, GuidedAnchorHead):
             proposals = self.bbox_coder.decode(
                 anchors, rpn_bbox_pred, max_shape=img_shape)
             # filter out too small bboxes
-            if cfg.min_bbox_size > 0:
+            if cfg.min_bbox_size >= 0:
                 w = proposals[:, 2] - proposals[:, 0]
                 h = proposals[:, 3] - proposals[:, 1]
                 valid_inds = torch.nonzero(
-                    (w >= cfg.min_bbox_size) & (h >= cfg.min_bbox_size),
+                    (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size),
                     as_tuple=False).squeeze()
                 proposals = proposals[valid_inds, :]
                 scores = scores[valid_inds]

--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -218,12 +218,12 @@ class RPNHead(RPNTestMixin, AnchorHead):
              mlvl_ids) in zip(batch_mlvl_proposals, batch_mlvl_scores,
                               batch_mlvl_ids):
             # Skip nonzero op while exporting to ONNX
-            if cfg.min_bbox_size > 0 and (not torch.onnx.is_in_onnx_export()):
+            if cfg.min_bbox_size >= 0 and (not torch.onnx.is_in_onnx_export()):
                 w = mlvl_proposals[:, 2] - mlvl_proposals[:, 0]
                 h = mlvl_proposals[:, 3] - mlvl_proposals[:, 1]
                 valid_ind = torch.nonzero(
-                    (w >= cfg.min_bbox_size)
-                    & (h >= cfg.min_bbox_size),
+                    (w > cfg.min_bbox_size)
+                    & (h > cfg.min_bbox_size),
                     as_tuple=False).squeeze()
                 if valid_ind.sum().item() != len(mlvl_proposals):
                     mlvl_proposals = mlvl_proposals[valid_ind, :]


### PR DESCRIPTION
As described in #5005, sometimes anchor heads may produce proposals with `area == 0`, which brings errors during mask prediction (masks can not be predicted when the areas of bboxes are 0). A possible solution is setting `min_bbox_size` to a value larger than 0, but I suggest simply discarding all the proposals with `area == min_bbox_size` in anchor heads directly.