### PR TITLE
fix supplement_mask

### DIFF
--- a/mmdet/models/roi_heads/test_mixins.py
+++ b/mmdet/models/roi_heads/test_mixins.py
@@ -114,8 +114,8 @@ class BBoxTestMixin(object):
         cls_score = cls_score.reshape(batch_size, num_proposals_per_img, -1)
 
         if not torch.onnx.is_in_onnx_export():
-            # remove padding
-            supplement_mask = rois[..., -1] == 0
+            # remove padding, ignore batch_index when calculating mask
+            supplement_mask = rois.abs()[..., 1:].sum(dim=-1) == 0
             cls_score[supplement_mask, :] = 0
 
         # bbox_pred would be None in some detector when with_reg is False,
@@ -137,7 +137,7 @@ class BBoxTestMixin(object):
                 det_labels = []
                 for i in range(len(proposals)):
                     # remove padding
-                    supplement_mask = proposals[i][..., -1] == 0
+                    supplement_mask = proposals[i].abs().sum(dim=-1) == 0
                     for bbox in bbox_preds[i]:
                         bbox[supplement_mask] = 0
                     det_bbox, det_label = self.bbox_head.get_bboxes(
@@ -308,7 +308,7 @@ class MaskTestMixin(object):
             det_label = det_labels[i]
 
             # remove padding
-            supplement_mask = det_bbox[..., -1] != 0
+            supplement_mask = det_bbox.abs().sum(dim=-1) != 0
             mask_pred = mask_pred[supplement_mask]
             det_bbox = det_bbox[supplement_mask]
             det_label = det_label[supplement_mask]


### PR DESCRIPTION
Fix the bug when calculating supplement_mask.
Although the risk is low, the last number of a box has chances to be zero.
It may lead to inconsistent numbers of bbox_results and segm_results. And the evaluation process fails at
`File "/mnt/mmdet-dev/mmdetection/mmdet/datasets/coco.py", line 259, in _segm2json`
`if isinstance(segms[i]['counts'], bytes): `
`IndexError: list index out of range`.
 