### PR TITLE
fix get_cat_ids

### DIFF
--- a/mmdet/datasets/api_wrappers/coco_api.py
+++ b/mmdet/datasets/api_wrappers/coco_api.py
@@ -26,20 +26,14 @@ class COCO(_COCO):
     def get_ann_ids(self, img_ids=[], cat_ids=[], area_rng=[], iscrowd=None):
         return self.getAnnIds(img_ids, cat_ids, area_rng, iscrowd)
 
-    def get_cat_ids(self,
-                    cat_names=[],
-                    sup_names=[],
-                    cat_ids=[],
-                    keep_order=True):
-        if keep_order:
-            keep_order_cat_ids = []
-            # make cat_ids consistent with the order of class_name
-            for name in cat_names:
-                keep_order_cat_ids.append(
-                    self.getCatIds(name, sup_names, cat_ids)[0])
-            return keep_order_cat_ids
-        else:
-            return self.getCatIds(cat_names, sup_names, cat_ids)
+    def get_cat_ids(
+        self,
+        cat_names=[],
+        sup_names=[],
+        cat_ids=[],
+    ):
+
+        return self.getCatIds(cat_names, sup_names, cat_ids)
 
     def get_img_ids(self, img_ids=[], cat_ids=[]):
         return self.getImgIds(img_ids, cat_ids)

--- a/tests/test_data/test_datasets/test_coco_dataset.py
+++ b/tests/test_data/test_datasets/test_coco_dataset.py
@@ -47,59 +47,6 @@ def _create_ids_error_coco_json(json_name):
     mmcv.dump(fake_json, json_name)
 
 
-def _create_three_class(json_name):
-    image = {
-        'id': 0,
-        'width': 640,
-        'height': 640,
-        'file_name': 'fake_name.jpg',
-    }
-
-    annotation_1 = {
-        'id': 1,
-        'image_id': 0,
-        'category_id': 0,
-        'area': 400,
-        'bbox': [50, 60, 20, 20],
-        'iscrowd': 0,
-    }
-
-    annotation_2 = {
-        'id': 2,
-        'image_id': 0,
-        'category_id': 1,
-        'area': 900,
-        'bbox': [100, 120, 30, 30],
-        'iscrowd': 0,
-    }
-    annotation_3 = {
-        'id': 3,
-        'image_id': 0,
-        'category_id': 2,
-        'area': 900,
-        'bbox': [100, 120, 30, 30],
-        'iscrowd': 0,
-    }
-
-    categories = [{
-        'id': 0,
-        'name': 'person'
-    }, {
-        'id': 1,
-        'name': 'bicycle'
-    }, {
-        'id': 2,
-        'name': 'car'
-    }]
-
-    fake_json = {
-        'images': [image],
-        'annotations': [annotation_1, annotation_2, annotation_3],
-        'categories': categories
-    }
-    mmcv.dump(fake_json, json_name)
-
-
 def test_coco_annotation_ids_unique():
     tmp_dir = tempfile.TemporaryDirectory()
     fake_json_file = osp.join(tmp_dir.name, 'fake_data.json')
@@ -108,17 +55,3 @@ def test_coco_annotation_ids_unique():
     # test annotation ids not unique error
     with pytest.raises(AssertionError):
         CocoDataset(ann_file=fake_json_file, classes=('car', ), pipeline=[])
-
-
-def test_coco_ids_consisitent_with_name():
-    names1 = ('person', 'bicycle', 'car')
-    names2 = ('bicycle', 'car', 'person')
-    tmp_dir = tempfile.TemporaryDirectory()
-    three_class_json_file = osp.join(tmp_dir.name, 'three_class.json')
-    _create_three_class(three_class_json_file)
-    cat_names1 = CocoDataset(
-        ann_file=three_class_json_file, classes=names1, pipeline=[])
-    cat_names2 = CocoDataset(
-        ann_file=three_class_json_file, classes=names2, pipeline=[])
-    assert cat_names1.cat_ids == [0, 1, 2]
-    assert cat_names2.cat_ids == [1, 2, 0]


### PR DESCRIPTION

## Motivation
In https://github.com/open-mmlab/mmdetection/pull/5227/ , the modification about the `get_cat_ids` would  make the return `keep_order_cat_ids`  contains duplicate categories.



## BC-breaking (Optional)
None
