### PR TITLE
Fix unittest error of pretrain cfg

### DIFF
--- a/configs/fast_rcnn/fast_rcnn_r101_caffe_fpn_1x_coco.py
+++ b/configs/fast_rcnn/fast_rcnn_r101_caffe_fpn_1x_coco.py
@@ -1,6 +1,5 @@
 _base_ = './fast_rcnn_r50_caffe_fpn_1x_coco.py'
 model = dict(
-    pretrained='open-mmlab://detectron2/resnet101_caffe',
     backbone=dict(
         depth=101,
         init_cfg=dict(

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -45,17 +45,14 @@ def _get_detector_cfg(fname):
 def test_sparse_rcnn_forward():
     config_path = 'sparse_rcnn/sparse_rcnn_r50_fpn_1x_coco.py'
     model = _get_detector_cfg(config_path)
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
     from mmdet.models import build_detector
     detector = build_detector(model)
-    detector.init_weights()
     input_shape = (1, 3, 550, 550)
     mm_inputs = _demo_mm_inputs(input_shape, num_items=[5])
     imgs = mm_inputs.pop('imgs')
     img_metas = mm_inputs.pop('img_metas')
     # Test forward train with non-empty truth batch
-    detector = detector
-    imgs = imgs
     detector.train()
     gt_bboxes = mm_inputs['gt_bboxes']
     gt_bboxes = [item for item in gt_bboxes]
@@ -75,7 +72,6 @@ def test_sparse_rcnn_forward():
     # Test forward train with an empty truth batch
     mm_inputs = _demo_mm_inputs(input_shape, num_items=[0])
     imgs = mm_inputs.pop('imgs')
-    imgs = imgs
     img_metas = mm_inputs.pop('img_metas')
     gt_bboxes = mm_inputs['gt_bboxes']
     gt_bboxes = [item for item in gt_bboxes]
@@ -105,7 +101,7 @@ def test_sparse_rcnn_forward():
 
 def test_rpn_forward():
     model = _get_detector_cfg('rpn/rpn_r50_fpn_1x_coco.py')
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -151,7 +147,7 @@ def test_single_stage_forward_gpu(cfg_file):
         pytest.skip('test requires GPU and torch+cuda')
 
     model = _get_detector_cfg(cfg_file)
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -188,7 +184,7 @@ def test_single_stage_forward_gpu(cfg_file):
 def test_faster_rcnn_ohem_forward():
     model = _get_detector_cfg(
         'faster_rcnn/faster_rcnn_r50_fpn_ohem_1x_coco.py')
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -250,7 +246,7 @@ def test_two_stage_forward(cfg_file):
         with_semantic = False
 
     model = _get_detector_cfg(cfg_file)
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     # Save cost
     if cfg_file in [
@@ -305,7 +301,7 @@ def test_two_stage_forward(cfg_file):
     'cfg_file', ['ghm/retinanet_ghm_r50_fpn_1x_coco.py', 'ssd/ssd300_coco.py'])
 def test_single_stage_forward_cpu(cfg_file):
     model = _get_detector_cfg(cfg_file)
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -417,7 +413,7 @@ def _demo_mm_inputs(input_shape=(1, 3, 300, 300),
 
 def test_yolact_forward():
     model = _get_detector_cfg('yolact/yolact_r50_1x8_coco.py')
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -456,7 +452,7 @@ def test_yolact_forward():
 
 def test_detr_forward():
     model = _get_detector_cfg('detr/detr_r50_8x2_150e_coco.py')
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -511,7 +507,7 @@ def test_detr_forward():
 
 def test_kd_single_stage_forward():
     model = _get_detector_cfg('ld/ld_r18_gflv1_r101_fpn_coco_1x.py')
-    model['pretrained'] = None
+    model.backbone.init_cfg = None
 
     from mmdet.models import build_detector
     detector = build_detector(model)
@@ -573,7 +569,6 @@ def test_inference_detector():
     num_class = 3
     model_dict = dict(
         type='RetinaNet',
-        pretrained=None,
         backbone=dict(
             type='ResNet',
             depth=18,

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -48,6 +48,7 @@ def test_sparse_rcnn_forward():
     model.backbone.init_cfg = None
     from mmdet.models import build_detector
     detector = build_detector(model)
+    detector.init_weights()
     input_shape = (1, 3, 550, 550)
     mm_inputs = _demo_mm_inputs(input_shape, num_items=[5])
     imgs = mm_inputs.pop('imgs')


### PR DESCRIPTION
## Motivation

The unit test for the pretrain configuration is wrong.

## Modification

model.backbone.init_cfg = None





