### PR TITLE
[Enhancement] Add main to pytorch2onnx

### DIFF
--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -179,7 +179,7 @@ def pytorch2onnx(config_path,
         print('The numerical values are the same between Pytorch and ONNX')
 
 
-def parse_args():
+def parse_args(args_list=None):
     parser = argparse.ArgumentParser(
         description='Convert MMDetection models to ONNX')
     parser.add_argument('config', help='test config file path')
@@ -235,13 +235,11 @@ def parse_args():
         '--dynamic-export',
         action='store_true',
         help='Whether to export onnx with dynamic axis.')
-    args = parser.parse_args()
+    args = parser.parse_args(args=args_list)
     return args
 
 
-if __name__ == '__main__':
-    args = parse_args()
-
+def main(args):
     assert args.opset_version == 11, 'MMDet only support opset 11 now'
 
     if not args.input_img:
@@ -276,3 +274,7 @@ if __name__ == '__main__':
         do_simplify=args.simplify,
         cfg_options=args.cfg_options,
         dynamic_export=args.dynamic_export)
+
+
+if __name__ == '__main__':
+    main(parse_args())


### PR DESCRIPTION
## Motivation
This RP adds an argument list as an argument to the `parse_args` function, which makes it easier to use additional parsers.
The creation of an additional `main` function simplifies the use of wrappers over `pytorch2onnx`, because you can reuse argument handling.

## Modification
 `tools/deployment/pytorch2onnx.py`:
- Added an argument with a list of arguments to the `parse_args` function.
- Moved arguments handling with `pytorch2onnx` call to `main` function.

