### PR TITLE
Fix AugTest  of Cascade_MaskRCNN when len(det_bboxes) is 0

### DIFF
--- a/mmdet/models/roi_heads/cascade_roi_head.py
+++ b/mmdet/models/roi_heads/cascade_roi_head.py
@@ -459,9 +459,8 @@ class CascadeRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
 
         if self.with_mask:
             if det_bboxes.shape[0] == 0:
-                segm_result = [[[]
-                                for _ in range(self.mask_head[-1].num_classes)]
-                               ]
+                segm_result = [[]
+                               for _ in range(self.mask_head[-1].num_classes)]
             else:
                 aug_masks = []
                 aug_img_metas = []


### PR DESCRIPTION

## Motivation
In the original implementation, when do the AugTest of `cascade_mask`,   
https://github.com/open-mmlab/mmdetection/blob/68c2c1192a3e16987c8100d2d75abd15d7c39ea2/mmdet/models/roi_heads/cascade_roi_head.py#L462
The outermost `[]`  which means the `num_img`  should be deleted.

## BC-breaking (Optional)
None

resolve #5110 