### PR TITLE
fix shape error in code annotation of auto-assign

### DIFF
--- a/mmdet/models/dense_heads/autoassign_head.py
+++ b/mmdet/models/dense_heads/autoassign_head.py
@@ -484,7 +484,7 @@ class AutoAssignHead(FCOSHead):
 
         Args:
             gt_bboxes (Tensor): gt_bbox of single image, has shape
-                (num_gt,)
+                (num_gt, 4).
             points (Tensor): Points of all fpn level, has shape
                 (num_points, 2).
 


### PR DESCRIPTION
## Motivation
I am viewing source code of auto-assign. When I read the function "_get_target_single(self, gt_bboxes, points)", I find that there is a small mistake in the function annotation. 

## Modification
See the changes, below. Just small modification.

