### PR TITLE
Fix torch.chunk int32 overflow

### DIFF
--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -287,14 +287,14 @@ class FCNMaskHead(BaseModule):
         else:
             # GPU benefits from parallelism for larger chunks,
             # but may have memory issue
-            # 
-            # the types of img_w and img_h are np.int32, 
-            # when the image resolution is large, 
+            # the types of img_w and img_h are np.int32,
+            # when the image resolution is large,
             # the calculation of num_chunks will overflow.
             # so we neet to change the types of img_w and img_h to int.
             # See https://github.com/open-mmlab/mmdetection/pull/5191
             num_chunks = int(
-                np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
+                np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT /
+                        GPU_MEM_LIMIT))
             assert (num_chunks <=
                     N), 'Default GPU_MEM_LIMIT is too small; try increasing it'
         chunks = torch.chunk(torch.arange(N, device=device), num_chunks)

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -292,6 +292,7 @@ class FCNMaskHead(BaseModule):
             # when the image resolution is large, 
             # the calculation of num_chunks will overflow.
             # so we neet to change the types of img_w and img_h to int.
+            # See https://github.com/open-mmlab/mmdetection/pull/5191
             num_chunks = int(
                 np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
             assert (num_chunks <=

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -287,6 +287,11 @@ class FCNMaskHead(BaseModule):
         else:
             # GPU benefits from parallelism for larger chunks,
             # but may have memory issue
+            # 
+            # the types of img_w and img_h are np.int32, 
+            # when the image resolution is large, 
+            # the calculation of num_chunks will overflow.
+            # so we neet to change the types of img_w and img_h to int.
             num_chunks = int(
                 np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
             assert (num_chunks <=

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -288,7 +288,7 @@ class FCNMaskHead(BaseModule):
             # GPU benefits from parallelism for larger chunks,
             # but may have memory issue
             num_chunks = int(
-                np.ceil(N * img_h * img_w * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
+                np.ceil(N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT))
             assert (num_chunks <=
                     N), 'Default GPU_MEM_LIMIT is too small; try increasing it'
         chunks = torch.chunk(torch.arange(N, device=device), num_chunks)


### PR DESCRIPTION
## Environment

```
------------------------------------------------------------
sys.platform: win32
Python: 3.8.5 (default, Sep  3 2020, 21:29:08) [MSC v.1916 64 bit (AMD64)]
CUDA available: True
GPU 0: NVIDIA GeForce RTX 3090
CUDA_HOME: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.1
NVCC: Not Available
GCC: n/a
PyTorch: 1.8.1+cu111
PyTorch compiling details: PyTorch built with:
  - C++ Version: 199711
  - MSVC 192829913
  - Intel(R) Math Kernel Library Version 2020.0.2 Product Build 20200624 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v1.7.0 (Git Hash 7aed236906b1f7a05c0917e5257a1af05e9ff683)
  - OpenMP 2019
  - CPU capability usage: AVX2
  - CUDA Runtime 11.1
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_61,code=sm_61;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86;-gencode;arch=compute_37,code=compute_37
  - CuDNN 8.0.5
  - Magma 2.5.4
  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CUDA_VERSION=11.1, CUDNN_VERSION=8.0.5, CXX_COMPILER=C:/w/b/windows/tmp_bin/sccache-cl.exe, CXX_FLAGS=/DWIN32 /D_WINDOWS /GR /EHsc /w /bigobj -DUSE_PTHREADPOOL -openmp:experimental -DNDEBUG -DUSE_FBGEMM -DUSE_XNNPACK, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, TORCH_VERSION=1.8.1, USE_CUDA=ON, USE_CUDNN=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=OFF, USE_NNPACK=OFF, USE_OPENMP=ON,

TorchVision: 0.9.1+cu111
OpenCV: 4.5.1
MMCV: 1.3.4
MMCV Compiler: MSVC 191627045
MMCV CUDA Compiler: 11.1
MMDetection: 2.12.0+unknown
------------------------------------------------------------
```

Since I have fixed the bug, MMDetection version has become unknown. 

Don't worry, I installed mmdet via `pip install mmdet -U` .

## Error Log

```
Traceback (most recent call last):
  File "C:\Users\ypw\Desktop\aoi-server-v0.7.2\detect\utils_flask.py", line 53, in wrap
    func_result = func(*args, input_config=data, img=img, **kwargs)
  File "C:\Users\ypw\Desktop\aoi-server-v0.7.2\detect\app.py", line 87, in predict
    model_result = self.predictor.predict(img, **input_config)
  File "C:\Users\ypw\Desktop\aoi-server-v0.7.2\detect\predictor.py", line 89, in predict
    result = inference(model, cfg=pipeline, img=image, lock=self.lock)
  File "C:\Users\ypw\Desktop\aoi-server-v0.7.2\detect\utils_torchvision.py", line 87, in inference
    results = model(return_loss=False, rescale=True, **data)
  File "C:\Miniconda3\Lib\site-packages\torch\nn\modules\module.py", line 889, in _call_impl
    result = self.forward(*input, **kwargs)
  File "C:\Miniconda3\Lib\site-packages\mmcv\runner\fp16_utils.py", line 124, in new_func
    output = old_func(*new_args, **new_kwargs)
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\detectors\base.py", line 169, in forward
    return self.forward_test(img, img_metas, **kwargs)
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\detectors\base.py", line 153, in forward_test
    return self.aug_test(imgs, img_metas, **kwargs)
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\detectors\two_stage.py", line 193, in aug_test
    return self.roi_head.aug_test(
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\roi_heads\standard_roi_head.py", line 273, in aug_test
    segm_results = self.aug_test_mask(x, img_metas, det_bboxes,
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\roi_heads\test_mixins.py", line 362, in aug_test_mask
    segm_result = self.mask_head.get_seg_masks(
  File "C:\Miniconda3\Lib\site-packages\mmdet\models\roi_heads\mask_heads\fcn_mask_head.py", line 291, in get_seg_masks
    chunks = torch.chunk(torch.arange(N, device=device), num_chunks)
RuntimeError: chunk expects `chunks` to be greater than 0, got: -1
```

## Reason

Because the types of `img_w` and `img_h` are `np.int32`, when the image resolution is large, the calculation of `num_chunks` will overflow.

```
N * img_h * img_w * BYTES_PER_FLOAT
Out[16]: -1576238080

N * img_h * img_w * BYTES_PER_FLOAT / GPU_MEM_LIMIT
Out[18]: -1.4679861068725586
```

![mmdet_overflow](https://user-images.githubusercontent.com/10473170/119071550-99602e00-ba1c-11eb-99cd-d0ac20d154b8.png)

## Solution

Change the types of `img_w` and `img_h` to `int`.

```
N * int(img_h) * int(img_w) * BYTES_PER_FLOAT / GPU_MEM_LIMIT
Out[17]: 2.5320138931274414
```

Or... Use Linux. This error does not occur under Linux.

![image](https://user-images.githubusercontent.com/10473170/119071886-2c00cd00-ba1d-11eb-9a0a-78a68b780d0e.png)

```
In [3]: type(10000 * np.int32(10000))
Out[3]: numpy.int32
```

![image](https://user-images.githubusercontent.com/10473170/119071990-52bf0380-ba1d-11eb-887e-97c2c0497d50.png)

```
In [3]: type(10000 * np.int32(10000))
Out[3]: numpy.int64
```
