### PR TITLE
fix val_step() optimizer parameter error in IterBasedRunner.

### DIFF
--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -242,7 +242,7 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
 
         return outputs
 
-    def val_step(self, data, optimizer):
+    def val_step(self, data, optimizer=None):
         """The iteration step during validation.
 
         This method shares the same signature as :func:`train_step`, but used


### PR DESCRIPTION
## Motivation
val_step() missing 1 required positional argument: 'optimizer'

Reslove: https://github.com/open-mmlab/mmcv/issues/1107

## Modification
add the default value.