### PR TITLE
change to import MultiScaleDeformableAttention from ops

### DIFF
--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -6,9 +6,9 @@ from mmcv.cnn import build_activation_layer, build_norm_layer, xavier_init
 from mmcv.cnn.bricks.registry import (TRANSFORMER_LAYER,
                                       TRANSFORMER_LAYER_SEQUENCE)
 from mmcv.cnn.bricks.transformer import (BaseTransformerLayer,
-                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence,
                                          build_transformer_layer_sequence)
+from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention
 from mmcv.runner.base_module import BaseModule
 from torch.nn.init import normal_
 


### PR DESCRIPTION
## Motivation
In order to be compatible with the latest mmcv, I fix the import of `MultiScaleDeformableAttention` .


## BC-breaking (Optional)
None

This pr should be merged after https://github.com/open-mmlab/mmcv/pull/978