### PR TITLE
[Fix] fix default type of scale_factor during onnx export

### DIFF
--- a/mmdet/core/export/pytorch2onnx.py
+++ b/mmdet/core/export/pytorch2onnx.py
@@ -153,7 +153,7 @@ def preprocess_example_input(input_config):
         'ori_shape': (H, W, C),
         'pad_shape': (H, W, C),
         'filename': '<demo>.png',
-        'scale_factor': np.ones(4),
+        'scale_factor': np.ones(4, dtype=np.float32),
         'flip': False,
         'show_img': show_img,
     }


### PR DESCRIPTION
## Motivation

The default type of `scale_factor` in `one_meta` (Line 123 in pytorch2onnx.py) is double. That leads to the type error when exporting Mask R-CNN to ONNX.

Change the default type to float32.

## The type error

RuntimeError: expected scalar type Float but found Double.
