### PR TITLE
[Refactor] refactor losses function, support key `reduction_override`

### DIFF
--- a/mmdet/models/losses/ghm_loss.py
+++ b/mmdet/models/losses/ghm_loss.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from ..builder import LOSSES
+from .utils import weight_reduce_loss
 
 
 def _expand_onehot_labels(labels, label_weights, label_channels):
@@ -30,9 +31,16 @@ class GHMC(nn.Module):
         momentum (float): The parameter for moving average.
         use_sigmoid (bool): Can only be true for BCE based loss now.
         loss_weight (float): The weight of the total GHM-C loss.
+        reduction (str): Options are "none", "mean" and "sum".
+            Defaults to "sum"
     """
 
-    def __init__(self, bins=10, momentum=0, use_sigmoid=True, loss_weight=1.0):
+    def __init__(self,
+                 bins=10,
+                 momentum=0,
+                 use_sigmoid=True,
+                 loss_weight=1.0,
+                 reduction='mean'):
         super(GHMC, self).__init__()
         self.bins = bins
         self.momentum = momentum
@@ -46,8 +54,14 @@ class GHMC(nn.Module):
         if not self.use_sigmoid:
             raise NotImplementedError
         self.loss_weight = loss_weight
+        self.reduction = reduction
 
-    def forward(self, pred, target, label_weight, *args, **kwargs):
+    def forward(self,
+                pred,
+                target,
+                label_weight,
+                reduction_override=None,
+                **kwargs):
         """Calculate the GHM-C loss.
 
         Args:
@@ -57,9 +71,15 @@ class GHMC(nn.Module):
                 Binary class target for each sample.
             label_weight (float tensor of size [batch_num, class_num]):
                 the value is 1 if the sample is valid and 0 if ignored.
+            reduction_override (str, optional): The reduction method used to
+                override the original reduction method of the loss.
+                Defaults to None.
         Returns:
             The gradient harmonized loss.
         """
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
         # the target should be binary class label
         if pred.dim() != target.dim():
             target, label_weight = _expand_onehot_labels(
@@ -90,7 +110,9 @@ class GHMC(nn.Module):
             weights = weights / n
 
         loss = F.binary_cross_entropy_with_logits(
-            pred, target, weights, reduction='sum') / tot
+            pred, target, reduction='none')
+        loss = weight_reduce_loss(
+            loss, weights, reduction=reduction, avg_factor=tot)
         return loss * self.loss_weight
 
 
@@ -110,7 +132,12 @@ class GHMR(nn.Module):
         loss_weight (float): The weight of the total GHM-R loss.
     """
 
-    def __init__(self, mu=0.02, bins=10, momentum=0, loss_weight=1.0):
+    def __init__(self,
+                 mu=0.02,
+                 bins=10,
+                 momentum=0,
+                 loss_weight=1.0,
+                 reduction='mean'):
         super(GHMR, self).__init__()
         self.mu = mu
         self.bins = bins
@@ -122,9 +149,15 @@ class GHMR(nn.Module):
             acc_sum = torch.zeros(bins)
             self.register_buffer('acc_sum', acc_sum)
         self.loss_weight = loss_weight
+        self.reduction = reduction
 
     # TODO: support reduction parameter
-    def forward(self, pred, target, label_weight, avg_factor=None):
+    def forward(self,
+                pred,
+                target,
+                label_weight,
+                avg_factor=None,
+                reduction_override=None):
         """Calculate the GHM-R loss.
 
         Args:
@@ -138,6 +171,9 @@ class GHMR(nn.Module):
         Returns:
             The gradient harmonized loss.
         """
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
         mu = self.mu
         edges = self.edges
         mmt = self.momentum
@@ -166,7 +202,6 @@ class GHMR(nn.Module):
                     weights[inds] = tot / num_in_bin
         if n > 0:
             weights /= n
-
-        loss = loss * weights
-        loss = loss.sum() / tot
+        loss = weight_reduce_loss(
+            loss, weights, reduction=reduction, avg_factor=tot)
         return loss * self.loss_weight

--- a/mmdet/models/losses/ghm_loss.py
+++ b/mmdet/models/losses/ghm_loss.py
@@ -32,7 +32,7 @@ class GHMC(nn.Module):
         use_sigmoid (bool): Can only be true for BCE based loss now.
         loss_weight (float): The weight of the total GHM-C loss.
         reduction (str): Options are "none", "mean" and "sum".
