### PR TITLE
[Fix] Faster R-CNN fix in ONNX Runtime 

### DIFF
--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -218,7 +218,7 @@ class RPNHead(RPNTestMixin, AnchorHead):
             from mmdet.core.export import add_dummy_nms_for_onnx
             batch_mlvl_scores = batch_mlvl_scores.unsqueeze(2)
             score_threshold = cfg.nms.get('score_thr', 0.0)
-            nms_pre = cfg.get('deploy_nms_pre', cfg.max_per_img)
+            nms_pre = cfg.get('deploy_nms_pre', -1)
             dets, _ = add_dummy_nms_for_onnx(batch_mlvl_proposals,
                                              batch_mlvl_scores,
                                              cfg.max_per_img,

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -43,10 +43,11 @@ def pytorch2onnx(config_path,
     output_names = ['dets', 'labels']
     if model.with_mask:
         output_names.append('masks')
+    input_name = 'input'
     dynamic_axes = None
     if dynamic_export:
         dynamic_axes = {
-            'input': {
+            input_name: {
                 0: 'batch',
                 2: 'width',
                 3: 'height'
@@ -67,7 +68,7 @@ def pytorch2onnx(config_path,
         model,
         tensor_data,
         output_file,
-        input_names=['input'],
+        input_names=[input_name],
         output_names=output_names,
         export_params=True,
         keep_initializers_as_inputs=True,


### PR DESCRIPTION
## Motivation
In the current version of mmdetection, the quality of the Faster R-CNN model in ONNX Runtime has dropped.
This PR will fix it and return the quality as in the [table](https://github.com/open-mmlab/mmdetection/blob/master/docs/tutorials/pytorch2onnx.md#results-and-models).

To get the results I used `tools/deployment/test.py configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py --eval bbox`:
|   | master | fix_faster_rcnn |
|---|:------:|:---------------:|
| Average Precision  (AP) @[ IoU=0.50:0.95 , area=   all , maxDets=100 ]  | 0.370 | 0.374 |
| Average Precision  (AP) @[ IoU=0.75      , area=   all , maxDets=1000 ] | 0.575 | 0.582 |
| Average Precision  (AP) @[ IoU=0.50:0.95 , area= small , maxDets=1000 ] | 0.402 | 0.406 |
| Average Precision  (AP) @[ IoU=0.50      , area=   all , maxDets=1000 ] | 0.207 | 0.212 |
| Average Precision  (AP) @[ IoU=0.50:0.95 , area=medium , maxDets=1000 ] | 0.404 | 0.409 |
| Average Precision  (AP) @[ IoU=0.50:0.95 , area= large , maxDets=1000 ] | 0.481 | 0.481 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area=   all , maxDets=100 ]  | 0.502 | 0.517 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area=   all , maxDets=300 ]  | 0.502 | 0.517 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area=   all , maxDets=1000 ] | 0.502 | 0.517 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area= small , maxDets=1000 ] | 0.306 | 0.325 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area=medium , maxDets=1000 ] | 0.540 | 0.557 |
| Average Recall     (AR) @[ IoU=0.50:0.95 , area= large , maxDets=1000 ] | 0.641 | 0.648 |


## Modification

1. `mmdet/models/dense_heads/rpn_head.py`: Removed re-filtering with `nms_pre` before nms.
2. `tools/deployment/pytorch2onnx.py`: Moved the input name into a variable, since it is used twice.



