### PR TITLE
[Feature] Skipping post-processing in Mask R-CNN

### DIFF
--- a/configs/_base_/models/mask_rcnn_r50_fpn.py
+++ b/configs/_base_/models/mask_rcnn_r50_fpn.py
@@ -117,4 +117,5 @@ model = dict(
             score_thr=0.05,
             nms=dict(type='nms', iou_threshold=0.5),
             max_per_img=100,
-            mask_thr_binary=0.5)))
+            mask_thr_binary=0.5,
+            rescale_mask_to_input_shape=True)))

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -35,8 +35,7 @@ class FCNMaskHead(BaseModule):
                  predictor_cfg=dict(type='Conv'),
                  loss_mask=dict(
                      type='CrossEntropyLoss', use_mask=True, loss_weight=1.0),
-                 init_cfg=None,
-                 rescale_mask_to_input_shape=True):
+                 init_cfg=None):
         assert init_cfg is None, 'To prevent abnormal initialization ' \
                                  'behavior, init_cfg is not allowed to be set'
         super(FCNMaskHead, self).__init__(init_cfg)
@@ -63,7 +62,6 @@ class FCNMaskHead(BaseModule):
         self.predictor_cfg = predictor_cfg
         self.fp16_enabled = False
         self.loss_mask = build_loss(loss_mask)
-        self.rescale_mask_to_input_shape = rescale_mask_to_input_shape
 
         self.convs = ModuleList()
         for i in range(self.num_convs):
@@ -340,7 +338,7 @@ class FCNMaskHead(BaseModule):
         if not self.class_agnostic:
             box_inds = torch.arange(mask_pred.shape[0])
             mask_pred = mask_pred[box_inds, labels][:, None]
-        if self.rescale_mask_to_input_shape:
+        if rcnn_test_cfg.rescale_mask_to_input_shape:
             masks, _ = _do_paste_mask(
                 mask_pred, bboxes, img_h, img_w, skip_empty=False)
         else:

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -322,7 +322,13 @@ class FCNMaskHead(BaseModule):
             ori_shape (Tuple): original image height and width, shape (2,)
 
         Returns:
-            Tensor: a mask of shape (N, img_h, img_w).
+            Tensor: tensor with masks.
+            If self.rescale_mask_to_input_shape == True,
+                then masks will be returned with the shape of the input image.
+                It will return masks with shape (N, img_h, img_w).
+            If self.rescale_mask_to_input_shape == False,
+                then post-processing will not be applied to masks.
+                It will return masks with shape (N, 28, 28).
         """
 
         mask_pred = mask_pred.sigmoid()

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -321,10 +321,10 @@ class FCNMaskHead(BaseModule):
 
         Returns:
             Tensor: tensor with masks.
-            If self.rescale_mask_to_input_shape == True,
+            If rcnn_test_cfg.rescale_mask_to_input_shape == True,
                 then masks will be returned with the shape of the input image.
                 It will return masks with shape (N, img_h, img_w).
-            If self.rescale_mask_to_input_shape == False,
+            If rcnn_test_cfg.rescale_mask_to_input_shape == False,
                 then post-processing will not be applied to masks.
                 It will return masks with shape (N, 28, 28).
         """
@@ -342,7 +342,7 @@ class FCNMaskHead(BaseModule):
             masks, _ = _do_paste_mask(
                 mask_pred, bboxes, img_h, img_w, skip_empty=False)
         else:
-            masks = mask_pred.squeeze()
+            masks = mask_pred.squeeze(dim=1)
         if threshold >= 0:
             masks = (masks >= threshold).to(dtype=torch.bool)
         return masks

--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -35,7 +35,8 @@ class FCNMaskHead(BaseModule):
                  predictor_cfg=dict(type='Conv'),
                  loss_mask=dict(
                      type='CrossEntropyLoss', use_mask=True, loss_weight=1.0),
-                 init_cfg=None):
+                 init_cfg=None,
+                 rescale_mask_to_input_shape=True):
         assert init_cfg is None, 'To prevent abnormal initialization ' \
                                  'behavior, init_cfg is not allowed to be set'
         super(FCNMaskHead, self).__init__(init_cfg)
@@ -62,6 +63,7 @@ class FCNMaskHead(BaseModule):
         self.predictor_cfg = predictor_cfg
         self.fp16_enabled = False
         self.loss_mask = build_loss(loss_mask)
+        self.rescale_mask_to_input_shape = rescale_mask_to_input_shape
 
         self.convs = ModuleList()
         for i in range(self.num_convs):
@@ -332,8 +334,11 @@ class FCNMaskHead(BaseModule):
         if not self.class_agnostic:
             box_inds = torch.arange(mask_pred.shape[0])
             mask_pred = mask_pred[box_inds, labels][:, None]