-            Defaults to "sum"
+            Defaults to "mean"
     """
 
     def __init__(self,
@@ -130,6 +130,8 @@ class GHMR(nn.Module):
         bins (int): Number of the unit regions for distribution calculation.
         momentum (float): The parameter for moving average.
         loss_weight (float): The weight of the total GHM-R loss.
+        reduction (str): Options are "none", "mean" and "sum".
+            Defaults to "mean"
     """
 
     def __init__(self,
@@ -168,6 +170,9 @@ class GHMR(nn.Module):
                 The target regression values with the same size of pred.
             label_weight (float tensor of size [batch_num, 4 (* class_num)]):
                 The weight of each sample, 0 if ignored.
+            reduction_override (str, optional): The reduction method used to
+                override the original reduction method of the loss.
+                Defaults to None.
         Returns:
             The gradient harmonized loss.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = PIL,asynctest,cityscapesscripts,cv2,gather_models,matplotlib,mmcv,numpy,onnx,onnxruntime,pycocotools,pytest,seaborn,six,terminaltables,torch,ts,yaml
+known_third_party = PIL,asynctest,cityscapesscripts,cv2,gather_models,matplotlib,mmcv,numpy,onnx,onnxruntime,pycocotools,pytest,seaborn,six,terminaltables,test_forward,torch,ts,yaml
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet
-known_third_party = PIL,asynctest,cityscapesscripts,cv2,gather_models,matplotlib,mmcv,numpy,onnx,onnxruntime,pycocotools,pytest,seaborn,six,terminaltables,test_forward,torch,ts,yaml
+known_third_party = PIL,asynctest,cityscapesscripts,cv2,gather_models,matplotlib,mmcv,numpy,onnx,onnxruntime,pycocotools,pytest,seaborn,six,terminaltables,torch,ts,yaml
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 

--- a/tests/test_models/test_loss.py
+++ b/tests/test_models/test_loss.py
@@ -1,12 +1,15 @@
 import pytest
 import torch
 
-from mmdet.models.losses import (BalancedL1Loss, BoundedIoULoss, CIoULoss,
-                                 CrossEntropyLoss, DIoULoss,
+from mmdet.models.losses import (BalancedL1Loss, CrossEntropyLoss,
                                  DistributionFocalLoss, FocalLoss,
-                                 GaussianFocalLoss, GIoULoss, IoULoss, L1Loss,
-                                 MSELoss, QualityFocalLoss, SmoothL1Loss,
-                                 VarifocalLoss)
+                                 GaussianFocalLoss,
+                                 KnowledgeDistillationKLDivLoss, L1Loss,
+                                 MSELoss, QualityFocalLoss, SeesawLoss,
+                                 SmoothL1Loss, VarifocalLoss)
+from mmdet.models.losses.ghm_loss import GHMC, GHMR
+from mmdet.models.losses.iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss,
+                                          GIoULoss, IoULoss)
 
 
 @pytest.mark.parametrize(
@@ -21,19 +24,22 @@ def test_iou_type_loss_zeros_weight(loss_class):
 
 
 @pytest.mark.parametrize('loss_class', [
-    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, MSELoss, L1Loss,
-    SmoothL1Loss, BalancedL1Loss, FocalLoss, QualityFocalLoss,
-    GaussianFocalLoss, DistributionFocalLoss, VarifocalLoss, CrossEntropyLoss
+    BalancedL1Loss, BoundedIoULoss, CIoULoss, CrossEntropyLoss, DIoULoss,
+    FocalLoss, DistributionFocalLoss, MSELoss, SeesawLoss, GaussianFocalLoss,
+    GIoULoss, IoULoss, L1Loss, QualityFocalLoss, VarifocalLoss, GHMR, GHMC,
+    SmoothL1Loss, KnowledgeDistillationKLDivLoss
 ])
 def test_loss_with_reduction_override(loss_class):
     pred = torch.rand((10, 4))
-    target = torch.rand((10, 4))
+    target = torch.rand((10, 4)),
+    weight = None
 
     with pytest.raises(AssertionError):
         # only reduction_override from [None, 'none', 'mean', 'sum']
         # is not allowed
         reduction_override = True
-        loss_class()(pred, target, reduction_override=reduction_override)
+        loss_class()(
+            pred, target, weight, reduction_override=reduction_override)
 
 
 @pytest.mark.parametrize('loss_class', [
@@ -43,9 +49,14 @@ def test_loss_with_reduction_override(loss_class):
 def test_regression_losses(loss_class):
     pred = torch.rand((10, 4))
     target = torch.rand((10, 4))
+    weight = torch.rand((10, 4))
 
     # Test loss forward
     loss = loss_class()(pred, target)
+    assert isinstance(loss, torch.Tensor)
+
+    # Test loss forward with weight
+    loss = loss_class()(pred, target, weight)
     assert isinstance(loss, torch.Tensor)
 
     # Test loss forward with reduction_override
@@ -99,3 +110,14 @@ def test_classification_losses(loss_class):
         loss_class()(
             pred, target, avg_factor=10, reduction_override=reduction_override)
         assert isinstance(loss, torch.Tensor)
+
+
+@pytest.mark.parametrize('loss_class', [GHMR])
+def test_GHMR_loss(loss_class):
+    pred = torch.rand((10, 4))
+    target = torch.rand((10, 4))
+    weight = torch.rand((10, 4))
+
+    # Test loss forward
+    loss = loss_class()(pred, target, weight)
+    assert isinstance(loss, torch.Tensor)

--- a/tests/test_models/test_loss_compatibility.py
+++ b/tests/test_models/test_loss_compatibility.py
@@ -17,7 +17,7 @@ from mmdet.models import build_detector
     dict(type='BalancedL1Loss', loss_weight=1.0)
 ])
 def test_bbox_loss_compatibility(loss_bbox):
-    """Test loss_cls and loss_bbox compatibility.
+    """Test loss_bbox compatibility.
 
     Using Faster R-CNN as a sample, modifying the loss function in the config
     file to verify the compatibility of Loss APIS
@@ -54,7 +54,7 @@ def test_bbox_loss_compatibility(loss_bbox):
         type='GHMC', bins=30, momentum=0.75, use_sigmoid=True, loss_weight=1.0)
 ])
 def test_cls_loss_compatibility(loss_cls):
