### PR TITLE
[Fix] Use `warnings.warn` instead of `logger.warning`

### DIFF
--- a/mmdet/models/roi_heads/point_rend_roi_head.py
+++ b/mmdet/models/roi_heads/point_rend_roi_head.py
@@ -1,6 +1,6 @@
 # Modified from https://github.com/facebookresearch/detectron2/tree/master/projects/PointRend  # noqa
-import logging
 import os
+import warnings
 
 import numpy as np
 import torch
@@ -11,8 +11,6 @@ from mmdet.core import bbox2roi, bbox_mapping, merge_aug_masks
 from .. import builder
 from ..builder import HEADS
 from .standard_roi_head import StandardRoIHead
-
-logger = logging.getLogger(__name__)
 
 
 @HEADS.register_module()
@@ -164,7 +162,7 @@ class PointRendRoIHead(StandardRoIHead):
         scale_factors = tuple(meta['scale_factor'] for meta in img_metas)
 
         if isinstance(scale_factors[0], float):
-            logger.warning(
+            warnings.warn(
                 'Scale factor in img_metas should be a '
                 'ndarray with shape (4,) '
                 'arrange as (factor_w, factor_h, factor_w, factor_h), '

--- a/mmdet/models/roi_heads/test_mixins.py
+++ b/mmdet/models/roi_heads/test_mixins.py
@@ -1,5 +1,5 @@
-import logging
 import sys
+import warnings
 
 import numpy as np
 import torch
@@ -7,7 +7,6 @@ import torch
 from mmdet.core import (bbox2roi, bbox_mapping, merge_aug_bboxes,
                         merge_aug_masks, multiclass_nms)
 
-logger = logging.getLogger(__name__)
 if sys.version_info >= (3, 7):
     from mmdet.utils.contextmanagers import completed
 
@@ -233,7 +232,7 @@ class MaskTestMixin:
         scale_factors = tuple(meta['scale_factor'] for meta in img_metas)
 
         if isinstance(scale_factors[0], float):
-            logger.warning(
+            warnings.warn(
                 'Scale factor in img_metas should be a '
                 'ndarray with shape (4,) '
                 'arrange as (factor_w, factor_h, factor_w, factor_h), '


### PR DESCRIPTION
Logger.warning() will report a warning message every time during inference.
We should fix it.