### PR TITLE
[Docs] clarify installation document

### DIFF
--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -34,9 +34,6 @@ If mmcv and mmcv-full are both installed, there will be `ModuleNotFoundError`.
 
 ## Installation
 
-0. You can simply install mmdetection with the following commands:
-    `pip install mmdet`
-
 1. Create a conda virtual environment and activate it.
 
     ```shell
@@ -110,6 +107,12 @@ If mmcv and mmcv-full are both installed, there will be `ModuleNotFoundError`.
     ```shell
     pip install -r requirements/build.txt
     pip install -v -e .  # or "python setup.py develop"
+    ```
+
+    Or, you can simply install mmdetection with the following commands:
+
+    ```shell
+    pip install mmdet
     ```
 
 Note:


### PR DESCRIPTION
The origin `getting_start` markdown file is not clear at installing conda environment. 

Especially, `pip install mmdet` is not clear. So we clarify the way how to install conda environment. 

We remove 0.`pip install mmdet`, and create conda env first.
In step 5, we give two options to install mmdet.
```shell
    pip install -r requirements/build.txt
    pip install -v -e .  # or "python setup.py develop"
 ```

    Or, you can simply install mmdetection with the following commands:

```shell
    pip install mmdet
```
relevant issue: #5029
