### PR TITLE
Fix browse_dataset bug when using dataset wrappers

### DIFF
--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -53,6 +53,8 @@ def retrieve_data_cfg(config_path, skip_type, cfg_options):
         from mmcv.utils import import_modules_from_strings
         import_modules_from_strings(**cfg['custom_imports'])
     train_data_cfg = cfg.data.train
+    while 'dataset' in train_data_cfg:
+        train_data_cfg = train_data_cfg['dataset']
     train_data_cfg['pipeline'] = [
         x for x in train_data_cfg.pipeline if x['type'] not in skip_type
     ]


### PR DESCRIPTION
When using dataset wrappers, there is no `pipeline` key in `cfg.data.train`. This will cause an error when running  browse_dataset.py. This PR fixes this bug.