### PR TITLE
Update YOLOv3 models

### DIFF
--- a/configs/yolo/README.md
+++ b/configs/yolo/README.md
@@ -21,7 +21,15 @@
 | :-------------: | :-----: | :-----: | :------: | :------------: | :----: | :------: | :--------: |
 |   DarkNet-53    |   320   |   273e  |   2.7    |      63.9      |  27.9  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_320_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_320_273e_coco/yolov3_d53_320_273e_coco-421362b6.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_320_273e_coco/yolov3_d53_320_273e_coco-20200819_172101.log.json) |
 |   DarkNet-53    |   416   |   273e  |   3.8    |      61.2      |  30.9  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-416_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-416_273e_coco/yolov3_d53_mstrain-416_273e_coco-2b60fcd9.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-416_273e_coco/yolov3_d53_mstrain-416_273e_coco-20200819_173424.log.json) |
-|   DarkNet-53    |   608   |   273e  |   7.1    |      48.1      |  33.4  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco-139f5633.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco-20200819_170820.log.json) |
+|   DarkNet-53    |   608   |   273e  |   7.4    |      48.1      |  33.7  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py) | [model]() &#124; [log]() |
+
+## Mixed Precision Training
+
+We also train YOLOv3 with mixed precision training.
+
+|    Backbone     |  Scale  | Lr schd | Mem (GB) | Inf time (fps) | box AP | Config | Download  |
+| :-------------: | :-----: | :-----: | :------: | :------------: | :----: | :------: | :--------: |
+|   DarkNet-53    |   608   |   273e  |   4.7    |      48.1      |  33.8  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py) | [model]() &#124; [log]() |
 
 ## Credit
 

--- a/configs/yolo/README.md
+++ b/configs/yolo/README.md
@@ -21,7 +21,7 @@
 | :-------------: | :-----: | :-----: | :------: | :------------: | :----: | :------: | :--------: |
 |   DarkNet-53    |   320   |   273e  |   2.7    |      63.9      |  27.9  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_320_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_320_273e_coco/yolov3_d53_320_273e_coco-421362b6.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_320_273e_coco/yolov3_d53_320_273e_coco-20200819_172101.log.json) |
 |   DarkNet-53    |   416   |   273e  |   3.8    |      61.2      |  30.9  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-416_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-416_273e_coco/yolov3_d53_mstrain-416_273e_coco-2b60fcd9.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-416_273e_coco/yolov3_d53_mstrain-416_273e_coco-20200819_173424.log.json) |
-|   DarkNet-53    |   608   |   273e  |   7.4    |      48.1      |  33.7  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py) | [model]() &#124; [log]() |
+|   DarkNet-53    |   608   |   273e  |   7.4    |      48.1      |  33.7  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco_20210518_115020-a2c3acb8.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco_20210518_115020.log.json) |
 
 ## Mixed Precision Training
 
@@ -29,7 +29,7 @@ We also train YOLOv3 with mixed precision training.
 
 |    Backbone     |  Scale  | Lr schd | Mem (GB) | Inf time (fps) | box AP | Config | Download  |
 | :-------------: | :-----: | :-----: | :------: | :------------: | :----: | :------: | :--------: |
-|   DarkNet-53    |   608   |   273e  |   4.7    |      48.1      |  33.8  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py) | [model]() &#124; [log]() |
+|   DarkNet-53    |   608   |   273e  |   4.7    |      48.1      |  33.8  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py) | [model](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_fp16_mstrain-608_273e_coco/yolov3_d53_fp16_mstrain-608_273e_coco_20210517_213542-4bc34944.pth) &#124; [log](http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_fp16_mstrain-608_273e_coco/yolov3_d53_fp16_mstrain-608_273e_coco_20210517_213542.log.json) |
 
 ## Credit
 

--- a/configs/yolo/metafile.yml
+++ b/configs/yolo/metafile.yml
@@ -52,7 +52,7 @@ Models:
         Dataset: COCO
         Metrics:
           box AP: 33.7
-    Weights:
+    Weights: http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco_20210518_115020-a2c3acb8.pth
 
   - Name: yolov3_d53_fp16_mstrain-608_273e_coco
     In Collection: YOLOv3
@@ -66,4 +66,4 @@ Models:
         Dataset: COCO
         Metrics:
           box AP: 33.7
-    Weights:
+    Weights: http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_fp16_mstrain-608_273e_coco/yolov3_d53_fp16_mstrain-608_273e_coco_20210517_213542-4bc34944.pth

--- a/configs/yolo/metafile.yml
+++ b/configs/yolo/metafile.yml
@@ -44,12 +44,26 @@ Models:
     In Collection: YOLOv3
     Config: configs/yolo/yolov3_d53_mstrain-608_273e_coco.py
     Metadata:
-      Training Memory (GB): 7.1
+      Training Memory (GB): 7.4
       inference time (s/im): 0.02079
       Epochs: 273
     Results:
       - Task: Object Detection
         Dataset: COCO
         Metrics:
-          box AP: 33.4
-    Weights: http://download.openmmlab.com/mmdetection/v2.0/yolo/yolov3_d53_mstrain-608_273e_coco/yolov3_d53_mstrain-608_273e_coco-139f5633.pth
+          box AP: 33.7
+    Weights:
+
+  - Name: yolov3_d53_fp16_mstrain-608_273e_coco
+    In Collection: YOLOv3
+    Config: configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py
+    Metadata:
+      Training Memory (GB): 4.7
+      inference time (s/im): 0.02079
+      Epochs: 273
+    Results:
+      - Task: Object Detection
+        Dataset: COCO
+        Metrics:
+          box AP: 33.7
+    Weights:

--- a/configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py
+++ b/configs/yolo/yolov3_d53_fp16_mstrain-608_273e_coco.py
@@ -1,0 +1,3 @@
+_base_ = './yolov3_d53_mstrain-608_273e_coco.py'
+# fp16 settings
+fp16 = dict(loss_scale='dynamic')


### PR DESCRIPTION
Update yolov3_d53_mstrain-608_273e_coco result after #5181 and add a model using fp16 training.

 Pre-trained weights and logs have been added.