### PR TITLE
fix the import path of msda

### DIFF
--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 
 import torch
 import torch.nn as nn
@@ -8,11 +9,19 @@ from mmcv.cnn.bricks.registry import (TRANSFORMER_LAYER,
 from mmcv.cnn.bricks.transformer import (BaseTransformerLayer,
                                          TransformerLayerSequence,
                                          build_transformer_layer_sequence)
-from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention
 from mmcv.runner.base_module import BaseModule
 from torch.nn.init import normal_
 
 from mmdet.models.utils.builder import TRANSFORMER
+
+try:
+    from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention
+
+except ImportError:
+    warnings.warn(
+        '`MultiScaleDeformableAttention` in MMCV has been moved to '
+        '`mmcv.ops.multi_scale_deform_attn`, please update your MMCV')
+    from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
 
 
 def inverse_sigmoid(x, eps=1e-5):

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -6,9 +6,9 @@ from mmcv.cnn import build_activation_layer, build_norm_layer, xavier_init
 from mmcv.cnn.bricks.registry import (TRANSFORMER_LAYER,
                                       TRANSFORMER_LAYER_SEQUENCE)
 from mmcv.cnn.bricks.transformer import (BaseTransformerLayer,
-                                         MultiScaleDeformableAttention,
                                          TransformerLayerSequence,
                                          build_transformer_layer_sequence)
+from mmcv.ops.multi_scale_deform_attn import MultiScaleDeformableAttention
 from mmcv.runner.base_module import BaseModule
 from torch.nn.init import normal_
 
@@ -384,7 +384,7 @@ class DeformableDetrTransformer(Transformer):
                 nn.init.xavier_uniform_(p)
         for m in self.modules():
             if isinstance(m, MultiScaleDeformableAttention):
-                m.init_weight()
+                m.init_weights()
         if not self.as_two_stage:
             xavier_init(self.reference_points, distribution='uniform', bias=0.)
         normal_(self.level_embeds)


### PR DESCRIPTION
## Motivation
In https://github.com/open-mmlab/mmcv/pull/978, `MultiScaleDeformableAttention` has been moved to `mmcv/ops/multi_scale_deform_attn.py`. We have to fix the import path of  `MultiScaleDeformableAttention`.

## BC-breaking
None
