### PR TITLE
[Feature] Support non-bbox result show

### DIFF
--- a/mmdet/core/visualization/image.py
+++ b/mmdet/core/visualization/image.py
@@ -65,6 +65,8 @@ def imshow_det_bboxes(img,
         wait_time (float): Value of waitKey param. Default: 0.
         out_file (str, optional): The filename to write the image.
             Default: None
+        show_bbox (bool): Whether to show the bounding box in the image,
+            Default: True
 
     Returns:
         ndarray: The image with bboxes drawn on it.
@@ -157,10 +159,10 @@ def imshow_det_bboxes(img,
             img[mask] = img[mask] * 0.5 + color_mask * 0.5
 
     plt.imshow(img)
-
-    p = PatchCollection(
-        polygons, facecolor='none', edgecolors=color, linewidths=thickness)
-    ax.add_collection(p)
+    if show_bbox:
+        p = PatchCollection(
+            polygons, facecolor='none', edgecolors=color, linewidths=thickness)
+        ax.add_collection(p)
 
     stream, _ = canvas.print_to_buffer()
     buffer = np.frombuffer(stream, dtype='uint8')

--- a/mmdet/core/visualization/image.py
+++ b/mmdet/core/visualization/image.py
@@ -39,7 +39,8 @@ def imshow_det_bboxes(img,
                       win_name='',
                       show=True,
                       wait_time=0,
-                      out_file=None):
+                      out_file=None,
+                      show_bbox=True):
     """Draw bboxes and class labels (with scores) on an image.
 
     Args:

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -314,7 +314,8 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
                     for i, bbox in enumerate(bbox_result)
                 ]
             else:  # segm only
-                # estimate center of mask through segm_result
+                # Estimate the center of mask through segm_result
+                # so that the label is in the mask.
                 for scores, segms in \
                         zip(bbox_result, segm_result):
                     assert len(scores) == len(segms)

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -275,7 +275,7 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
 
         Args:
             img (str or Tensor): The image to be displayed.
-            result (Tensor or np.ndarray): The results to draw over `img`
+            result (tuple or np.ndarray): The results to draw over `img`
                 bbox_result or (bbox_result, segm_result).
             score_thr (float, optional): Minimum score of bboxes to be shown.
                 Default: 0.3.
@@ -307,15 +307,17 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
             bbox_result, segm_result = result
             if isinstance(segm_result, tuple):
                 segm_result = segm_result[0]  # ms rcnn
-            if bbox_result[0].shape[1] == 5:  # bbox-segm two stage
+            if bbox_result[0].shape[1] == 5:
+                # Show both bbox and mask
                 bboxes = np.vstack(bbox_result)
                 labels = [
                     np.full(bbox.shape[0], i, dtype=np.int32)
                     for i, bbox in enumerate(bbox_result)
                 ]
-            else:  # segm only
+            else:
+                # Show segmentation only
                 # Estimate the center of mask through segm_result
-                # so that the label is in the mask.
+                # so that the label can be displayed in the mask.
                 for scores, segms in \
                         zip(bbox_result, segm_result):
                     assert len(scores) == len(segms)
@@ -337,6 +339,7 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
                 ]
                 show_bbox = False
         else:
+            # Show bbox only
             bbox_result, segm_result = result, None
             bboxes = np.vstack(bbox_result)
             labels = [


### PR DESCRIPTION
In order to support one-stage instance segmentation(e.g. SOLO, SOLOv2 etc.), it is important to support non-bbox result show. Now this can support SOLO.

Simply using segm_result to estimate bbox and then display the result

Need to improve after mmdet supporting one-stage instance segmentation method.