### PR TITLE
[Feature] MobileNetV2 SSD-Lite

### DIFF
--- a/configs/ssd/README.md
+++ b/configs/ssd/README.md
@@ -13,14 +13,22 @@
 }
 ```
 
-## Results and models
+## Results and models of SSD
 
 | Backbone | Size  | Style | Lr schd | Mem (GB) | Inf time (fps) | box AP | Config | Download |
 | :------: | :---: | :---: | :-----: | :------: | :------------: | :----: | :------: |  :--------: |
 |  VGG16   |  300  | caffe |  120e   |   9.9    |  43.7          |  25.9  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/ssd/ssd300_coco.py) | [model](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssd300_coco/ssd300_coco_20210604_193052-b61137df.pth) &#124; [log](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssd300_coco/ssd300_coco_20210604_193052.log.json) |
 |  VGG16   |  512  | caffe |  120e   |   19.4   |  30.7          |  29.8  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/ssd/ssd512_coco.py) | [model](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssd512_coco/ssd512_coco_20210604_111835-d3eba047.pth) &#124; [log](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssd512_coco/ssd512_coco_20210604_111835.log.json) |
 
+## Results and models of SSD-Lite
+
+|    Backbone    | Size  | Training from scratch | Lr schd | Mem (GB) | Inf time (fps) | box AP | Config | Download |
+| :------------: | :---: | :-------------------: | :-----: | :------: | :------------: | :----: | :------: |  :--------: |
+|  MobileNetV2   |  320  |        yes            |  600e   |   4.0    |     69.9       |  21.3  | [config](https://github.com/open-mmlab/mmdetection/tree/master/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py) | [model](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssdlite_mobilenetv2_scratch_600e_coco/ssdlite_mobilenetv2_scratch_600e_coco_20210629_110627-974d9307.pth) &#124; [log](https://download.openmmlab.com/mmdetection/v2.0/ssd/ssdlite_mobilenetv2_scratch_600e_coco/ssdlite_mobilenetv2_scratch_600e_coco_20210629_110627.log.json) |
+
 ## Notice
+
+### Compatibility
 
 In v2.14.0, [PR5291](https://github.com/open-mmlab/mmdetection/pull/5291) refactored SSD neck and head for more
 flexible usage. If users want to use the SSD checkpoint trained in the older versions, we provide a scripts
@@ -33,3 +41,12 @@ python tools/model_converters/upgrade_ssd_version.py ${OLD_MODEL_PATH} ${NEW_MOD
 
 - OLD_MODEL_PATH: the path to load the old version SSD model.
 - NEW_MODEL_PATH: the path to save the converted model weights.
+
+### SSD-Lite training settings
+
+There are some differences between our implementation of MobileNetV2 SSD-Lite and the one in [TensorFlow 1.x detection model zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md) .
+
+1. Use 320x320 as input size instead of 300x300.
+2. The anchor sizes are different.
+3. The C4 feature map is taken from the last layer of stage 4 instead of the middle of the block.
+4. The model in TensorFlow1.x is trained on coco 2014 and validated on coco minival2014, but we trained and validated the model on coco 2017. The mAP on val2017 is usually a little lower than minival2014 (refer to the results in TensorFlow Object Detection API, e.g., MobileNetV2 SSD gets 22 mAP on minival2014 but 20.2 mAP on val2017).

--- a/configs/ssd/metafile.yml
+++ b/configs/ssd/metafile.yml
@@ -24,6 +24,7 @@ Models:
           batch size: 1
           mode: FP32
           resolution: (300, 300)
+      Epochs: 120
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -43,9 +44,30 @@ Models:
           batch size: 1
           mode: FP32
           resolution: (512, 512)
+      Epochs: 120
     Results:
       - Task: Object Detection
         Dataset: COCO
         Metrics:
           box AP: 29.8
     Weights: https://download.openmmlab.com/mmdetection/v2.0/ssd/ssd512_coco/ssd512_coco_20210604_111835-d3eba047.pth
+
+  - Name: ssdlite_mobilenetv2_scratch_600e_coco
+    In Collection: SSD
+    Config: configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
+    Metadata:
+      Training Memory (GB): 4.0
+      inference time (ms/im):
+        - value: 14.3
+          hardware: V100
+          backend: PyTorch
+          batch size: 1
+          mode: FP32
+          resolution: (320, 320)
+      Epochs: 600
+    Results:
+      - Task: Object Detection
+        Dataset: COCO
+        Metrics:
+          box AP: 21.3
+    Weights: https://download.openmmlab.com/mmdetection/v2.0/ssd/ssdlite_mobilenetv2_scratch_600e_coco/ssdlite_mobilenetv2_scratch_600e_coco_20210629_110627-974d9307.pth

--- a/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
+++ b/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
@@ -1,0 +1,138 @@
+_base_ = [
+    '../_base_/datasets/coco_detection.py', '../_base_/default_runtime.py'
+]
+
+model = dict(
+    type='SingleStageDetector',
+    backbone=dict(
+        type='MobileNetV2',
+        out_indices=(4, 7),
+        norm_cfg=dict(type='BN', eps=0.001, momentum=0.03),
+        init_cfg=dict(type='TruncNormal', layer='Conv2d', std=0.03)),
+    neck=dict(
+        type='SSDNeck',
+        in_channels=(96, 1280),
+        out_channels=(96, 1280, 512, 256, 256, 128),
+        level_strides=(2, 2, 2, 2),
+        level_paddings=(1, 1, 1, 1),
+        l2_norm_scale=None,
+        use_depthwise=True,
+        norm_cfg=dict(type='BN', eps=0.001, momentum=0.03),
+        act_cfg=dict(type='ReLU6'),
+        init_cfg=dict(type='TruncNormal', layer='Conv2d', std=0.03)),
+    bbox_head=dict(
+        type='SSDHead',
+        in_channels=(96, 1280, 512, 256, 256, 128),
+        num_classes=80,
+        use_depthwise=True,
+        norm_cfg=dict(type='BN', eps=0.001, momentum=0.03),
+        act_cfg=dict(type='ReLU6'),
+        init_cfg=dict(type='Normal', layer='Conv2d', std=0.001),
+        anchor_generator=dict(
+            type='SSDAnchorGenerator',
+            scale_major=False,
+            strides=[16, 32, 64, 107, 160, 320],
+            ratios=[[2, 3], [2, 3], [2, 3], [2, 3], [2, 3], [2, 3]],
+            min_sizes=[48, 100, 150, 202, 253, 304],
+            max_sizes=[100, 150, 202, 253, 304, 320]),
+        bbox_coder=dict(
+            type='DeltaXYWHBBoxCoder',
+            target_means=[.0, .0, .0, .0],
+            target_stds=[0.1, 0.1, 0.2, 0.2])),
+    # model training and testing settings
+    train_cfg=dict(
+        assigner=dict(
+            type='MaxIoUAssigner',
+            pos_iou_thr=0.5,
+            neg_iou_thr=0.5,
+            min_pos_iou=0.,
+            ignore_iof_thr=-1,
+            gt_max_assign_all=False),
+        smoothl1_beta=1.,
+        allowed_border=-1,
+        pos_weight=-1,
+        neg_pos_ratio=3,
+        debug=False),
+    test_cfg=dict(
+        nms_pre=1000,
+        nms=dict(type='nms', iou_threshold=0.45),
+        min_bbox_size=0,
+        score_thr=0.02,
+        max_per_img=200))
+cudnn_benchmark = True
+
+# dataset settings
+dataset_type = 'CocoDataset'
+data_root = 'data/coco/'
+img_norm_cfg = dict(
+    mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
+train_pipeline = [
+    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(
+        type='Expand',
+        mean=img_norm_cfg['mean'],
+        to_rgb=img_norm_cfg['to_rgb'],
+        ratio_range=(1, 4)),
+    dict(
+        type='MinIoURandomCrop',
+        min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
+        min_crop_size=0.3),
+    dict(type='Resize', img_scale=(320, 320), keep_ratio=False),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='Pad', size_divisor=320),
+    dict(type='DefaultFormatBundle'),
+    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
+]
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='MultiScaleFlipAug',
+        img_scale=(320, 320),
+        flip=False,
+        transforms=[
+            dict(type='Resize', keep_ratio=False),
+            dict(type='Normalize', **img_norm_cfg),
+            dict(type='Pad', size_divisor=320),
+            dict(type='ImageToTensor', keys=['img']),
+            dict(type='Collect', keys=['img']),
+        ])
+]
+data = dict(
+    samples_per_gpu=24,
+    workers_per_gpu=4,
+    train=dict(
+        _delete_=True,
+        type='RepeatDataset',
+        times=5,
+        dataset=dict(
+            type=dataset_type,
+            ann_file=data_root + 'annotations/instances_train2017.json',
+            img_prefix=data_root + 'train2017/',
+            pipeline=train_pipeline)),
+    val=dict(pipeline=test_pipeline),
+    test=dict(pipeline=test_pipeline))
+
+# optimizer
+optimizer = dict(type='SGD', lr=0.015, momentum=0.9, weight_decay=4.0e-5)
+optimizer_config = dict(grad_clip=None)
+
+# learning policy
+lr_config = dict(
+    policy='CosineAnnealing',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=0.001,
+    min_lr=0)
+runner = dict(type='EpochBasedRunner', max_epochs=120)
+
+# Avoid evaluation and saving weights too frequently
+evaluation = dict(interval=5, metric='bbox')
+checkpoint_config = dict(interval=5)

--- a/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
+++ b/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
@@ -28,6 +28,9 @@ model = dict(
         norm_cfg=dict(type='BN', eps=0.001, momentum=0.03),
         act_cfg=dict(type='ReLU6'),
         init_cfg=dict(type='Normal', layer='Conv2d', std=0.001),
+
+        # set anchor size manually instead of using the predefined
+        # SSD300 setting.
         anchor_generator=dict(
             type='SSDAnchorGenerator',
             scale_major=False,
@@ -110,7 +113,7 @@ data = dict(
     workers_per_gpu=4,
     train=dict(
         _delete_=True,
-        type='RepeatDataset',
+        type='RepeatDataset',  # use RepeatDataset to speed up training
         times=5,
         dataset=dict(
             type=dataset_type,

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -539,6 +539,8 @@ class SSDAnchorGenerator(AnchorGenerator):
                     'not setting min_sizes and max_sizes, '
                     f'got {self.input_size}.')
 
+        assert len(min_sizes) == len(max_sizes) == len(strides)
+
         anchor_ratios = []
         anchor_scales = []
         for k in range(len(self.strides)):
@@ -707,9 +709,12 @@ class LegacySSDAnchorGenerator(SSDAnchorGenerator, LegacyAnchorGenerator):
                  basesize_ratio_range,
                  input_size=300,
                  scale_major=True):
-        super(LegacySSDAnchorGenerator,
-              self).__init__(strides, ratios, basesize_ratio_range, input_size,
-                             scale_major)
+        super(LegacySSDAnchorGenerator, self).__init__(
+            strides=strides,
+            ratios=ratios,
+            basesize_ratio_range=basesize_ratio_range,
+            input_size=input_size,
+            scale_major=scale_major)
         self.centers = [((stride - 1) / 2., (stride - 1) / 2.)
                         for stride in strides]
         self.base_anchors = self.gen_base_anchors()

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -539,8 +539,6 @@ class SSDAnchorGenerator(AnchorGenerator):
                     'not setting min_sizes and max_sizes, '
                     f'got {self.input_size}.')
 
-        assert len(strides) == len(min_sizes) == len(max_sizes)
-
         anchor_ratios = []
         anchor_scales = []
         for k in range(len(self.strides)):

--- a/mmdet/core/anchor/anchor_generator.py
+++ b/mmdet/core/anchor/anchor_generator.py
@@ -466,9 +466,14 @@ class SSDAnchorGenerator(AnchorGenerator):
             in multiple feature levels.
         ratios (list[float]): The list of ratios between the height and width
             of anchors in a single level.
-        basesize_ratio_range (tuple(float)): Ratio range of anchors.
-        input_size (int): Size of feature map, 300 for SSD300,
-            512 for SSD512.
+        min_sizes (list[float]): The list of minimum anchor sizes on each
+            level.
+        max_sizes (list[float]): The list of maximum anchor sizes on each
+            level.
+        basesize_ratio_range (tuple(float)): Ratio range of anchors. Being
+            used when not setting min_sizes and max_sizes.
+        input_size (int): Size of feature map, 300 for SSD300, 512 for
+            SSD512. Being used when not setting min_sizes and max_sizes.
         scale_major (bool): Whether to multiply scales first when generating
             base anchors. If true, the anchors in the same row will have the
             same scales. It is always set to be False in SSD.
@@ -477,54 +482,64 @@ class SSDAnchorGenerator(AnchorGenerator):
     def __init__(self,
                  strides,
                  ratios,
-                 basesize_ratio_range,
+                 min_sizes=None,
+                 max_sizes=None,
+                 basesize_ratio_range=(0.15, 0.9),
                  input_size=300,
                  scale_major=True):
         assert len(strides) == len(ratios)
-        assert mmcv.is_tuple_of(basesize_ratio_range, float)
-
+        assert not (min_sizes is None) ^ (max_sizes is None)
         self.strides = [_pair(stride) for stride in strides]
-        self.input_size = input_size
         self.centers = [(stride[0] / 2., stride[1] / 2.)
                         for stride in self.strides]
-        self.basesize_ratio_range = basesize_ratio_range
 
-        # calculate anchor ratios and sizes
-        min_ratio, max_ratio = basesize_ratio_range
-        min_ratio = int(min_ratio * 100)
-        max_ratio = int(max_ratio * 100)
-        step = int(np.floor(max_ratio - min_ratio) / (self.num_levels - 2))
-        min_sizes = []
-        max_sizes = []
-        for ratio in range(int(min_ratio), int(max_ratio) + 1, step):
-            min_sizes.append(int(self.input_size * ratio / 100))
-            max_sizes.append(int(self.input_size * (ratio + step) / 100))
-        if self.input_size == 300:
-            if basesize_ratio_range[0] == 0.15:  # SSD300 COCO
-                min_sizes.insert(0, int(self.input_size * 7 / 100))
-                max_sizes.insert(0, int(self.input_size * 15 / 100))
-            elif basesize_ratio_range[0] == 0.2:  # SSD300 VOC
-                min_sizes.insert(0, int(self.input_size * 10 / 100))
-                max_sizes.insert(0, int(self.input_size * 20 / 100))
+        if min_sizes is None and max_sizes is None:
+            # use hard code to generate SSD anchors
+            self.input_size = input_size
+            assert mmcv.is_tuple_of(basesize_ratio_range, float)
+            self.basesize_ratio_range = basesize_ratio_range
+            # calculate anchor ratios and sizes
+            min_ratio, max_ratio = basesize_ratio_range
+            min_ratio = int(min_ratio * 100)
+            max_ratio = int(max_ratio * 100)
+            step = int(np.floor(max_ratio - min_ratio) / (self.num_levels - 2))
+            min_sizes = []
+            max_sizes = []
+            for ratio in range(int(min_ratio), int(max_ratio) + 1, step):
+                min_sizes.append(int(self.input_size * ratio / 100))
+                max_sizes.append(int(self.input_size * (ratio + step) / 100))
+            if self.input_size == 300:
+                if basesize_ratio_range[0] == 0.15:  # SSD300 COCO
+                    min_sizes.insert(0, int(self.input_size * 7 / 100))
+                    max_sizes.insert(0, int(self.input_size * 15 / 100))
+                elif basesize_ratio_range[0] == 0.2:  # SSD300 VOC
+                    min_sizes.insert(0, int(self.input_size * 10 / 100))
+                    max_sizes.insert(0, int(self.input_size * 20 / 100))
+                else:
+                    raise ValueError(
+                        'basesize_ratio_range[0] should be either 0.15'
+                        'or 0.2 when input_size is 300, got '
+                        f'{basesize_ratio_range[0]}.')
+            elif self.input_size == 512:
+                if basesize_ratio_range[0] == 0.1:  # SSD512 COCO
+                    min_sizes.insert(0, int(self.input_size * 4 / 100))
+                    max_sizes.insert(0, int(self.input_size * 10 / 100))
+                elif basesize_ratio_range[0] == 0.15:  # SSD512 VOC
+                    min_sizes.insert(0, int(self.input_size * 7 / 100))
+                    max_sizes.insert(0, int(self.input_size * 15 / 100))
+                else:
+                    raise ValueError(
+                        'When not setting min_sizes and max_sizes,'
+                        'basesize_ratio_range[0] should be either 0.1'
+                        'or 0.15 when input_size is 512, got'
+                        f' {basesize_ratio_range[0]}.')
             else:
                 raise ValueError(
-                    'basesize_ratio_range[0] should be either 0.15'
-                    'or 0.2 when input_size is 300, got '
-                    f'{basesize_ratio_range[0]}.')
-        elif self.input_size == 512:
-            if basesize_ratio_range[0] == 0.1:  # SSD512 COCO
-                min_sizes.insert(0, int(self.input_size * 4 / 100))
-                max_sizes.insert(0, int(self.input_size * 10 / 100))
-            elif basesize_ratio_range[0] == 0.15:  # SSD512 VOC
-                min_sizes.insert(0, int(self.input_size * 7 / 100))
-                max_sizes.insert(0, int(self.input_size * 15 / 100))
-            else:
-                raise ValueError('basesize_ratio_range[0] should be either 0.1'
-                                 'or 0.15 when input_size is 512, got'
-                                 f' {basesize_ratio_range[0]}.')
-        else:
-            raise ValueError('Only support 300 or 512 in SSDAnchorGenerator'
-                             f', got {self.input_size}.')
+                    'Only support 300 or 512 in SSDAnchorGenerator when '
+                    'not setting min_sizes and max_sizes, '
+                    f'got {self.input_size}.')
+
+        assert len(strides) == len(min_sizes) == len(max_sizes)
 
         anchor_ratios = []
         anchor_scales = []

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -322,17 +322,6 @@ def test_ssd_anchor_generator():
             ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
         build_anchor_generator(anchor_generator_cfg)
 
-    # length of min_sizes max_sizes must be same
-    with pytest.raises(AssertionError):
-        anchor_generator_cfg = dict(
-            type='SSDAnchorGenerator',
-            scale_major=False,
-            min_sizes=[48, 100, 150, 202, 253, 300],
-            max_sizes=[100, 150, 202, 253, 300],
-            strides=[8, 16, 32, 64, 100, 300],
-            ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
-        build_anchor_generator(anchor_generator_cfg)
-
     anchor_generator_cfg = dict(
         type='SSDAnchorGenerator',
         scale_major=False,

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -311,6 +311,28 @@ def test_ssd_anchor_generator():
     else:
         device = 'cpu'
 
+    # min_sizes max_sizes must set at the same time
+    with pytest.raises(AssertionError):
+        anchor_generator_cfg = dict(
+            type='SSDAnchorGenerator',
+            scale_major=False,
+            min_sizes=[48, 100, 150, 202, 253, 300],
+            max_sizes=None,
+            strides=[8, 16, 32, 64, 100, 300],
+            ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
+        build_anchor_generator(anchor_generator_cfg)
+
+    # length of min_sizes max_sizes must be same
+    with pytest.raises(AssertionError):
+        anchor_generator_cfg = dict(
+            type='SSDAnchorGenerator',
+            scale_major=False,
+            min_sizes=[48, 100, 150, 202, 253, 300],
+            max_sizes=[100, 150, 202, 253, 300],
+            strides=[8, 16, 32, 64, 100, 300],
+            ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
+        build_anchor_generator(anchor_generator_cfg)
+
     anchor_generator_cfg = dict(
         type='SSDAnchorGenerator',
         scale_major=False,

--- a/tests/test_utils/test_anchor.py
+++ b/tests/test_utils/test_anchor.py
@@ -322,6 +322,87 @@ def test_ssd_anchor_generator():
             ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
         build_anchor_generator(anchor_generator_cfg)
 
+    # length of min_sizes max_sizes must be the same
+    with pytest.raises(AssertionError):
+        anchor_generator_cfg = dict(
+            type='SSDAnchorGenerator',
+            scale_major=False,
+            min_sizes=[48, 100, 150, 202, 253, 300],
+            max_sizes=[100, 150, 202, 253],
+            strides=[8, 16, 32, 64, 100, 300],
+            ratios=[[2], [2, 3], [2, 3], [2, 3], [2], [2]])
+        build_anchor_generator(anchor_generator_cfg)
+
+    # test setting anchor size manually
+    anchor_generator_cfg = dict(
+        type='SSDAnchorGenerator',
+        scale_major=False,
+        min_sizes=[48, 100, 150, 202, 253, 304],
+        max_sizes=[100, 150, 202, 253, 304, 320],
+        strides=[16, 32, 64, 107, 160, 320],
+        ratios=[[2, 3], [2, 3], [2, 3], [2, 3], [2, 3], [2, 3]])
+
+    featmap_sizes = [(38, 38), (19, 19), (10, 10), (5, 5), (3, 3), (1, 1)]
+    anchor_generator = build_anchor_generator(anchor_generator_cfg)
+
+    expected_base_anchors = [
+        torch.Tensor([[-16.0000, -16.0000, 32.0000, 32.0000],
+                      [-26.6410, -26.6410, 42.6410, 42.6410],
+                      [-25.9411, -8.9706, 41.9411, 24.9706],
+                      [-8.9706, -25.9411, 24.9706, 41.9411],
+                      [-33.5692, -5.8564, 49.5692, 21.8564],
+                      [-5.8564, -33.5692, 21.8564, 49.5692]]),
+        torch.Tensor([[-34.0000, -34.0000, 66.0000, 66.0000],
+                      [-45.2372, -45.2372, 77.2372, 77.2372],
+                      [-54.7107, -19.3553, 86.7107, 51.3553],
+                      [-19.3553, -54.7107, 51.3553, 86.7107],
+                      [-70.6025, -12.8675, 102.6025, 44.8675],
+                      [-12.8675, -70.6025, 44.8675, 102.6025]]),
+        torch.Tensor([[-43.0000, -43.0000, 107.0000, 107.0000],
+                      [-55.0345, -55.0345, 119.0345, 119.0345],
+                      [-74.0660, -21.0330, 138.0660, 85.0330],
+                      [-21.0330, -74.0660, 85.0330, 138.0660],
+                      [-97.9038, -11.3013, 161.9038, 75.3013],
+                      [-11.3013, -97.9038, 75.3013, 161.9038]]),
+        torch.Tensor([[-47.5000, -47.5000, 154.5000, 154.5000],
+                      [-59.5332, -59.5332, 166.5332, 166.5332],
+                      [-89.3356, -17.9178, 196.3356, 124.9178],
+                      [-17.9178, -89.3356, 124.9178, 196.3356],
+                      [-121.4371, -4.8124, 228.4371, 111.8124],
+                      [-4.8124, -121.4371, 111.8124, 228.4371]]),
+        torch.Tensor([[-46.5000, -46.5000, 206.5000, 206.5000],
+                      [-58.6651, -58.6651, 218.6651, 218.6651],
+                      [-98.8980, -9.4490, 258.8980, 169.4490],
+                      [-9.4490, -98.8980, 169.4490, 258.8980],
+                      [-139.1044, 6.9652, 299.1044, 153.0348],
+                      [6.9652, -139.1044, 153.0348, 299.1044]]),
+        torch.Tensor([[8.0000, 8.0000, 312.0000, 312.0000],
+                      [4.0513, 4.0513, 315.9487, 315.9487],
+                      [-54.9605, 52.5198, 374.9604, 267.4802],
+                      [52.5198, -54.9605, 267.4802, 374.9604],
+                      [-103.2717, 72.2428, 423.2717, 247.7572],
+                      [72.2428, -103.2717, 247.7572, 423.2717]])
+    ]
+
+    base_anchors = anchor_generator.base_anchors
+    for i, base_anchor in enumerate(base_anchors):
+        assert base_anchor.allclose(expected_base_anchors[i])
+
+    # check valid flags
+    expected_valid_pixels = [2400, 600, 150, 54, 24, 6]
+    multi_level_valid_flags = anchor_generator.valid_flags(
+        featmap_sizes, (320, 320), device)
+    for i, single_level_valid_flag in enumerate(multi_level_valid_flags):
+        assert single_level_valid_flag.sum() == expected_valid_pixels[i]
+
+    # check number of base anchors for each level
+    assert anchor_generator.num_base_anchors == [6, 6, 6, 6, 6, 6]
+
+    # check anchor generation
+    anchors = anchor_generator.grid_anchors(featmap_sizes, device)
+    assert len(anchors) == 6
+
+    # test vgg ssd anchor setting
     anchor_generator_cfg = dict(
         type='SSDAnchorGenerator',
         scale_major=False,


### PR DESCRIPTION
## Feature 

1. Support setting anchor size manually in SSDAnchorGenerator
2. Add MobileNetV2 SSD-Lite config

## Performance of MobileNetV2 SSD-Lite on coco val2017:

```
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.213
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=1000 ] = 0.354
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=1000 ] = 0.218
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.016
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.209
 Average Precision  (AP) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.413
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=100 ] = 0.322
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=300 ] = 0.322
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=1000 ] = 0.322
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.045
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.347
 Average Recall     (AR) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.597
```

## Notice

There are some differences between this implementation and the one in [TensorFlow 1.x detection model zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/tf1_detection_zoo.md).
1. Use 320x320 as input size instead of 300x300.
2. The anchor setting is different.
3. The C4 feature map is taken from the last layer of stage 4 instead of the middle of the block.
4. TensorFlow1.x implementation is trained on coco 2014 and validated on coco minival2014 but this is trained and validated on coco 2017. The mAP on val2017 is usually a little bit lower than minival2014 (refer to the results in TensorFlow Object Detection API, e.g. mAP of MobileNetV2 SSD is 22 on minival2014 but 20.2 on val2017).

