### PR TITLE
fix onnx_export of bbox_head when reg_class_agnostic

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/bbox_head.py
@@ -538,7 +538,9 @@ class BBoxHead(BaseModule):
         labels = labels.view(1, 1, -1).expand_as(scores)
         labels = labels.reshape(batch_size, -1)
         scores = scores.reshape(batch_size, -1)
-        bboxes = bboxes.reshape(batch_size, -1, 4)
+        if self.reg_class_agnostic:
+            bboxes = bboxes.reshape(batch_size, -1, 4)
+            bboxes = bboxes.repeat(1, self.num_classes, 1)
 
         max_size = torch.max(img_shape)
         # Offset bboxes of each class so that bboxes of different labels

--- a/mmdet/models/roi_heads/bbox_heads/bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/bbox_head.py
@@ -538,8 +538,8 @@ class BBoxHead(BaseModule):
         labels = labels.view(1, 1, -1).expand_as(scores)
         labels = labels.reshape(batch_size, -1)
         scores = scores.reshape(batch_size, -1)
+        bboxes = bboxes.reshape(batch_size, -1, 4)
         if self.reg_class_agnostic:
-            bboxes = bboxes.reshape(batch_size, -1, 4)
             bboxes = bboxes.repeat(1, self.num_classes, 1)
 
         max_size = torch.max(img_shape)


### PR DESCRIPTION
## Motivation

In the `onnx_export` of `bbox_head.py`, when the `self.reg_class_agnostic` is True, the shape of `bboxes`  can not match the shape of `scores` and `labels`.

https://github.com/open-mmlab/mmdetection/blob/ff649bd870190567d6c60aed4286909d5370da7b/mmdet/models/roi_heads/bbox_heads/bbox_head.py#L547
the shape would mismatch when `reg_class_agnostic` is True.
