### PR TITLE
[Docs] Add FAQ about COCO AP or AR =-1 

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,5 +84,5 @@ We list some common troubles faced by many users and their corresponding solutio
 ## Evaluation
 
 - COCO Dataset, AP or AR = -1
-    1. According to COCO dataset definition, small area < 32x32, 32x32 < medium area < 96x96, large area > 96x96.
-    2. If the corresponding area has no object, the result of AP and AR will set to -1. [#4494](https://github.com/open-mmlab/mmdetection/issues/4494)
+    1. According to the definition of COCO dataset, the small and medium areas in an image are less than 1024 (32\*32), 9216 (96\*96), respectively.
+    2. If the corresponding area has no object, the result of AP and AR will set to -1.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -80,3 +80,9 @@ We list some common troubles faced by many users and their corresponding solutio
 - "RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one"
     1. This error indicates that your module has parameters that were not used in producing loss. This phenomenon may be caused by running different branches in your code in DDP mode.
     2. You can set ` find_unused_parameters = True` in the config to solve the above problems or find those unused parameters manually.
+
+## Evaluation
+
+- COCO Dataset, AP or AR = -1
+    1. According to COCO dataset definition, small area < 32^2^, 32^2^ < medium area < 96^2^, large area > 96^2^.
+    2. If the corresponding area has no object, the result of AP and AR will set to -1. [#4494](https://github.com/open-mmlab/mmdetection/issues/4494)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -84,5 +84,5 @@ We list some common troubles faced by many users and their corresponding solutio
 ## Evaluation
 
 - COCO Dataset, AP or AR = -1
-    1. According to COCO dataset definition, small area < 32^2^, 32^2^ < medium area < 96^2^, large area > 96^2^.
+    1. According to COCO dataset definition, small area < 32x32, 32x32 < medium area < 96x96, large area > 96x96.
     2. If the corresponding area has no object, the result of AP and AR will set to -1. [#4494](https://github.com/open-mmlab/mmdetection/issues/4494)


### PR DESCRIPTION
Sometimes COCO will get a result of  -1 in the evaluation. We explained this phenomenon.

![image](https://user-images.githubusercontent.com/48282753/121015075-2cdf8000-c7cd-11eb-8529-af5a335d7922.png)

According to [cocotools evaluate code](https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py) line 452
![image](https://user-images.githubusercontent.com/48282753/121015708-dde61a80-c7cd-11eb-9587-26d7efd01fb9.png)

If there are no small or medium objects, the value will be set to -1.

Resolves #4494 