### PR TITLE
allow to configure out the mask_head of the HTC algorithm

### DIFF
--- a/mmdet/models/roi_heads/htc_roi_head.py
+++ b/mmdet/models/roi_heads/htc_roi_head.py
@@ -25,7 +25,7 @@ class HybridTaskCascadeRoIHead(CascadeRoIHead):
                  **kwargs):
         super(HybridTaskCascadeRoIHead,
               self).__init__(num_stages, stage_loss_weights, **kwargs)
-        assert self.with_bbox and self.with_mask
+        assert self.with_bbox
         assert not self.with_shared_head  # shared head is not supported
 
         if semantic_head is not None:


### PR DESCRIPTION
## Motivation
Originally the HTC algorithm it is intended to be used for Instance Segmentation. Nevertheless it is one of the best SOTA algorithms for Object Detection which is living in the mmdetection framework. The HTC algorithm has an interleaved execution of bbox_heads and mask_heads. For Object Detection only the bbox_heads are needed. The design of the HTC algorithms allows to remove the mask_head while the bbox_head keeps working.

## Modification
To get the above mentioned feature working, only the assert for the mask_head has to be removed. This allows to use config files with no mask_head configured, while still being able to use the bbox_head parts of the algorithm. Also all other configurations will still work. Please advice me if I have missed situations where the assert is really needed and therefore more code has to be changed. 

## Use cases
- Use HTC for Object Detection only
- Train custom HTC Object-Detection part (bbox_head) without the need to provide mask annotation data. 