-    """Test loss_cls and loss_bbox compatibility.
+    """Test loss_cls compatibility.
 
     Using Faster R-CNN as a sample, modifying the loss function in the config
     file to verify the compatibility of Loss APIS

--- a/tests/test_models/test_loss_compatibility.py
+++ b/tests/test_models/test_loss_compatibility.py
@@ -1,193 +1,78 @@
-import numpy as np
-import torch
-from mmcv import ConfigDict
+import pytest
+from test_forward import _demo_mm_inputs, _get_detector_cfg
 
 from mmdet.models import build_detector
 
 
-def test_loss_compatibility():
+@pytest.mark.parametrize('loss_bbox', [
+    dict(type='L1Loss', loss_weight=1.0),
+    dict(type='GHMR', mu=0.02, bins=10, momentum=0.7, loss_weight=10.0),
+    dict(type='IoULoss', loss_weight=1.0),
+    dict(type='BoundedIoULoss', loss_weight=1.0),
+    dict(type='GIoULoss', loss_weight=1.0),
+    dict(type='DIoULoss', loss_weight=1.0),
+    dict(type='CIoULoss', loss_weight=1.0),
+    dict(type='MSELoss', loss_weight=1.0),
+    dict(type='SmoothL1Loss', loss_weight=1.0),
+    dict(type='BalancedL1Loss', loss_weight=1.0)
+])
+def test_bbox_loss_compatibility(loss_bbox):
     """Test loss_cls and loss_bbox compatibility.
 
     Using Faster R-CNN as a sample, modifying the loss function in the config
     file to verify the compatibility of Loss APIS
     """
     # Faster R-CNN config dict
