### PR TITLE
Refactor anchor_generator and point_generator

### DIFF
--- a/mmdet/core/__init__.py
+++ b/mmdet/core/__init__.py
@@ -1,0 +1,6 @@
+from .anchor import *  # noqa: F401, F403
+from .bbox import *  # noqa: F401, F403
+from .evaluation import *  # noqa: F401, F403
+from .mask import *  # noqa: F401, F403
+from .post_processing import *  # noqa: F401, F403
+from .utils import *  # noqa: F401, F403

--- a/mmdet/core/__init__.py
+++ b/mmdet/core/__init__.py
@@ -1,6 +1,0 @@
-from .anchor import *  # noqa: F401, F403
-from .bbox import *  # noqa: F401, F403
-from .evaluation import *  # noqa: F401, F403
-from .mask import *  # noqa: F401, F403
-from .post_processing import *  # noqa: F401, F403
-from .utils import *  # noqa: F401, F403

--- a/mmdet/core/anchor/__init__.py
+++ b/mmdet/core/anchor/__init__.py
@@ -1,11 +1,13 @@
 from .anchor_generator import (AnchorGenerator, LegacyAnchorGenerator,
                                YOLOAnchorGenerator)
-from .builder import ANCHOR_GENERATORS, build_anchor_generator
-from .point_generator import PointGenerator
+from .builder import (ANCHOR_GENERATORS, PRIOR_GENERATORS,
+                      build_anchor_generator, build_prior_generator)
+from .point_generator import MlvlPointGenerator, PointGenerator
 from .utils import anchor_inside_flags, calc_region, images_to_levels
 
 __all__ = [
     'AnchorGenerator', 'LegacyAnchorGenerator', 'anchor_inside_flags',
     'PointGenerator', 'images_to_levels', 'calc_region',
-    'build_anchor_generator', 'ANCHOR_GENERATORS', 'YOLOAnchorGenerator'
+    'build_anchor_generator', 'ANCHOR_GENERATORS', 'YOLOAnchorGenerator',
+    'build_prior_generator', 'PRIOR_GENERATORS', 'MlvlPointGenerator'
 ]

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -268,7 +268,7 @@ class AnchorGenerator:
                       prior_idx,
                       featmap_size,
                       level_idx,
-                      dtype,
+                      dtype=torch.float32,
                       device='cuda'):
         """Generate sparse anchors according to the ``prior_idx``.
 
@@ -278,7 +278,8 @@ class AnchorGenerator:
             featmap_size (tuple[int]): feature map size arrange as (h, w).
             level_idx (int): The level index of corresponding feature
                 map.
-            dtype (obj:`torch.dtype`): Date type of points.
+            dtype (obj:`torch.dtype`): Date type of points.Defaults to
+                ``torch.float32``.
             device (obj:`torch.device`): The device where the points is
                 located.
         Returns:

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -212,7 +212,7 @@ class AnchorGenerator:
         Args:
             featmap_sizes (list[tuple]): List of feature map sizes in
                 multiple feature levels.
-            device (str): Device where the anchors will be put on.
+            device (str): The device where the anchors will be put on.
 
         Return:
             list[torch.Tensor]: Anchors in multiple feature levels. \
@@ -267,8 +267,8 @@ class AnchorGenerator:
             base_anchors (torch.Tensor): The base anchors of a feature grid.
             featmap_size (tuple[int]): Size of the feature maps.
             stride (tuple[int], optional): Stride of the feature map in order
-                (w, h). Defaults to (16, 16).
-            device (str, optional): Device the tensor will be put on.
+                (h, w). Defaults to (16, 16).
+            device (str, optional): The device the tensor will be put on.
                 Defaults to 'cuda'.
 
         Returns:
@@ -276,8 +276,9 @@ class AnchorGenerator:
         """
         # keep as Tensor, so that we can covert to ONNX correctly
         feat_h, feat_w = featmap_size
-        shift_x = torch.arange(0, feat_w, device=device) * stride[0]
-        shift_y = torch.arange(0, feat_h, device=device) * stride[1]
+        stride_w, stride_h = stride
+        shift_x = torch.arange(0, feat_w, device=device) * stride_w
+        shift_y = torch.arange(0, feat_h, device=device) * stride_h
 
         shift_xx, shift_yy = self._meshgrid(shift_x, shift_y)
         shifts = torch.stack([shift_xx, shift_yy, shift_xx, shift_yy], dim=-1)
@@ -299,7 +300,7 @@ class AnchorGenerator:
             featmap_sizes (list(tuple)): List of feature map sizes in
                 multiple feature levels.
             pad_shape (tuple): The padded shape of the image.
-            device (str): Device where the anchors will be put on.
+            device (str): The device where the anchors will be put on.
 
         Return:
             list(torch.Tensor): Valid flags of anchors in multiple levels.
@@ -327,10 +328,11 @@ class AnchorGenerator:
         """Generate the valid flags of anchor in a single feature map.
 
         Args:
-            featmap_size (tuple[int]): The size of feature maps.
+            featmap_size (tuple[int]): The size of feature maps, arrange
+                as (h, w).
             valid_size (tuple[int]): The valid size of the feature maps.
             num_base_anchors (int): The number of base anchors.
-            device (str, optional): Device where the flags will be put on.
+            device (str, optional): The device where the flags will be put on.
                 Defaults to 'cuda'.
 
         Returns:
@@ -361,11 +363,11 @@ class AnchorGenerator:
         Args:
             prior_indexs (Tensor): The index of corresponding anchors
                 in the feature map.
-            featmap_size (tuple[int]): feature map size arrange as (w, h).
+            featmap_size (tuple[int]): feature map size arrange as (h, w).
             level_idx (int): The level index of corresponding feature
                 map.
             dtype (obj:`torch.dtype`): Date type of points.
-            device (obj:`torch.device`): The Device where the points is
+            device (obj:`torch.device`): The device where the points is
                 located.
         Returns:
             Tensor: Anchor with shape (N, 4), N should be equal to

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -5,10 +5,10 @@ import numpy as np
 import torch
 from torch.nn.modules.utils import _pair
 
-from .builder import PRIORS_GENERATORS
+from .builder import PRIOR_GENERATORS
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class AnchorGenerator:
     """Standard anchor generator for 2D anchor-based detectors.
 
@@ -405,7 +405,7 @@ class AnchorGenerator:
         return repr_str
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class SSDAnchorGenerator(AnchorGenerator):
     """Anchor generator for SSD.
 
@@ -529,7 +529,7 @@ class SSDAnchorGenerator(AnchorGenerator):
         return repr_str
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class LegacyAnchorGenerator(AnchorGenerator):
     """Legacy anchor generator used in MMDetection V1.x.
 