-        masks, _ = _do_paste_mask(
-            mask_pred, bboxes, img_h, img_w, skip_empty=False)
+        if self.rescale_mask_to_input_shape:
+            masks, _ = _do_paste_mask(
+                mask_pred, bboxes, img_h, img_w, skip_empty=False)
+        else:
+            masks = mask_pred.squeeze()
         if threshold >= 0:
             masks = (masks >= threshold).to(dtype=torch.bool)
         return masks

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -320,8 +320,9 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
         segm_results = self.mask_head.onnx_export(mask_pred, det_bboxes,
                                                   det_labels, self.test_cfg,
                                                   max_shape)
-        segm_results = segm_results.reshape(batch_size, num_det, max_shape[0],
-                                            max_shape[1])
+        segm_results = segm_results.reshape(batch_size, num_det,
+                                            segm_results.shape[1],
+                                            segm_results.shape[2])
         return segm_results
 
     def bbox_onnx_export(self, x, img_metas, proposals, rcnn_test_cfg,

--- a/tests/test_models/test_roi_heads/test_mask_head.py
+++ b/tests/test_models/test_roi_heads/test_mask_head.py
@@ -80,15 +80,18 @@ def test_can_skip_post_processing_in_onnx():
     det_bboxes = torch.rand([num_bboxes, 4], dtype=torch.float32)
     det_labels = torch.randint(0, num_classes, [num_bboxes], dtype=torch.int64)
     from mmcv.utils.config import ConfigDict
-    rcnn_test_cfg = ConfigDict({'mask_thr_binary': 0.5})
+    rcnn_test_cfg = ConfigDict({
+        'mask_thr_binary': 0.5,
+        'rescale_mask_to_input_shape': True
+    })
     ori_shape = torch.tensor(original_shape, dtype=torch.int64)
 
-    self.rescale_mask_to_input_shape = True
+    rcnn_test_cfg.rescale_mask_to_input_shape = True
     masks = self.onnx_export(mask_pred, det_bboxes, det_labels, rcnn_test_cfg,
                              ori_shape)
     assert masks.shape[1:] == torch.Size(original_shape)
 
-    self.rescale_mask_to_input_shape = False
+    rcnn_test_cfg.rescale_mask_to_input_shape = False
     masks = self.onnx_export(mask_pred, det_bboxes, det_labels, rcnn_test_cfg,
                              ori_shape)
     assert masks.shape[1:] == torch.Size(mask_shape)

--- a/tests/test_models/test_roi_heads/test_mask_head.py
+++ b/tests/test_models/test_roi_heads/test_mask_head.py
@@ -67,3 +67,28 @@ def test_mask_head_loss():
     loss_mask_iou = mask_iou_head.loss(pos_mask_iou_pred, mask_iou_targets)
     onegt_mask_iou_loss = loss_mask_iou['loss_mask_iou'].sum()
     assert onegt_mask_iou_loss.item() >= 0
+
+
+def test_can_skip_post_processing_in_onnx():
+    self = FCNMaskHead()
+    num_classes = 80
+    num_bboxes = 10
+    mask_shape = [28, 28]
+    original_shape = [800, 1200]
+    mask_pred = torch.rand(
+        [num_bboxes, num_classes] + mask_shape, dtype=torch.float32)
+    det_bboxes = torch.rand([num_bboxes, 4], dtype=torch.float32)
+    det_labels = torch.randint(0, num_classes, [num_bboxes], dtype=torch.int64)
+    from mmcv.utils.config import ConfigDict
+    rcnn_test_cfg = ConfigDict({'mask_thr_binary': 0.5})
+    ori_shape = torch.tensor(original_shape, dtype=torch.int64)
+
+    self.rescale_mask_to_input_shape = True
+    masks = self.onnx_export(mask_pred, det_bboxes, det_labels, rcnn_test_cfg,
+                             ori_shape)
+    assert masks.shape[1:] == torch.Size(original_shape)
+
+    self.rescale_mask_to_input_shape = False
+    masks = self.onnx_export(mask_pred, det_bboxes, det_labels, rcnn_test_cfg,
+                             ori_shape)
+    assert masks.shape[1:] == torch.Size(mask_shape)


### PR DESCRIPTION
## Motivation
When exporting Mask R-CNN model to ONNX, it may be useful to skip post-processing of masks.
Then the model will not require an additional `grid_sampler` operation from the MMCV and 
it will be possible to add custom post-processing to the original masks.

## Modification
* `mmdet/models/roi_heads/mask_heads/fcn_mask_head.py`: Added `rescale_mask_to_input_shape` attribute to `FCNMaskHead`. By default, its value is `True`. When `onnx_export` is called, the `rescale_mask_to_input_shape` value is checked and this determines the `_do_paste_mask` function will be called or not.
* `mmdet/models/roi_heads/standard_roi_head.py`: Now `onnx_export` can return a tensor with the shape (N, 28, 28), so I have changed some parameters of the `reshape` function.
* `tests/test_models/test_roi_heads/test_mask_head.py`: Added a test for checking the shape of masks with different `rescale_mask_to_input_shape` values.

## Use cases (Optional)
Example of export without post-processing:
```
pytorch2onnx.py config.py snapshot.pth --output-file config.onnx --cfg-options model.roi_head.mask_head.rescale_mask_to_input_shape=False --dynamic-export
```

