### PR TITLE
remove unnecessary code in autoassign

### DIFF
--- a/mmdet/models/dense_heads/autoassign_head.py
+++ b/mmdet/models/dense_heads/autoassign_head.py
@@ -466,17 +466,9 @@ class AutoAssignHead(FCOSHead):
 
         concat_points = torch.cat(points, dim=0)
         # the number of points per img, per lvl
-        num_points = [center.size(0) for center in points]
         inside_gt_bbox_mask_list, bbox_targets_list = multi_apply(
             self._get_target_single, gt_bboxes_list, points=concat_points)
-        bbox_targets_list = [
-            list(bbox_targets.split(num_points, 0))
-            for bbox_targets in bbox_targets_list
-        ]
-        concat_lvl_bbox_targets = [
-            torch.cat(item, dim=0) for item in bbox_targets_list
-        ]
-        return inside_gt_bbox_mask_list, concat_lvl_bbox_targets
+        return inside_gt_bbox_mask_list, bbox_targets_list
 
     def _get_target_single(self, gt_bboxes, points):
         """Compute regression targets and each point inside or outside gt_bbox


### PR DESCRIPTION
## Motivation

Hello, I am viewing autoassign source code. I am confused about some code lines in file mmdet/models/dense_heads/autoassign_head.py. Code at line 472 ~ line 479 is puzzling, because that I think  concat_lvl_bbox_targets is just same as bbox_targets_list. right ?
## Modification

See my pr, please.
