### PR TITLE
Update structures.py

### DIFF
--- a/mmdet/core/mask/structures.py
+++ b/mmdet/core/mask/structures.py
@@ -637,8 +637,8 @@ class PolygonMasks(BaseInstanceMasks):
                 resized_poly = []
                 for p in poly_per_obj:
                     p = p.copy()
-                    p[0::2] *= w_scale
-                    p[1::2] *= h_scale
+                    p[0::2] = p[0::2] * w_scale
+                    p[1::2] = p[1::2] * h_scale
                     resized_poly.append(p)
                 resized_masks.append(resized_poly)
             resized_masks = PolygonMasks(resized_masks, *out_shape)
@@ -690,8 +690,8 @@ class PolygonMasks(BaseInstanceMasks):
                 for p in poly_per_obj:
                     # pycocotools will clip the boundary
                     p = p.copy()
-                    p[0::2] -= bbox[0]
-                    p[1::2] -= bbox[1]
+                    p[0::2] = p[0::2] - bbox[0]
+                    p[1::2] = p[1::2] - bbox[1]
                     cropped_poly_per_obj.append(p)
                 cropped_masks.append(cropped_poly_per_obj)
             cropped_masks = PolygonMasks(cropped_masks, h, w)
@@ -736,12 +736,12 @@ class PolygonMasks(BaseInstanceMasks):
                 p = p.copy()
                 # crop
                 # pycocotools will clip the boundary
-                p[0::2] -= bbox[0]
-                p[1::2] -= bbox[1]
+                p[0::2] = p[0::2] - bbox[0]
+                p[1::2] = p[1::2] - bbox[1]
 
                 # resize
-                p[0::2] *= w_scale
-                p[1::2] *= h_scale
+                p[0::2] = p[0::2] * w_scale
+                p[1::2] = p[1::2] * h_scale
                 resized_mask.append(p)
             resized_masks.append(resized_mask)
         return PolygonMasks(resized_masks, *out_shape)


### PR DESCRIPTION
When I trained using **resnest** model, I faced the two types of errors in 'mmdet/core/mask/structures.py in resize and crop_and_resize': 
1. UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
2. UFuncTypeError: Cannot cast ufunc 'subtract' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'

These errors are the same kind of error : UFuncTypeError

So I checked it, then I found the problem is this kind of automatic type-casting on these operators (+=, -=, *=, /= ) is not supported in **numpy**.
Then I changed the operators calculating two different types as follows.

`p[0::2] *= w_scale` => `p[0::2] = p[0::2] * w_scale `

... and other few codes.

Now it works well!

My environment is as follows:

conda==4.10.1
torch==1.6.0
torchvision==0.7.0
numpy==1.19.2
mmcv-full==1.3.4
mmpycocotools==12.0.3
python==3.7.10

Thank you!


### Error Trace
```
---------------------------------------------------------------------------
UFuncTypeError                            Traceback (most recent call last)
<ipython-input-7-59b5768e9e45> in <module>
----> 1 train_detector(model, datasets[0], cfg, distributed=False, validate=True)

~/code/mmdetection_trash/mmdet/apis/train.py in train_detector(model, dataset, cfg, distributed, validate, timestamp, meta)
    168     elif cfg.load_from:
    169         runner.load_checkpoint(cfg.load_from)
--> 170     runner.run(data_loaders, cfg.workflow)

/opt/conda/lib/python3.7/site-packages/mmcv/runner/epoch_based_runner.py in run(self, data_loaders, workflow, max_epochs, **kwargs)
    123                     if mode == 'train' and self.epoch >= self._max_epochs:
    124                         break
--> 125                     epoch_runner(data_loaders[i], **kwargs)
    126 
    127         time.sleep(1)  # wait for some hooks like loggers to finish

/opt/conda/lib/python3.7/site-packages/mmcv/runner/epoch_based_runner.py in train(self, data_loader, **kwargs)
     45         self.call_hook('before_train_epoch')
     46         time.sleep(2)  # Prevent possible deadlock during epoch transition
---> 47         for i, data_batch in enumerate(self.data_loader):
     48             self._inner_iter = i
     49             self.call_hook('before_train_iter')

/opt/conda/lib/python3.7/site-packages/torch/utils/data/dataloader.py in __next__(self)
    361 
    362     def __next__(self):
--> 363         data = self._next_data()
    364         self._num_yielded += 1
    365         if self._dataset_kind == _DatasetKind.Iterable and \

/opt/conda/lib/python3.7/site-packages/torch/utils/data/dataloader.py in _next_data(self)
    401     def _next_data(self):
    402         index = self._next_index()  # may raise StopIteration
--> 403         data = self._dataset_fetcher.fetch(index)  # may raise StopIteration
    404         if self._pin_memory:
    405             data = _utils.pin_memory.pin_memory(data)

/opt/conda/lib/python3.7/site-packages/torch/utils/data/_utils/fetch.py in fetch(self, possibly_batched_index)
     42     def fetch(self, possibly_batched_index):
     43         if self.auto_collation:
---> 44             data = [self.dataset[idx] for idx in possibly_batched_index]
     45         else:
     46             data = self.dataset[possibly_batched_index]

/opt/conda/lib/python3.7/site-packages/torch/utils/data/_utils/fetch.py in <listcomp>(.0)
     42     def fetch(self, possibly_batched_index):
     43         if self.auto_collation:
---> 44             data = [self.dataset[idx] for idx in possibly_batched_index]
     45         else:
     46             data = self.dataset[possibly_batched_index]

~/code/mmdetection_trash/mmdet/datasets/custom.py in __getitem__(self, idx)
    192             return self.prepare_test_img(idx)
    193         while True:
--> 194             data = self.prepare_train_img(idx)
    195             if data is None:
    196                 idx = self._rand_another(idx)

~/code/mmdetection_trash/mmdet/datasets/custom.py in prepare_train_img(self, idx)
    215             results['proposals'] = self.proposals[idx]
    216         self.pre_pipeline(results)
--> 217         return self.pipeline(results)
    218 
    219     def prepare_test_img(self, idx):

~/code/mmdetection_trash/mmdet/datasets/pipelines/compose.py in __call__(self, data)
     38 
     39         for t in self.transforms:
---> 40             data = t(data)
     41             if data is None:
     42                 return None

~/code/mmdetection_trash/mmdet/datasets/pipelines/transforms.py in __call__(self, results)
    288         self._resize_img(results)
    289         self._resize_bboxes(results)
--> 290         self._resize_masks(results)
    291         self._resize_seg(results)
    292         return results

~/code/mmdetection_trash/mmdet/datasets/pipelines/transforms.py in _resize_masks(self, results)
    248                 continue
    249             if self.keep_ratio:
--> 250                 results[key] = results[key].rescale(results['scale'])
    251             else:
    252                 results[key] = results[key].resize(results['img_shape'][:2])

~/code/mmdetection_trash/mmdet/core/mask/structures.py in rescale(self, scale, interpolation)
    623             rescaled_masks = PolygonMasks([], new_h, new_w)
    624         else:
--> 625             rescaled_masks = self.resize((new_h, new_w))
    626         return rescaled_masks
    627 

~/code/mmdetection_trash/mmdet/core/mask/structures.py in resize(self, out_shape, interpolation)
    638                 for p in poly_per_obj:
    639                     p = p.copy()
--> 640                     p[0::2] *= w_scale
    641                     p[1::2] *= h_scale
    642                     resized_poly.append(p)

UFuncTypeError: Cannot cast ufunc 'multiply' output from dtype('float64') to dtype('int64') with casting rule 'same_kind'
```