-    cfg_model = dict(
-        type='FasterRCNN',
-        backbone=dict(
-            type='ResNet',
-            depth=50,
-            num_stages=3,
-            strides=(1, 2, 2),
-            dilations=(1, 1, 1),
-            out_indices=(2, ),
-            frozen_stages=1,
-            norm_cfg=dict(type='BN', requires_grad=False),
-            norm_eval=True,
-            style='caffe'),
-        rpn_head=dict(
-            type='RPNHead',
-            in_channels=1024,
-            feat_channels=1024,
-            anchor_generator=dict(
-                type='AnchorGenerator',
-                scales=[2, 4, 8, 16, 32],
-                ratios=[0.5, 1.0, 2.0],
-                strides=[16]),
-            bbox_coder=dict(
-                type='DeltaXYWHBBoxCoder',
-                target_means=[.0, .0, .0, .0],
-                target_stds=[1.0, 1.0, 1.0, 1.0]),
-            loss_cls=dict(
-                type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
-            loss_bbox=dict(type='L1Loss', loss_weight=1.0)),
-        roi_head=dict(
-            type='StandardRoIHead',
-            shared_head=dict(
-                type='ResLayer',
-                depth=50,
-                stage=3,
-                stride=2,
-                dilation=1,
-                style='caffe',
-                norm_cfg=dict(type='BN', requires_grad=False),
-                norm_eval=True),
-            bbox_roi_extractor=dict(
-                type='SingleRoIExtractor',
-                roi_layer=dict(
-                    type='RoIAlign', output_size=14, sampling_ratio=0),
-                out_channels=1024,
-                featmap_strides=[16]),
-            bbox_head=dict(
-                type='BBoxHead',
-                with_avg_pool=True,
-                roi_feat_size=7,
-                in_channels=2048,
-                num_classes=80,
-                bbox_coder=dict(
-                    type='DeltaXYWHBBoxCoder',
-                    target_means=[0., 0., 0., 0.],
-                    target_stds=[0.1, 0.1, 0.2, 0.2]),
-                reg_class_agnostic=False,
-                loss_cls=dict(
-                    type='CrossEntropyLoss',
-                    use_sigmoid=False,
-                    loss_weight=1.0),
-                loss_bbox=dict(type='L1Loss', loss_weight=1.0))),
-        # model training and testing settings
-        train_cfg=dict(
-            rpn=dict(
-                assigner=dict(
-                    type='MaxIoUAssigner',
-                    pos_iou_thr=0.7,
-                    neg_iou_thr=0.3,
-                    min_pos_iou=0.3,
-                    match_low_quality=True,
-                    ignore_iof_thr=-1),
-                sampler=dict(
-                    type='RandomSampler',
-                    num=256,
-                    pos_fraction=0.5,
-                    neg_pos_ub=-1,
-                    add_gt_as_proposals=False),
-                allowed_border=0,
-                pos_weight=-1,
-                debug=False),
-            rpn_proposal=dict(
-                nms_pre=12000,
-                max_per_img=2000,
-                nms=dict(type='nms', iou_threshold=0.7),
-                min_bbox_size=0),
-            rcnn=dict(
-                assigner=dict(
-                    type='MaxIoUAssigner',
-                    pos_iou_thr=0.5,
-                    neg_iou_thr=0.5,
-                    min_pos_iou=0.5,
-                    match_low_quality=False,
-                    ignore_iof_thr=-1),
-                sampler=dict(
-                    type='RandomSampler',
-                    num=512,
-                    pos_fraction=0.25,
-                    neg_pos_ub=-1,
-                    add_gt_as_proposals=True),
-                pos_weight=-1,
-                debug=False)),
-        test_cfg=dict(
-            rpn=dict(
-                nms_pre=6000,
-                max_per_img=1000,
-                nms=dict(type='nms', iou_threshold=0.7),
-                min_bbox_size=0),
-            rcnn=dict(
-                score_thr=0.05,
-                nms=dict(type='nms', iou_threshold=0.5),
-                max_per_img=100)))
+    config_path = '_base_/models/faster_rcnn_r50_fpn.py'
+    cfg_model = _get_detector_cfg(config_path)
 
-    # bbox loss function used to verify compatibility
-    loss_bboxes = [
-        dict(type='L1Loss', loss_weight=1.0),
-        dict(type='GHMR', mu=0.02, bins=10, momentum=0.7, loss_weight=10.0),
-        dict(type='IoULoss', loss_weight=1.0),
-        dict(type='BoundedIoULoss', loss_weight=1.0),
-        dict(type='GIoULoss', loss_weight=1.0),
-        dict(type='DIoULoss', loss_weight=1.0),
-        dict(type='CIoULoss', loss_weight=1.0),
-        dict(type='MSELoss', loss_weight=1.0),
-        dict(type='SmoothL1Loss', loss_weight=1.0),
-        dict(type='BalancedL1Loss', loss_weight=1.0)
-    ]
-    # class loss function used to verify compatibility
-    loss_clses = [
-        dict(type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
-        dict(
-            type='FocalLoss',
-            use_sigmoid=True,
-            gamma=2.0,
-            alpha=0.25,
-            loss_weight=1.0),
-        dict(
-            type='GHMC',
-            bins=30,
-            momentum=0.75,
-            use_sigmoid=True,
-            loss_weight=1.0)
-    ]
-    # set some important args in forward_train
-    imgs = torch.randn(1, 3, 224, 224)
-    gt_bboxes = [torch.Tensor([[23.6667, 23.8757, 238.6326, 151.8874]])]
-    gt_labels = [torch.LongTensor([2])]
-    img_matas = {
-        'filename': '000000037777.jpg',
-        'ori_filename': '000000037777.jpg',
-        'ori_shape': (224, 224, 3),
-        'img_shape': (224, 224, 3),
-        'pad_shape': (224, 224, 3),
-        'scale_factor': 1.0,
-        'flip': False,
-        'flip_direction': None,
-        'img_norm_cfg': {
-            'mean': np.array([123.675, 116.28, 103.53], dtype=np.float32),
-            'std': np.array([58.395, 57.12, 57.375], dtype=np.float32),
-            'to_rgb': True
-        }
-    }
-    img_metas = [img_matas]
-    cfg_model = ConfigDict(cfg_model)
+    input_shape = (1, 3, 256, 256)
+    mm_inputs = _demo_mm_inputs(input_shape, num_items=[10])
+    imgs = mm_inputs.pop('imgs')
+    img_metas = mm_inputs.pop('img_metas')
 
-    # verify bbox loss function compatibility
-    for loss_bbox in loss_bboxes:
-        cfg_model.roi_head.bbox_head.loss_bbox = loss_bbox
-        model = build_detector(cfg_model)
-        loss = model.forward_train(imgs, img_metas, gt_bboxes, gt_labels)
-        assert isinstance(loss['loss_cls'], torch.Tensor)
-        assert isinstance(loss['loss_bbox'], torch.Tensor)
+    if 'IoULoss' in loss_bbox['type']:
+        cfg_model.roi_head.bbox_head.reg_decoded_bbox = True
+
+    cfg_model.roi_head.bbox_head.loss_bbox = loss_bbox
+    detector = build_detector(cfg_model)
+    loss = detector.forward(imgs, img_metas, return_loss=True, **mm_inputs)
+    assert isinstance(loss, dict)
+    loss, _ = detector._parse_losses(loss)
+    assert float(loss.item()) > 0
+
+
+@pytest.mark.parametrize('loss_cls', [
+    dict(type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
+    dict(
+        type='FocalLoss',
+        use_sigmoid=True,
+        gamma=2.0,
+        alpha=0.25,
+        loss_weight=1.0),
+    dict(
+        type='GHMC', bins=30, momentum=0.75, use_sigmoid=True, loss_weight=1.0)
+])
+def test_cls_loss_compatibility(loss_cls):
+    """Test loss_cls and loss_bbox compatibility.
+
+    Using Faster R-CNN as a sample, modifying the loss function in the config
+    file to verify the compatibility of Loss APIS
+    """
+    # Faster R-CNN config dict
+    config_path = '_base_/models/faster_rcnn_r50_fpn.py'
+    cfg_model = _get_detector_cfg(config_path)
+
+    input_shape = (1, 3, 256, 256)
+    mm_inputs = _demo_mm_inputs(input_shape, num_items=[10])
+    imgs = mm_inputs.pop('imgs')
+    img_metas = mm_inputs.pop('img_metas')
 
     # verify class loss function compatibility
-    for loss_cls in loss_clses:
-        cfg_model.roi_head.bbox_head.loss_cls = loss_cls
-        model = build_detector(cfg_model)
-        loss = model.forward_train(imgs, img_metas, gt_bboxes, gt_labels)
-        assert isinstance(loss['loss_cls'], torch.Tensor)
-        assert isinstance(loss['loss_bbox'], torch.Tensor)
+    # for loss_cls in loss_clses:
+    cfg_model.roi_head.bbox_head.loss_cls = loss_cls
+    detector = build_detector(cfg_model)
+    loss = detector.forward(imgs, img_metas, return_loss=True, **mm_inputs)
+    assert isinstance(loss, dict)
+    loss, _ = detector._parse_losses(loss)
+    assert float(loss.item()) > 0

--- a/tests/test_models/test_loss_compatibility.py
+++ b/tests/test_models/test_loss_compatibility.py
@@ -1,0 +1,193 @@
+import numpy as np
+import torch
+from mmcv import ConfigDict
+
+from mmdet.models import build_detector
+
+
+def test_loss_compatibility():
+    """Test loss_cls and loss_bbox compatibility.
+
+    Using Faster R-CNN as a sample, modifying the loss function in the config
+    file to verify the compatibility of Loss APIS
+    """
+    # Faster R-CNN config dict
+    cfg_model = dict(
+        type='FasterRCNN',
+        backbone=dict(
+            type='ResNet',
+            depth=50,
+            num_stages=3,
+            strides=(1, 2, 2),
+            dilations=(1, 1, 1),
+            out_indices=(2, ),
+            frozen_stages=1,
+            norm_cfg=dict(type='BN', requires_grad=False),
+            norm_eval=True,
+            style='caffe'),
+        rpn_head=dict(
+            type='RPNHead',
+            in_channels=1024,
+            feat_channels=1024,
+            anchor_generator=dict(
+                type='AnchorGenerator',
+                scales=[2, 4, 8, 16, 32],
+                ratios=[0.5, 1.0, 2.0],
+                strides=[16]),
+            bbox_coder=dict(
+                type='DeltaXYWHBBoxCoder',
+                target_means=[.0, .0, .0, .0],
+                target_stds=[1.0, 1.0, 1.0, 1.0]),
+            loss_cls=dict(
+                type='CrossEntropyLoss', use_sigmoid=True, loss_weight=1.0),
+            loss_bbox=dict(type='L1Loss', loss_weight=1.0)),
+        roi_head=dict(
+            type='StandardRoIHead',
+            shared_head=dict(
+                type='ResLayer',
+                depth=50,
+                stage=3,
+                stride=2,
+                dilation=1,
+                style='caffe',
+                norm_cfg=dict(type='BN', requires_grad=False),
+                norm_eval=True),
+            bbox_roi_extractor=dict(
+                type='SingleRoIExtractor',
+                roi_layer=dict(
+                    type='RoIAlign', output_size=14, sampling_ratio=0),
+                out_channels=1024,
+                featmap_strides=[16]),
+            bbox_head=dict(
+                type='BBoxHead',
+                with_avg_pool=True,
+                roi_feat_size=7,
+                in_channels=2048,
+                num_classes=80,
+                bbox_coder=dict(
+                    type='DeltaXYWHBBoxCoder',
+                    target_means=[0., 0., 0., 0.],
+                    target_stds=[0.1, 0.1, 0.2, 0.2]),
+                reg_class_agnostic=False,
+                loss_cls=dict(
+                    type='CrossEntropyLoss',
+                    use_sigmoid=False,
+                    loss_weight=1.0),
+                loss_bbox=dict(type='L1Loss', loss_weight=1.0))),
+        # model training and testing settings
+        train_cfg=dict(
+            rpn=dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.7,
+                    neg_iou_thr=0.3,
+                    min_pos_iou=0.3,
+                    match_low_quality=True,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=256,
+                    pos_fraction=0.5,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=False),
+                allowed_border=0,
+                pos_weight=-1,
+                debug=False),
+            rpn_proposal=dict(
+                nms_pre=12000,
+                max_per_img=2000,
+                nms=dict(type='nms', iou_threshold=0.7),
+                min_bbox_size=0),
+            rcnn=dict(
+                assigner=dict(
+                    type='MaxIoUAssigner',
+                    pos_iou_thr=0.5,
+                    neg_iou_thr=0.5,
+                    min_pos_iou=0.5,
+                    match_low_quality=False,
+                    ignore_iof_thr=-1),
+                sampler=dict(
+                    type='RandomSampler',
+                    num=512,
+                    pos_fraction=0.25,
+                    neg_pos_ub=-1,
+                    add_gt_as_proposals=True),
+                pos_weight=-1,
+                debug=False)),
+        test_cfg=dict(
+            rpn=dict(
+                nms_pre=6000,
+                max_per_img=1000,
+                nms=dict(type='nms', iou_threshold=0.7),
+                min_bbox_size=0),
+            rcnn=dict(
+                score_thr=0.05,
+                nms=dict(type='nms', iou_threshold=0.5),
+                max_per_img=100)))
+
+    # bbox loss function used to verify compatibility
+    loss_bboxes = [
+        dict(type='L1Loss', loss_weight=1.0),
+        dict(type='GHMR', mu=0.02, bins=10, momentum=0.7, loss_weight=10.0),
+        dict(type='IoULoss', loss_weight=1.0),
+        dict(type='BoundedIoULoss', loss_weight=1.0),
+        dict(type='GIoULoss', loss_weight=1.0),
+        dict(type='DIoULoss', loss_weight=1.0),
+        dict(type='CIoULoss', loss_weight=1.0),
+        dict(type='MSELoss', loss_weight=1.0),
+        dict(type='SmoothL1Loss', loss_weight=1.0),
+        dict(type='BalancedL1Loss', loss_weight=1.0)
+    ]
+    # class loss function used to verify compatibility
+    loss_clses = [
+        dict(type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
+        dict(
+            type='FocalLoss',
+            use_sigmoid=True,
+            gamma=2.0,
+            alpha=0.25,
+            loss_weight=1.0),
+        dict(
+            type='GHMC',
+            bins=30,
+            momentum=0.75,
+            use_sigmoid=True,
+            loss_weight=1.0)
+    ]
+    # set some important args in forward_train
+    imgs = torch.randn(1, 3, 224, 224)
+    gt_bboxes = [torch.Tensor([[23.6667, 23.8757, 238.6326, 151.8874]])]
+    gt_labels = [torch.LongTensor([2])]
+    img_matas = {
+        'filename': '000000037777.jpg',
+        'ori_filename': '000000037777.jpg',
+        'ori_shape': (224, 224, 3),
+        'img_shape': (224, 224, 3),
+        'pad_shape': (224, 224, 3),
+        'scale_factor': 1.0,
+        'flip': False,
+        'flip_direction': None,
+        'img_norm_cfg': {
+            'mean': np.array([123.675, 116.28, 103.53], dtype=np.float32),
+            'std': np.array([58.395, 57.12, 57.375], dtype=np.float32),
+            'to_rgb': True
+        }
+    }
+    img_metas = [img_matas]
+    cfg_model = ConfigDict(cfg_model)
+
+    # verify bbox loss function compatibility
+    for loss_bbox in loss_bboxes:
+        cfg_model.roi_head.bbox_head.loss_bbox = loss_bbox
+        model = build_detector(cfg_model)
+        loss = model.forward_train(imgs, img_metas, gt_bboxes, gt_labels)
+        assert isinstance(loss['loss_cls'], torch.Tensor)
+        assert isinstance(loss['loss_bbox'], torch.Tensor)
+
+    # verify class loss function compatibility
+    for loss_cls in loss_clses:
+        cfg_model.roi_head.bbox_head.loss_cls = loss_cls
+        model = build_detector(cfg_model)
+        loss = model.forward_train(imgs, img_metas, gt_bboxes, gt_labels)
+        assert isinstance(loss['loss_cls'], torch.Tensor)
+        assert isinstance(loss['loss_bbox'], torch.Tensor)

--- a/tests/test_models/test_loss_compatibility.py
+++ b/tests/test_models/test_loss_compatibility.py
@@ -1,7 +1,45 @@
-import pytest
-from test_forward import _demo_mm_inputs, _get_detector_cfg
+"""pytest tests/test_loss_compatibility.py."""
+import copy
+from os.path import dirname, exists, join
 
-from mmdet.models import build_detector
+import numpy as np
+import pytest
+import torch
+
+
+def _get_config_directory():
+    """Find the predefined detector config directory."""
+    try:
+        # Assume we are running in the source mmdetection repo
+        repo_dpath = dirname(dirname(dirname(__file__)))
+    except NameError:
+        # For IPython development when this __file__ is not defined
+        import mmdet
+        repo_dpath = dirname(dirname(mmdet.__file__))
+    config_dpath = join(repo_dpath, 'configs')
+    if not exists(config_dpath):
+        raise Exception('Cannot find config path')
+    return config_dpath
+
+
+def _get_config_module(fname):
+    """Load a configuration as a python module."""
+    from mmcv import Config
+    config_dpath = _get_config_directory()
+    config_fpath = join(config_dpath, fname)
+    config_mod = Config.fromfile(config_fpath)
+    return config_mod
+
+
+def _get_detector_cfg(fname):
+    """Grab configs necessary to create a detector.
+
+    These are deep copied to allow for safe modification of parameters without
+    influencing other tests.
+    """
+    config = _get_config_module(fname)
+    model = copy.deepcopy(config.model)
+    return model
 
 
 @pytest.mark.parametrize('loss_bbox', [
@@ -35,7 +73,10 @@ def test_bbox_loss_compatibility(loss_bbox):
         cfg_model.roi_head.bbox_head.reg_decoded_bbox = True
 
     cfg_model.roi_head.bbox_head.loss_bbox = loss_bbox
+
+    from mmdet.models import build_detector
     detector = build_detector(cfg_model)
+
     loss = detector.forward(imgs, img_metas, return_loss=True, **mm_inputs)
     assert isinstance(loss, dict)
     loss, _ = detector._parse_losses(loss)
@@ -71,8 +112,89 @@ def test_cls_loss_compatibility(loss_cls):
     # verify class loss function compatibility
     # for loss_cls in loss_clses:
     cfg_model.roi_head.bbox_head.loss_cls = loss_cls
+
+    from mmdet.models import build_detector
     detector = build_detector(cfg_model)
+
     loss = detector.forward(imgs, img_metas, return_loss=True, **mm_inputs)
     assert isinstance(loss, dict)
     loss, _ = detector._parse_losses(loss)
     assert float(loss.item()) > 0
+
+
+def _demo_mm_inputs(input_shape=(1, 3, 300, 300),
+                    num_items=None, num_classes=10,
+                    with_semantic=False):  # yapf: disable
+    """Create a superset of inputs needed to run test or train batches.
+
+    Args:
+        input_shape (tuple):
+            input batch dimensions
+
+        num_items (None | List[int]):
+            specifies the number of boxes in each batch item
+
+        num_classes (int):
+            number of different labels a box might have
+    """
+    from mmdet.core import BitmapMasks
+
+    (N, C, H, W) = input_shape
+
+    rng = np.random.RandomState(0)
+
+    imgs = rng.rand(*input_shape)
+
+    img_metas = [{
+        'img_shape': (H, W, C),
+        'ori_shape': (H, W, C),
+        'pad_shape': (H, W, C),
+        'filename': '<demo>.png',
+        'scale_factor': np.array([1.1, 1.2, 1.1, 1.2]),
+        'flip': False,
+        'flip_direction': None,
+    } for _ in range(N)]
+
+    gt_bboxes = []
+    gt_labels = []
+    gt_masks = []
+
+    for batch_idx in range(N):
+        if num_items is None:
+            num_boxes = rng.randint(1, 10)
+        else:
+            num_boxes = num_items[batch_idx]
+
+        cx, cy, bw, bh = rng.rand(num_boxes, 4).T
+
+        tl_x = ((cx * W) - (W * bw / 2)).clip(0, W)
+        tl_y = ((cy * H) - (H * bh / 2)).clip(0, H)
+        br_x = ((cx * W) + (W * bw / 2)).clip(0, W)
+        br_y = ((cy * H) + (H * bh / 2)).clip(0, H)
+
+        boxes = np.vstack([tl_x, tl_y, br_x, br_y]).T
+        class_idxs = rng.randint(1, num_classes, size=num_boxes)
+
+        gt_bboxes.append(torch.FloatTensor(boxes))
+        gt_labels.append(torch.LongTensor(class_idxs))
+
+    mask = np.random.randint(0, 2, (len(boxes), H, W), dtype=np.uint8)
+    gt_masks.append(BitmapMasks(mask, H, W))
+
+    mm_inputs = {
+        'imgs': torch.FloatTensor(imgs).requires_grad_(True),
+        'img_metas': img_metas,
+        'gt_bboxes': gt_bboxes,
+        'gt_labels': gt_labels,
+        'gt_bboxes_ignore': None,
+        'gt_masks': gt_masks,
+    }
+
+    if with_semantic:
+        # assume gt_semantic_seg using scale 1/8 of the img
+        gt_semantic_seg = np.random.randint(
+            0, num_classes, (1, 1, H // 8, W // 8), dtype=np.uint8)
+        mm_inputs.update(
+            {'gt_semantic_seg': torch.ByteTensor(gt_semantic_seg)})
+
+    return mm_inputs


### PR DESCRIPTION
Firstly, I used `weight_reduce_loss` to rewrite the forward function and, added `reduction` key in `__init__`, the reduction defaults to mean. Meanwhile, I refactored the GHMC, GHMR forward function in `ghm_loss.py`, which make the loss function can support the key `reduction_override `.

Then I supplemented the losses test unit, to ensure that the losses of the same task can be replaced.

I have confirmed the results of GHMC and GHMR are the same as before the modification.