### PR TITLE
fix the return bbox of `multiclass_nms`  when no any bboxes

### DIFF
--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -77,9 +77,9 @@ def multiclass_nms(multi_bboxes,
             raise RuntimeError('[ONNX Error] Can not record NMS '
                                'as it has not been executed this time')
         if return_inds:
-            return bboxes, labels, inds
+            return bboxes.new_zeros(0, 5), labels, inds
         else:
-            return bboxes, labels
+            return bboxes.new_zeros(0, 5), labels
 
     dets, keep = batched_nms(bboxes, scores, labels, nms_cfg)
 


### PR DESCRIPTION
## Motivation
In the original implementation of `multiclass_nms`, 
https://github.com/open-mmlab/mmdetection/blob/52c935d27bb5873bc2821090178428f58a287554/mmdet/core/post_processing/bbox_nms.py#L82

 the return bboxes when  `bboxes.numel() == 0` has shape (num_bboxs, 4) which is not consistent with normal return tensor with shape (num_bbox, 5).


## BC-breaking (Optional)
None