@@ -628,7 +628,7 @@ class LegacyAnchorGenerator(AnchorGenerator):
         return base_anchors
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class LegacySSDAnchorGenerator(SSDAnchorGenerator, LegacyAnchorGenerator):
     """Legacy anchor generator used in MMDetection V1.x.
 
@@ -650,7 +650,7 @@ class LegacySSDAnchorGenerator(SSDAnchorGenerator, LegacyAnchorGenerator):
         self.base_anchors = self.gen_base_anchors()
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class YOLOAnchorGenerator(AnchorGenerator):
     """Anchor generator for YOLO.
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -237,7 +237,7 @@ class AnchorGenerator:
         warnings.warn('``grid_anchors`` would be deprecated soon. Please use '
                       '``grid_priors``')
         return self.grid_priors(
-            self, featmap_size=featmap_size, stride=stride, device=device)
+            featmap_size=featmap_size, stride=stride, device=device)
 
     def single_level_grid_anchors(self,
                                   base_anchors,
@@ -249,7 +249,6 @@ class AnchorGenerator:
             'Please use ``single_level_grid_priors`` ')
 
         return self.single_level_grid_priors(
-            self,
             base_anchors=base_anchors,
             featmap_size=featmap_size,
             stride=stride,

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -239,25 +239,6 @@ class AnchorGenerator:
         return self.grid_priors(
             self, featmap_size=featmap_size, stride=stride, device=device)
 
-    def sparse_priors(self, prior_indexs, featmap_size, level_idx, dtype,
-                      device):
-        """
-        Args:
-            prior_indexs (Tensor): .
-
-        """
-
-        height, width = featmap_size
-        num_anchors = self.num_base_anchors[level_idx]
-        anchor_id = prior_indexs % num_anchors
-        x = (prior_indexs // num_anchors) % width
-        y = (prior_indexs // width // num_anchors) % height
-        priors = torch.stack([x, y, x, y], 1).to(
-            dtype) * self.strides[level_idx][0] + self.base_anchors[level_idx][
-                anchor_id, :].to(device)
-
-        return priors
-
     def single_level_grid_anchors(self,
                                   base_anchors,
                                   featmap_size,
@@ -388,6 +369,25 @@ class AnchorGenerator:
         repr_str += f'{indent_str}centers={self.centers},\n'
         repr_str += f'{indent_str}center_offset={self.center_offset})'
         return repr_str
+
+    def sparse_priors(self, prior_indexs, featmap_size, level_idx, dtype,
+                      device):
+        """
+        Args:
+            prior_indexs (Tensor): .
+
+        """
+
+        height, width = featmap_size
+        num_anchors = self.num_base_anchors[level_idx]
+        anchor_id = prior_indexs % num_anchors
+        x = (prior_indexs // num_anchors) % width
+        y = (prior_indexs // width // num_anchors) % height
+        priors = torch.stack([x, y, x, y], 1).to(
+            dtype) * self.strides[level_idx][0] + self.base_anchors[level_idx][
+                anchor_id, :].to(device)
+
+        return priors
 
 
 @PRIORS_GENERATORS.register_module()

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -375,13 +375,14 @@ class AnchorGenerator:
         """
 
         height, width = featmap_size
-        num_anchors = self.num_base_anchors[level_idx]
-        anchor_id = prior_indexs % num_anchors
-        x = (prior_indexs // num_anchors) % width
-        y = (prior_indexs // width // num_anchors) % height
+        num_base_anchors = self.num_base_anchors[level_idx]
+        base_anchor_id = prior_indexs % num_base_anchors
+        x = (prior_indexs //
+             num_base_anchors) % width * self.strides[level_idx][0]
+        y = (prior_indexs // width //
+             num_base_anchors) % height * self.strides[level_idx][1]
         priors = torch.stack([x, y, x, y], 1).to(
-            dtype) * self.strides[level_idx][0] + self.base_anchors[level_idx][
-                anchor_id, :].to(device)
+            dtype) + self.base_anchors[level_idx][base_anchor_id, :].to(device)
 
         return priors
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -232,11 +232,11 @@ class AnchorGenerator:
             multi_level_anchors.append(anchors)
         return multi_level_anchors
 
-    def grid_anchors(self, featmap_size, device='cuda'):
+    def grid_anchors(self, featmap_sizes, device='cuda'):
 
         warnings.warn('``grid_anchors`` would be deprecated soon. Please use '
                       '``grid_priors``')
-        return self.grid_priors(featmap_size=featmap_size, device=device)
+        return self.grid_priors(featmap_sizes=featmap_sizes, device=device)
 
     def single_level_grid_anchors(self,
                                   base_anchors,

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -265,15 +265,15 @@ class AnchorGenerator:
         return all_anchors
 
     def sparse_priors(self,
-                      prior_idx,
+                      prior_idxs,
                       featmap_size,
                       level_idx,
                       dtype=torch.float32,
                       device='cuda'):
-        """Generate sparse anchors according to the ``prior_idx``.
+        """Generate sparse anchors according to the ``prior_idxs``.
 
         Args:
-            prior_idx (Tensor): The index of corresponding anchors
+            prior_idxs (Tensor): The index of corresponding anchors
                 in the feature map.
             featmap_size (tuple[int]): feature map size arrange as (h, w).
             level_idx (int): The level index of corresponding feature
@@ -284,15 +284,15 @@ class AnchorGenerator:
                 located.
         Returns:
             Tensor: Anchor with shape (N, 4), N should be equal to
-                the length of ``prior_idx``.
+                the length of ``prior_idxs``.
         """
 
         height, width = featmap_size
         num_base_anchors = self.num_base_anchors[level_idx]
-        base_anchor_id = prior_idx % num_base_anchors
-        x = (prior_idx //
+        base_anchor_id = prior_idxs % num_base_anchors
+        x = (prior_idxs //
              num_base_anchors) % width * self.strides[level_idx][0]
-        y = (prior_idx // width //
+        y = (prior_idxs // width //
              num_base_anchors) % height * self.strides[level_idx][1]
         priors = torch.stack([x, y, x, y], 1).to(dtype).to(device) + \
             self.base_anchors[level_idx][base_anchor_id, :].to(device)

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -267,7 +267,7 @@ class AnchorGenerator:
             base_anchors (torch.Tensor): The base anchors of a feature grid.
             featmap_size (tuple[int]): Size of the feature maps.
             stride (tuple[int], optional): Stride of the feature map in order
-                (h, w). Defaults to (16, 16).
+                (w, h). Defaults to (16, 16).
             device (str, optional): The device the tensor will be put on.
                 Defaults to 'cuda'.
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -232,12 +232,11 @@ class AnchorGenerator:
             multi_level_anchors.append(anchors)
         return multi_level_anchors
 
-    def grid_anchors(self, featmap_size, stride=16, device='cuda'):
+    def grid_anchors(self, featmap_size, device='cuda'):
 
         warnings.warn('``grid_anchors`` would be deprecated soon. Please use '
                       '``grid_priors``')
-        return self.grid_priors(
-            featmap_size=featmap_size, stride=stride, device=device)
+        return self.grid_priors(featmap_size=featmap_size, device=device)
 
     def single_level_grid_anchors(self,
                                   base_anchors,

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -294,8 +294,8 @@ class AnchorGenerator:
              num_base_anchors) % width * self.strides[level_idx][0]
         y = (prior_idx // width //
              num_base_anchors) % height * self.strides[level_idx][1]
-        priors = (torch.stack([x, y, x, y], 1).to(dtype) +
-                  self.base_anchors[level_idx][base_anchor_id, :]).to(device)
+        priors = torch.stack([x, y, x, y], 1).to(dtype).to(device) + \
+            self.base_anchors[level_idx][base_anchor_id, :].to(device)
 
         return priors
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -294,8 +294,8 @@ class AnchorGenerator:
              num_base_anchors) % width * self.strides[level_idx][0]
         y = (prior_idx // width //
              num_base_anchors) % height * self.strides[level_idx][1]
-        priors = torch.stack([x, y, x, y], 1).to(
-            dtype) + self.base_anchors[level_idx][base_anchor_id, :].to(device)
+        priors = (torch.stack([x, y, x, y], 1).to(dtype) +
+                  self.base_anchors[level_idx][base_anchor_id, :]).to(device)
 
         return priors
 

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -114,6 +114,12 @@ class AnchorGenerator:
     @property
     def num_base_anchors(self):
         """list[int]: total number of base anchors in a feature grid"""
+        return self.num_base_priors
+
+    @property
+    def num_base_priors(self):
+        """list[int]: The number of priors (anchors) at a point
+        on the feature grid"""
         return [base_anchors.size(0) for base_anchors in self.base_anchors]
 
     @property

--- a/mmdet/core/anchor/builder.py
+++ b/mmdet/core/anchor/builder.py
@@ -2,17 +2,17 @@ import warnings
 
 from mmcv.utils import Registry, build_from_cfg
 
-PRIORS_GENERATORS = Registry('Priors generator')
+PRIOR_GENERATORS = Registry('Generator for anchors and points')
 
-ANCHOR_GENERATORS = PRIORS_GENERATORS
+ANCHOR_GENERATORS = PRIOR_GENERATORS
 
 
-def build_priors_generator(cfg, default_args=None):
-    return build_from_cfg(cfg, ANCHOR_GENERATORS, default_args)
+def build_prior_generator(cfg, default_args=None):
+    return build_from_cfg(cfg, PRIOR_GENERATORS, default_args)
 
 
 def build_anchor_generator(cfg, default_args=None):
     warnings.warn(
         '``build_anchor_generator`` would be deprecated soon, please use '
-        '``build_priors_generator`` ')
-    return build_priors_generator(cfg, default_args=default_args)
+        '``build_prior_generator`` ')
+    return build_prior_generator(cfg, default_args=default_args)

--- a/mmdet/core/anchor/builder.py
+++ b/mmdet/core/anchor/builder.py
@@ -2,9 +2,9 @@ import warnings
 
 from mmcv.utils import Registry, build_from_cfg
 
-PROIRS_GENERATORS = Registry('Priors generator')
+PRIORS_GENERATORS = Registry('Priors generator')
 
-ANCHOR_GENERATORS = PROIRS_GENERATORS
+ANCHOR_GENERATORS = PRIORS_GENERATORS
 
 
 def build_priors_generator(cfg, default_args=None):

--- a/mmdet/core/anchor/builder.py
+++ b/mmdet/core/anchor/builder.py
@@ -1,7 +1,18 @@
+import warnings
+
 from mmcv.utils import Registry, build_from_cfg
 
-ANCHOR_GENERATORS = Registry('Anchor generator')
+PROIRS_GENERATORS = Registry('Priors generator')
+
+ANCHOR_GENERATORS = PROIRS_GENERATORS
+
+
+def build_priors_generator(cfg, default_args=None):
+    return build_from_cfg(cfg, ANCHOR_GENERATORS, default_args)
 
 
 def build_anchor_generator(cfg, default_args=None):
-    return build_from_cfg(cfg, ANCHOR_GENERATORS, default_args)
+    warnings.warn(
+        '``build_anchor_generator`` would be deprecated soon, please use '
+        '``build_priors_generator`` ')
+    return build_priors_generator(cfg, default_args=default_args)

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -203,15 +203,15 @@ class MlvlPointGenerator:
         return valid
 
     def sparse_priors(self,
-                      prior_idx,
+                      prior_idxs,
                       featmap_size,
                       level_idx,
                       dtype=torch.float32,
                       device='cuda'):
-        """Generate sparse points according to the ``prior_idx``.
+        """Generate sparse points according to the ``prior_idxs``.
 
         Args:
-            prior_idx (Tensor): The index of corresponding anchors
+            prior_idxs (Tensor): The index of corresponding anchors
                 in the feature map.
             featmap_size (tuple[int]): feature map size arrange as (w, h).
             level_idx (int): The level index of corresponding feature
@@ -222,12 +222,12 @@ class MlvlPointGenerator:
                 located.
         Returns:
             Tensor: Anchor with shape (N, 2), N should be equal to
-            the length of ``prior_idx``. And last dimension
+            the length of ``prior_idxs``. And last dimension
             2 represent (coord_x, coord_y).
         """
         height, width = featmap_size
-        x = (prior_idx % width + self.offset) * self.strides[level_idx][0]
-        y = ((prior_idx // width) % height +
+        x = (prior_idxs % width + self.offset) * self.strides[level_idx][0]
+        y = ((prior_idxs // width) % height +
              self.offset) * self.strides[level_idx][1]
         prioris = torch.stack([x, y], 1).to(dtype)
         prioris = prioris.to(device)

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -2,10 +2,10 @@ import numpy as np
 import torch
 from torch.nn.modules.utils import _pair
 
-from .builder import PRIORS_GENERATORS
+from .builder import PRIOR_GENERATORS
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class PointGenerator:
 
     def _meshgrid(self, x, y, row_major=True):
@@ -39,7 +39,7 @@ class PointGenerator:
         return valid
 
 
-@PRIORS_GENERATORS.register_module()
+@PRIOR_GENERATORS.register_module()
 class MlvlPointGenerator:
 
     def __init__(self, strides, offset=0.5):

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -206,7 +206,7 @@ class MlvlPointGenerator:
                       prior_idx,
                       featmap_size,
                       level_idx,
-                      dtype,
+                      dtype=torch.float32,
                       device='cuda'):
         """Generate sparse points according to the ``prior_idx``.
 
@@ -216,7 +216,8 @@ class MlvlPointGenerator:
             featmap_size (tuple[int]): feature map size arrange as (w, h).
             level_idx (int): The level index of corresponding feature
                 map.
-            dtype (obj:`torch.dtype`): Date type of points.
+            dtype (obj:`torch.dtype`): Date type of points. Defaults to
+                ``torch.float32``.
             device (obj:`torch.device`): The device where the points is
                 located.
         Returns:

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -60,6 +60,12 @@ class MlvlPointGenerator:
         """int: number of feature levels that the generator will be applied"""
         return len(self.strides)
 
+    @property
+    def num_base_priors(self):
+        """list[int]: The number of priors (points) at a point
+        on the feature grid"""
+        return [1 for _ in range(len(self.strides))]
+
     def _meshgrid(self, x, y, row_major=True):
         xx = x.repeat(len(y))
         yy = y.view(-1, 1).repeat(1, len(x)).view(-1)

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -41,7 +41,7 @@ class PointGenerator:
 
 @PRIOR_GENERATORS.register_module()
 class MlvlPointGenerator:
-    """Standard points generator for multi-level(Mlvl) feature maps in 2D
+    """Standard points generator for multi-level (Mlvl) feature maps in 2D
     points-based detectors.
 
     Args:

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -153,7 +153,8 @@ class MlvlPointGenerator:
             featmap_sizes (list(tuple)): List of feature map sizes in
                 multiple feature levels, each size arrange as
                 as (h, w).
-            pad_shape (tuple): The padded shape of the image.
+            pad_shape (tuple(int)): The padded shape of the image,
+                 arrange as (h, w).
             device (str): The device where the anchors will be put on.
 
         Return:

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -41,16 +41,17 @@ class PointGenerator:
 
 @PRIOR_GENERATORS.register_module()
 class MlvlPointGenerator:
+    """Standard points generator for multi-level(Mlvl) feature maps in 2D
+    points-based detectors.
+
+    Args:
+        strides (list[int] | list[tuple[int, int]]): Strides of anchors
+            in multiple feature levels in order (w, h).
+        offset (float): The offset of points, the value is normalized with
+            corresponding stride. Defaults to 0.5.
+    """
 
     def __init__(self, strides, offset=0.5):
-        """Standard points generator for 2D points-based detectors.
-
-        Args:
-            strides (list[int] | list[tuple[int, int]]): Strides of anchors
-                in multiple feature levels in order (w, h).
-            offset (float): The offset of points, the value is normalized with
-                corresponding stride. Defaults to 0.5.
-        """
         self.strides = [_pair(stride) for stride in strides]
         self.offset = offset
 

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -1,11 +1,12 @@
 import warnings
 
+import numpy as np
 import torch
 
-from .builder import PROIRS_GENERATORS
+from .builder import PRIORS_GENERATORS
 
 
-@PROIRS_GENERATORS.register_module()
+@PRIORS_GENERATORS.register_module()
 class PointGenerator:
 
     def _meshgrid(self, x, y, row_major=True):
@@ -44,11 +45,144 @@ class PointGenerator:
         valid = valid_xx & valid_yy
         return valid
 
-    def spares_priors(self, level_idx, featmap_size, dtype, device, topk_inds):
-        height, width = featmap_size
+    def sparse_priors(self, prior_indexs, featmap_size, level_idx, dtype,
+                      device):
 
-        x = topk_inds % width
-        y = (topk_inds // width) % height
+        height, width = featmap_size
+        x = prior_indexs % width
+        y = (prior_indexs // width) % height
+        prioris = torch.stack([x, y],
+                              1).to(dtype) * self.strides[level_idx] + (
+                                  self.strides[level_idx] // 2)
+        prioris = prioris.to(device)
+        return prioris
+
+
+@PRIORS_GENERATORS.register_module()
+class MlvlPointGenerator:
+
+    def __init__(self, strides):
+        """Standard anchor generator for 2D anchor-based detectors.
+
+        Args:
+            strides (list[int] | list[tuple[int, int]]): Strides of anchors
+                in multiple feature levels in order (w, h).
+        """
+        self.strides = strides
+
+    @property
+    def num_levels(self):
+        """int: number of feature levels that the generator will be applied"""
+        return len(self.strides)
+
+    def _meshgrid(self, x, y, row_major=True):
+        xx = x.repeat(len(y))
+        yy = y.view(-1, 1).repeat(1, len(x)).view(-1)
+        if row_major:
+            return xx, yy
+        else:
+            return yy, xx
+
+    def grid_priors(self, featmap_sizes, device='cuda'):
+        """Generate grid anchors in multiple feature levels.
+
+        Args:
+            featmap_sizes (list[tuple]): List of feature map sizes in
+                multiple feature levels.
+            device (str): Device where the anchors will be put on.
+
+        Return:
+            list[torch.Tensor]: Anchors in multiple feature levels. \
+                The sizes of each tensor should be [N, 4], where \
+                N = width * height * num_base_anchors, width and height \
+                are the sizes of the corresponding feature level, \
+                num_base_anchors is the number of anchors for that level.
+        """
+        assert self.num_levels == len(featmap_sizes)
+        multi_level_priors = []
+        for i in range(self.num_levels):
+            priors = self.single_level_grid_priors(
+                featmap_sizes[i], self.strides[i], device=device)
+            multi_level_priors.append(priors)
+        return multi_level_priors
+
+    def single_level_grid_priors(self,
+                                 featmap_size,
+                                 stride=(16, 16),
+                                 device='cuda'):
+        """Generate grid anchors of a single level.
+
+        Note:
+            This function is usually called by method ``self.grid_priors``.
+
+        Args:
+            base_anchors (torch.Tensor): The base anchors of a feature grid.
+            featmap_size (tuple[int]): Size of the feature maps.
+            stride (int, tuple[int], optional): Stride of the feature map
+                in order (w, h). Defaults to (16, 16).
+            device (str, optional): Device the tensor will be put on.
+                Defaults to 'cuda'.
+
+        Returns:
+            torch.Tensor: Anchors in the overall feature maps.
+        """
+        feat_h, feat_w = featmap_size
+        stride_w, stride_h = stride
+        shift_x = torch.arange(0., feat_w, device=device) * stride_w
+        shift_y = torch.arange(0., feat_h, device=device) * stride_h
+        shift_xx, shift_yy = self._meshgrid(shift_x, shift_y)
+        stride = shift_x.new_full((shift_xx.shape[0], ), stride)
+        shifts = torch.stack([shift_xx, shift_yy, stride], dim=-1)
+        all_points = shifts.to(device)
+        return all_points
+
+    def valid_flags(self, featmap_sizes, pad_shape, device='cuda'):
+        """Generate valid flags of anchors in multiple feature levels.
+
+        Args:
+            featmap_sizes (list(tuple)): List of feature map sizes in
+                multiple feature levels.
+            pad_shape (tuple): The padded shape of the image.
+            device (str): Device where the anchors will be put on.
+
+        Return:
+            list(torch.Tensor): Valid flags of anchors in multiple levels.
+        """
+        assert self.num_levels == len(featmap_sizes)
+        multi_level_flags = []
+        for i in range(self.num_levels):
+            point_stride = self.strides[i]
+            feat_h, feat_w = featmap_sizes[i]
+            h, w = pad_shape[:2]
+            valid_feat_h = min(int(np.ceil(h / point_stride[1])), feat_h)
+            valid_feat_w = min(int(np.ceil(w / point_stride[0])), feat_w)
+            flags = self.single_level_valid_flags((feat_h, feat_w),
+                                                  (valid_feat_h, valid_feat_w),
+                                                  device=device)
+            multi_level_flags.append(flags)
+        return multi_level_flags
+
+    def single_level_valid_flags(self,
+                                 featmap_size,
+                                 valid_size,
+                                 device='cuda'):
+        feat_h, feat_w = featmap_size
+        valid_h, valid_w = valid_size
+        assert valid_h <= feat_h and valid_w <= feat_w
+        valid_x = torch.zeros(feat_w, dtype=torch.bool, device=device)
+        valid_y = torch.zeros(feat_h, dtype=torch.bool, device=device)
+        valid_x[:valid_w] = 1
+        valid_y[:valid_h] = 1
+        valid_xx, valid_yy = self._meshgrid(valid_x, valid_y)
+        valid = valid_xx & valid_yy
+        return valid
+
+    def sparse_priors(self, level_idx, featmap_size, dtype, device,
+                      prior_indexs):
+
+        height, width = featmap_size
+        x = prior_indexs % width
+        y = (prior_indexs // width) % height
         prioris = torch.stack([x, y],
                               1).to(dtype) * self.strides[level_idx] + (
                                   self.strides[level_idx] // 2)

--- a/mmdet/core/anchor/point_generator.py
+++ b/mmdet/core/anchor/point_generator.py
@@ -69,8 +69,9 @@ class MlvlPointGenerator:
 
         Args:
             featmap_sizes (list[tuple]): List of feature map sizes in
-                multiple feature levels.
-            device (str): Device where the anchors will be put on.
+                multiple feature levels, each size arrange as
+                as (h, w).
+            device (str): The device where the anchors will be put on.
             with_stride (bool): Whether to concatenate the stride to
                 the last dimension of points.
 
@@ -97,7 +98,7 @@ class MlvlPointGenerator:
 
     def single_level_grid_priors(self,
                                  featmap_size,
-                                 stride=(16, 16),
+                                 stride=None,
                                  device='cuda',
                                  with_stride=False):
         """Generate grid Points of a single level.
@@ -106,10 +107,11 @@ class MlvlPointGenerator:
             This function is usually called by method ``self.grid_priors``.
 
         Args:
-            featmap_size (tuple[int]): Size of the feature maps.
+            featmap_size (tuple[int]): Size of the feature maps, arrange as
+                (h, w).
             stride (int, tuple[int], optional): Stride of the feature map
-                in order (w, h). Defaults to (16, 16).
-            device (str, optional): Device the tensor will be put on.
+                in order (w, h). Defaults to None.
+            device (str, optional): The device the tensor will be put on.
                 Defaults to 'cuda'.
             with_stride (bool): Concatenate the stride to the last dimension
                 of points.
@@ -144,9 +146,10 @@ class MlvlPointGenerator:
 
         Args:
             featmap_sizes (list(tuple)): List of feature map sizes in
-                multiple feature levels.
+                multiple feature levels, each size arrange as
+                as (h, w).
             pad_shape (tuple): The padded shape of the image.
-            device (str): Device where the anchors will be put on.
+            device (str): The device where the anchors will be put on.
 
         Return:
             list(torch.Tensor): Valid flags of points of multiple levels.
@@ -172,9 +175,11 @@ class MlvlPointGenerator:
         """Generate the valid flags of points of a single feature map.
 
         Args:
-            featmap_size (tuple[int]): The size of feature maps.
+            featmap_size (tuple[int]): The size of feature maps, arrange as
+                as (h, w).
             valid_size (tuple[int]): The valid size of the feature maps.
-            device (str, optional): Device where the flags will be put on.
+                The size arrange as as (h, w).
+            device (str, optional): The device where the flags will be put on.
                 Defaults to 'cuda'.
 
         Returns:
@@ -207,7 +212,7 @@ class MlvlPointGenerator:
             level_idx (int): The level index of corresponding feature
                 map.
             dtype (obj:`torch.dtype`): Date type of points.
-            device (obj:`torch.device`): The Device where the points is
+            device (obj:`torch.device`): The device where the points is
                 located.
         Returns:
             Tensor: Anchor with shape (N, 2), N should be equal to

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -367,7 +367,6 @@ class RepPointsHead(AnchorFreeHead):
                              gt_bboxes,
                              gt_bboxes_ignore,
                              gt_labels,
-                             label_channels=1,
                              stage='init',
                              unmap_outputs=True):
         inside_flags = valid_flags
@@ -499,7 +498,6 @@ class RepPointsHead(AnchorFreeHead):
              gt_bboxes_ignore_list,
              gt_labels_list,
              stage=stage,
-             label_channels=label_channels,
              unmap_outputs=unmap_outputs)
         # no valid points
         if any([labels is None for labels in all_labels]):

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -309,7 +309,7 @@ class RepPointsHead(AnchorFreeHead):
         # since feature map sizes of all images are the same, we only compute
         # points center for one time
         multi_level_points = self.point_generator.grid_priors(
-            featmap_sizes, device, with_stride=True)
+            featmap_sizes, device, with_stride=True, offset=0.)
         points_list = [[point.clone() for point in multi_level_points]
                        for _ in range(num_imgs)]
 

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -309,7 +309,7 @@ class RepPointsHead(AnchorFreeHead):
         # since feature map sizes of all images are the same, we only compute
         # points center for one time
         multi_level_points = self.point_generator.grid_priors(
-            featmap_sizes, device)
+            featmap_sizes, device, with_stride=True)
         points_list = [[point.clone() for point in multi_level_points]
                        for _ in range(num_imgs)]
 

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -4,8 +4,9 @@ import torch.nn as nn
 from mmcv.cnn import ConvModule
 from mmcv.ops import DeformConv2d
 
-from mmdet.core import (PointGenerator, build_assigner, build_sampler,
-                        images_to_levels, multi_apply, multiclass_nms, unmap)
+from mmdet.core import (build_assigner, build_sampler, images_to_levels,
+                        multi_apply, multiclass_nms, unmap)
+from mmdet.core.anchor.point_generator import MlvlPointGenerator
 from ..builder import HEADS, build_loss
 from .anchor_free_head import AnchorFreeHead
 
@@ -92,7 +93,7 @@ class RepPointsHead(AnchorFreeHead):
         self.gradient_mul = gradient_mul
         self.point_base_scale = point_base_scale
         self.point_strides = point_strides
-        self.point_generators = [PointGenerator() for _ in self.point_strides]
+        self.point_generator = MlvlPointGenerator(self.point_strides)
 
         self.sampling = loss_cls['type'] not in ['FocalLoss']
         if self.train_cfg:
@@ -304,31 +305,19 @@ class RepPointsHead(AnchorFreeHead):
             tuple: points of each image, valid flags of each image
         """
         num_imgs = len(img_metas)
-        num_levels = len(featmap_sizes)
 
         # since feature map sizes of all images are the same, we only compute
         # points center for one time
-        multi_level_points = []
-        for i in range(num_levels):
-            points = self.point_generators[i].grid_points(
-                featmap_sizes[i], self.point_strides[i], device)
-            multi_level_points.append(points)
+        multi_level_points = self.point_generator.grid_priors(
+            featmap_sizes, device)
         points_list = [[point.clone() for point in multi_level_points]
                        for _ in range(num_imgs)]
 
         # for each image, we compute valid flags of multi level grids
         valid_flag_list = []
         for img_id, img_meta in enumerate(img_metas):
-            multi_level_flags = []
-            for i in range(num_levels):
-                point_stride = self.point_strides[i]
-                feat_h, feat_w = featmap_sizes[i]
-                h, w = img_meta['pad_shape'][:2]
-                valid_feat_h = min(int(np.ceil(h / point_stride)), feat_h)
-                valid_feat_w = min(int(np.ceil(w / point_stride)), feat_w)
-                flags = self.point_generators[i].valid_flags(
-                    (feat_h, feat_w), (valid_feat_h, valid_feat_w), device)
-                multi_level_flags.append(flags)
+            multi_level_flags = self.point_generator.valid_flags(
+                featmap_sizes, img_meta['pad_shape'])
             valid_flag_list.append(multi_level_flags)
 
         return points_list, valid_flag_list
@@ -575,7 +564,6 @@ class RepPointsHead(AnchorFreeHead):
              img_metas,
              gt_bboxes_ignore=None):
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
-        assert len(featmap_sizes) == len(self.point_generators)
         device = cls_scores[0].device
         label_channels = self.cls_out_channels if self.use_sigmoid_cls else 1
 
@@ -677,24 +665,22 @@ class RepPointsHead(AnchorFreeHead):
             for pts_pred_refine in pts_preds_refine
         ]
         num_levels = len(cls_scores)
-        mlvl_points = [
-            self.point_generators[i].grid_points(cls_scores[i].size()[-2:],
-                                                 self.point_strides[i], device)
-            for i in range(num_levels)
+        featmap_sizes = [
+            cls_scores[i].size()[-2:] for i in range(len(cls_scores))
         ]
+        multi_level_points = self.point_generator.grid_priors(
+            featmap_sizes, device)
+
         result_list = []
         for img_id in range(len(img_metas)):
-            cls_score_list = [
-                cls_scores[i][img_id].detach() for i in range(num_levels)
-            ]
+            cls_score_list = [cls_scores[i][img_id] for i in range(num_levels)]
             bbox_pred_list = [
-                bbox_preds_refine[i][img_id].detach()
-                for i in range(num_levels)
+                bbox_preds_refine[i][img_id] for i in range(num_levels)
             ]
             img_shape = img_metas[img_id]['img_shape']
             scale_factor = img_metas[img_id]['scale_factor']
             proposals = self._get_bboxes_single(cls_score_list, bbox_pred_list,
-                                                mlvl_points, img_shape,
+                                                multi_level_points, img_shape,
                                                 scale_factor, cfg, rescale,
                                                 with_nms)
             result_list.append(proposals)

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -93,7 +93,8 @@ class RepPointsHead(AnchorFreeHead):
         self.gradient_mul = gradient_mul
         self.point_base_scale = point_base_scale
         self.point_strides = point_strides
-        self.point_generator = MlvlPointGenerator(self.point_strides)
+        self.point_generator = MlvlPointGenerator(
+            self.point_strides, offset=0.)
 
         self.sampling = loss_cls['type'] not in ['FocalLoss']
         if self.train_cfg:
@@ -309,7 +310,7 @@ class RepPointsHead(AnchorFreeHead):
         # since feature map sizes of all images are the same, we only compute
         # points center for one time
         multi_level_points = self.point_generator.grid_priors(
-            featmap_sizes, device, with_stride=True, offset=0.)
+            featmap_sizes, device, with_stride=True)
         points_list = [[point.clone() for point in multi_level_points]
                        for _ in range(num_imgs)]
 

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -15,7 +15,7 @@ def test_standard_points_generator():
         type='MlvlPointGenerator', strides=[4, 8], offset=0)
     anchor_generator = build_prior_generator(anchor_generator_cfg)
     assert anchor_generator is not None
-
+    assert anchor_generator.num_base_priors == [1, 1]
     # test_stride
     from mmdet.core.anchor import MlvlPointGenerator
 
@@ -277,6 +277,9 @@ def test_standard_anchor_generator():
         strides=[4, 8])
 
     anchor_generator = build_anchor_generator(anchor_generator_cfg)
+    assert anchor_generator.num_base_priors == \
+           anchor_generator.num_base_anchors
+    assert anchor_generator.num_base_priors == [3, 3]
     assert anchor_generator is not None
 
 

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -4,7 +4,59 @@ CommandLine:
     xdoctest tests/test_utils/test_anchor.py zero
 
 """
+import pytest
 import torch
+
+
+def test_standard_points_generator():
+    from mmdet.core.anchor import build_prior_generator
+    # teat init
+    anchor_generator_cfg = dict(
+        type='MlvlPointGenerator', strides=[4, 8], offset=0)
+    anchor_generator = build_prior_generator(anchor_generator_cfg)
+    assert anchor_generator is not None
+
+    # test_stride
+    from mmdet.core.anchor import MlvlPointGenerator
+
+    # Square strides
+    mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
+    mlvl_points_half_stride_generator = MlvlPointGenerator(
+        strides=[4, 10], offset=0.5)
+    assert mlvl_points.num_levels == 2
+
+    # assert self.num_levels == len(featmap_sizes)
+    with pytest.raises(AssertionError):
+        mlvl_points.grid_priors(featmap_sizes=[(2, 2)], device='cpu')
+    priors = mlvl_points.grid_priors(
+        featmap_sizes=[(2, 2), (4, 8)], device='cpu')
+    priors_with_stride = mlvl_points.grid_priors(
+        featmap_sizes=[(2, 2), (4, 8)], with_stride=True, device='cpu')
+    assert len(priors) == 2
+
+    # assert last dimension is (coord_x, coord_y, stride_w, stride_h).
+    assert priors_with_stride[0].size(1) == 4
+    assert priors_with_stride[0][0][2] == 4
+    assert priors_with_stride[0][0][3] == 4
+    assert priors_with_stride[1][0][2] == 10
+    assert priors_with_stride[1][0][3] == 10
+
+    stride_4_feat_2_2 = priors[0]
+    assert (stride_4_feat_2_2[1] - stride_4_feat_2_2[0]).sum() == 4
+    assert stride_4_feat_2_2.size(0) == 4
+    assert stride_4_feat_2_2.size(1) == 2
+
+    stride_10_feat_4_8 = priors[1]
+    assert (stride_10_feat_4_8[1] - stride_10_feat_4_8[0]).sum() == 10
+    assert stride_10_feat_4_8.size(0) == 4 * 8
+    assert stride_10_feat_4_8.size(1) == 2
+
+    # assert the offset of 0.5 * stride
+    priors_half_offset = mlvl_points_half_stride_generator.grid_priors(
+        featmap_sizes=[(2, 2), (4, 8)], device='cpu')
+
+    assert (priors_half_offset[0][0] - priors[0][0]).sum() == 4 * 0.5 * 2
+    assert (priors_half_offset[1][0] - priors[1][0]).sum() == 10 * 0.5 * 2
 
 
 def test_standard_anchor_generator():
@@ -17,6 +69,10 @@ def test_standard_anchor_generator():
 
     anchor_generator = build_anchor_generator(anchor_generator_cfg)
     assert anchor_generator is not None
+
+
+def test_sparse_prior():
+    pass
 
 
 def test_strides():

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -57,6 +57,49 @@ def test_standard_points_generator():
 
     assert (priors_half_offset[0][0] - priors[0][0]).sum() == 4 * 0.5 * 2
     assert (priors_half_offset[1][0] - priors[1][0]).sum() == 10 * 0.5 * 2
+    if torch.cuda.is_available():
+        anchor_generator_cfg = dict(
+            type='MlvlPointGenerator', strides=[4, 8], offset=0)
+        anchor_generator = build_prior_generator(anchor_generator_cfg)
+        assert anchor_generator is not None
+        # Square strides
+        mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
+        mlvl_points_half_stride_generator = MlvlPointGenerator(
+            strides=[4, 10], offset=0.5)
+        assert mlvl_points.num_levels == 2
+
+        # assert self.num_levels == len(featmap_sizes)
+        with pytest.raises(AssertionError):
+            mlvl_points.grid_priors(featmap_sizes=[(2, 2)], device='cuda')
+        priors = mlvl_points.grid_priors(
+            featmap_sizes=[(2, 2), (4, 8)], device='cuda')
+        priors_with_stride = mlvl_points.grid_priors(
+            featmap_sizes=[(2, 2), (4, 8)], with_stride=True, device='cuda')
+        assert len(priors) == 2
+
+        # assert last dimension is (coord_x, coord_y, stride_w, stride_h).
+        assert priors_with_stride[0].size(1) == 4
+        assert priors_with_stride[0][0][2] == 4
+        assert priors_with_stride[0][0][3] == 4
+        assert priors_with_stride[1][0][2] == 10
+        assert priors_with_stride[1][0][3] == 10
+
+        stride_4_feat_2_2 = priors[0]
+        assert (stride_4_feat_2_2[1] - stride_4_feat_2_2[0]).sum() == 4
+        assert stride_4_feat_2_2.size(0) == 4
+        assert stride_4_feat_2_2.size(1) == 2
+
+        stride_10_feat_4_8 = priors[1]
+        assert (stride_10_feat_4_8[1] - stride_10_feat_4_8[0]).sum() == 10
+        assert stride_10_feat_4_8.size(0) == 4 * 8
+        assert stride_10_feat_4_8.size(1) == 2
+
+        # assert the offset of 0.5 * stride
+        priors_half_offset = mlvl_points_half_stride_generator.grid_priors(
+            featmap_sizes=[(2, 2), (4, 8)], device='cuda')
+
+        assert (priors_half_offset[0][0] - priors[0][0]).sum() == 4 * 0.5 * 2
+        assert (priors_half_offset[1][0] - priors[1][0]).sum() == 10 * 0.5 * 2
 
 
 def test_sparse_prior():
@@ -72,6 +115,8 @@ def test_sparse_prior():
         featmap_size=featmap_sizes[0],
         level_idx=0,
         device='cpu')
+
+    assert not sparse_prior.is_cuda
     assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
     sparse_prior = mlvl_points.sparse_priors(
         prior_idx=prior_indexs,
@@ -100,6 +145,47 @@ def test_sparse_prior():
         level_idx=1,
         device='cpu')
     assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
+
+    if torch.cuda.is_available():
+        mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
+        prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
+
+        featmap_sizes = [(3, 5), (6, 4)]
+        grid_anchors = mlvl_points.grid_priors(
+            featmap_sizes=featmap_sizes, with_stride=False, device='cuda')
+        sparse_prior = mlvl_points.sparse_priors(
+            prior_idx=prior_indexs,
+            featmap_size=featmap_sizes[0],
+            level_idx=0,
+            device='cuda')
+        assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
+        sparse_prior = mlvl_points.sparse_priors(
+            prior_idx=prior_indexs,
+            featmap_size=featmap_sizes[1],
+            level_idx=1,
+            device='cuda')
+        assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
+        assert sparse_prior.is_cuda
+        from mmdet.core.anchor import AnchorGenerator
+        mlvl_anchors = AnchorGenerator(
+            strides=[16, 32], ratios=[1.], scales=[1.], base_sizes=[4, 8])
+        prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
+
+        featmap_sizes = [(3, 5), (6, 4)]
+        grid_anchors = mlvl_anchors.grid_priors(
+            featmap_sizes=featmap_sizes, device='cuda')
+        sparse_prior = mlvl_anchors.sparse_priors(
+            prior_idx=prior_indexs,
+            featmap_size=featmap_sizes[0],
+            level_idx=0,
+            device='cuda')
+        assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
+        sparse_prior = mlvl_anchors.sparse_priors(
+            prior_idx=prior_indexs,
+            featmap_size=featmap_sizes[1],
+            level_idx=1,
+            device='cuda')
+        assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
 
 
 def test_standard_anchor_generator():

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -62,14 +62,44 @@ def test_standard_points_generator():
 def test_sparse_prior():
     from mmdet.core.anchor import MlvlPointGenerator
     mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
-    prior_indexs = torch.Tensor([[0, 2, 4, 5, 6, 9]], dtype=torch.Long)
+    prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
 
     featmap_sizes = [(3, 5), (6, 4)]
     grid_anchors = mlvl_points.grid_priors(
-        featmap_sizes=featmap_sizes, with_stride=False)
+        featmap_sizes=featmap_sizes, with_stride=False, device='cpu')
     sparse_prior = mlvl_points.sparse_priors(
-        prior_indexs=prior_indexs, featmap_size=featmap_sizes[0], level_idx=0)
+        prior_idx=prior_indexs,
+        featmap_size=featmap_sizes[0],
+        level_idx=0,
+        device='cpu')
     assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
+    sparse_prior = mlvl_points.sparse_priors(
+        prior_idx=prior_indexs,
+        featmap_size=featmap_sizes[1],
+        level_idx=1,
+        device='cpu')
+    assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
+
+    from mmdet.core.anchor import AnchorGenerator
+    mlvl_anchors = AnchorGenerator(
+        strides=[16, 32], ratios=[1.], scales=[1.], base_sizes=[4, 8])
+    prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
+
+    featmap_sizes = [(3, 5), (6, 4)]
+    grid_anchors = mlvl_anchors.grid_priors(
+        featmap_sizes=featmap_sizes, device='cpu')
+    sparse_prior = mlvl_anchors.sparse_priors(
+        prior_idx=prior_indexs,
+        featmap_size=featmap_sizes[0],
+        level_idx=0,
+        device='cpu')
+    assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
+    sparse_prior = mlvl_anchors.sparse_priors(
+        prior_idx=prior_indexs,
+        featmap_size=featmap_sizes[1],
+        level_idx=1,
+        device='cpu')
+    assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
 
 
 def test_standard_anchor_generator():

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -59,6 +59,19 @@ def test_standard_points_generator():
     assert (priors_half_offset[1][0] - priors[1][0]).sum() == 10 * 0.5 * 2
 
 
+def test_sparse_prior():
+    from mmdet.core.anchor import MlvlPointGenerator
+    mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
+    prior_indexs = torch.Tensor([[0, 2, 4, 5, 6, 9]], dtype=torch.Long)
+
+    featmap_sizes = [(3, 5), (6, 4)]
+    grid_anchors = mlvl_points.grid_priors(
+        featmap_sizes=featmap_sizes, with_stride=False)
+    sparse_prior = mlvl_points.sparse_priors(
+        prior_indexs=prior_indexs, featmap_size=featmap_sizes[0], level_idx=0)
+    assert (sparse_prior == grid_anchors[0][prior_indexs]).all()
+
+
 def test_standard_anchor_generator():
     from mmdet.core.anchor import build_anchor_generator
     anchor_generator_cfg = dict(
@@ -69,10 +82,6 @@ def test_standard_anchor_generator():
 
     anchor_generator = build_anchor_generator(anchor_generator_cfg)
     assert anchor_generator is not None
-
-
-def test_sparse_prior():
-    pass
 
 
 def test_strides():

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -148,9 +148,10 @@ def test_sparse_prior():
 
     if torch.cuda.is_available():
         mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
-        prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
+        prior_indexs = torch.Tensor([0, 3, 4, 5, 6, 7, 1, 2, 4, 5, 6,
+                                     9]).long()
 
-        featmap_sizes = [(3, 5), (6, 4)]
+        featmap_sizes = [(6, 8), (6, 4)]
         grid_anchors = mlvl_points.grid_priors(
             featmap_sizes=featmap_sizes, with_stride=False, device='cuda')
         sparse_prior = mlvl_points.sparse_priors(
@@ -166,12 +167,14 @@ def test_sparse_prior():
             device='cuda')
         assert (sparse_prior == grid_anchors[1][prior_indexs]).all()
         assert sparse_prior.is_cuda
-        from mmdet.core.anchor import AnchorGenerator
         mlvl_anchors = AnchorGenerator(
-            strides=[16, 32], ratios=[1.], scales=[1.], base_sizes=[4, 8])
-        prior_indexs = torch.Tensor([0, 2, 4, 5, 6, 9]).long()
+            strides=[16, 32],
+            ratios=[1., 2.5],
+            scales=[1., 5.],
+            base_sizes=[4, 8])
+        prior_indexs = torch.Tensor([4, 5, 6, 7, 0, 2, 50, 4, 5, 6, 9]).long()
 
-        featmap_sizes = [(3, 5), (6, 4)]
+        featmap_sizes = [(13, 5), (16, 4)]
         grid_anchors = mlvl_anchors.grid_priors(
             featmap_sizes=featmap_sizes, device='cuda')
         sparse_prior = mlvl_anchors.sparse_priors(

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -149,7 +149,7 @@ def test_sparse_prior():
     if torch.cuda.is_available():
         mlvl_points = MlvlPointGenerator(strides=[4, 10], offset=0)
         prior_indexs = torch.Tensor([0, 3, 4, 5, 6, 7, 1, 2, 4, 5, 6,
-                                     9]).long()
+                                     9]).long().cuda()
 
         featmap_sizes = [(6, 8), (6, 4)]
         grid_anchors = mlvl_points.grid_priors(


### PR DESCRIPTION
## Motivation
As an essential step of unifying the `get_bboxes` of `anchor_head` and `anchor_free_head`, we need to design a more unified interface for the generation of anchors and points.

## Modification 
1. Rename the ``ANCHOR_GENERATORS`` to  ``PROIRS_GENERATORS``.
2. Add  `MlvlPointGenerator` which follow the logic of `AnchorGenerator`.
3. Add `spares_priors` to all `AnchorGenerator` and `PointGenerator` 
4. Rename `grid_anchors` and `grid_points` to `grid_priors`.
5. Add a more unified function as `single_level_grid_priors` to `AnchorGenerator` which follow the original implementation as `single_level_grid_anchors`, but we remove the `base_anchors` and `strides` from dataflow and add `level_idx` to be consistent with `MlvlPointGenerator`

## BC-Breaking
None.
I retain all the original interfaces and add deprecated warnings.