### PR TITLE
Make YOLOv3 neck more flexible

### DIFF
--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -109,7 +109,8 @@ class YOLOV3Neck(BaseModule):
         self.detect1 = DetectionBlock(in_channels[0], out_channels[0], **cfg)
         for i in range(1, self.num_scales):
             in_c, out_c = self.in_channels[i], self.out_channels[i]
-            self.add_module(f'conv{i}', ConvModule(out_channels[i - 1], out_c, 1, **cfg))
+            inter_c = out_channels[i - 1]
+            self.add_module(f'conv{i}', ConvModule(inter_c, out_c, 1, **cfg))
             # in_c + out_c : High-lvl feats will be cat with low-lvl feats
             self.add_module(f'detect{i+1}',
                             DetectionBlock(in_c + out_c, out_c, **cfg))

--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -109,7 +109,7 @@ class YOLOV3Neck(BaseModule):
         self.detect1 = DetectionBlock(in_channels[0], out_channels[0], **cfg)
         for i in range(1, self.num_scales):
             in_c, out_c = self.in_channels[i], self.out_channels[i]
-            self.add_module(f'conv{i}', ConvModule(in_c, out_c, 1, **cfg))
+            self.add_module(f'conv{i}', ConvModule(out_channels[i - 1], out_c, 1, **cfg))
             # in_c + out_c : High-lvl feats will be cat with low-lvl feats
             self.add_module(f'detect{i+1}',
                             DetectionBlock(in_c + out_c, out_c, **cfg))

--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -76,12 +76,13 @@ class YOLOV3Neck(BaseModule):
 
     Args:
         num_scales (int): The number of scales / stages.
-        in_channels (int): The number of input channels.
-        out_channels (int): The number of output channels.
-        conv_cfg (dict): Config dict for convolution layer. Default: None.
-        norm_cfg (dict): Dictionary to construct and config norm layer.
-            Default: dict(type='BN', requires_grad=True)
-        act_cfg (dict): Config dict for activation layer.
+        in_channels (List[int]): The number of input channels  per scale.
+        out_channels (List[int]): The number of output channels  per scale.
+        conv_cfg (dict, optional): Config dict for convolution layer.
+            Default: None.
+        norm_cfg (dict, optional): Dictionary to construct and config norm
+            layer. Default: dict(type='BN', requires_grad=True)
+        act_cfg (dict, optional): Config dict for activation layer.
             Default: dict(type='LeakyReLU', negative_slope=0.1).
         init_cfg (dict or list[dict], optional): Initialization config dict.
             Default: None

--- a/mmdet/models/necks/yolo_neck.py
+++ b/mmdet/models/necks/yolo_neck.py
@@ -76,7 +76,7 @@ class YOLOV3Neck(BaseModule):
 
     Args:
         num_scales (int): The number of scales / stages.
-        in_channels (List[int]): The number of input channels  per scale.
+        in_channels (List[int]): The number of input channels per scale.
         out_channels (List[int]): The number of output channels  per scale.
         conv_cfg (dict, optional): Config dict for convolution layer.
             Default: None.

--- a/tests/test_models/test_necks.py
+++ b/tests/test_models/test_necks.py
@@ -324,7 +324,7 @@ def test_yolov3_neck():
     # test more flexible setting
     s = 32
     in_channels = [32, 8, 16]
-    out_channels = [8, 16, 4]
+    out_channels = [19, 21, 5]
     feat_sizes = [s // 2**i for i in range(len(in_channels) - 1, -1, -1)]
     feats = [
         torch.rand(1, in_channels[i], feat_sizes[i], feat_sizes[i])


### PR DESCRIPTION
## Motivation
At the moment, YOLOV3Neck only allows to create neck architectures that have `out_channels[0] == in_channels[1]` and `out_channels[1] == i_channels[2]`. This is due to this line of code:

```
        for i in range(1, self.num_scales):
            in_c, out_c = self.in_channels[i], self.out_channels[i]
            self.add_module(f'conv{i}', ConvModule(in_c, out_c, 1, **cfg)) <<<---
            # in_c + out_c : High-lvl feats will be cat with low-lvl feats
            self.add_module(f'detect{i+1}',
                            DetectionBlock(in_c + out_c, out_c, **cfg))
```
It can be easily fixed to allow more flexible architectures without any backward compatibility issues.

It is convenient when you assemble YOLO-like architecture using some pretrained backbone, e.g. mobilenetv2_100 that has [320, 96, 32] channels in output feature maps. Current implementation enforces you to use very tight neck with [96, 32, X] channels. Less strict implementation will allow you to create a wider neck and increase your model's capacity.

## Modification
Change input channels of conv{i} layers in order to accept arbitrary number of output channels from the previous DetectionBlock.

## BC-breaking (Optional)
No breaking changes.
