### PR TITLE
Fix valid_mask logic error of rpn_head

### DIFF
--- a/mmdet/models/dense_heads/cascade_rpn_head.py
+++ b/mmdet/models/dense_heads/cascade_rpn_head.py
@@ -631,14 +631,11 @@ class StageCascadeRPNHead(RPNHead):
         if cfg.min_bbox_size >= 0 and (not torch.onnx.is_in_onnx_export()):
             w = proposals[:, 2] - proposals[:, 0]
             h = proposals[:, 3] - proposals[:, 1]
-            valid_inds = torch.nonzero(
-                (w > cfg.min_bbox_size)
-                & (h > cfg.min_bbox_size),
-                as_tuple=False).squeeze()
-            if valid_inds.sum().item() != len(proposals):
-                proposals = proposals[valid_inds, :]
-                scores = scores[valid_inds]
-                ids = ids[valid_inds]
+            valid_mask = (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size)
+            if not valid_mask.all():
+                proposals = proposals[valid_mask]
+                scores = scores[valid_mask]
+                ids = ids[valid_mask]
 
         # deprecate arguments warning
         if 'nms' not in cfg or 'max_num' in cfg or 'nms_thr' in cfg:

--- a/mmdet/models/dense_heads/ga_rpn_head.py
+++ b/mmdet/models/dense_heads/ga_rpn_head.py
@@ -153,11 +153,11 @@ class GARPNHead(GuidedAnchorHead):
             if cfg.min_bbox_size >= 0:
                 w = proposals[:, 2] - proposals[:, 0]
                 h = proposals[:, 3] - proposals[:, 1]
-                valid_inds = torch.nonzero(
-                    (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size),
-                    as_tuple=False).squeeze()
-                proposals = proposals[valid_inds, :]
-                scores = scores[valid_inds]
+                valid_mask = (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size)
+                if not valid_mask.all():
+                    proposals = proposals[valid_mask]
+                    scores = scores[valid_mask]
+
             # NMS in current level
             proposals, _ = nms(proposals, scores, cfg.nms.iou_threshold)
             proposals = proposals[:cfg.nms_post, :]

--- a/mmdet/models/dense_heads/rpn_head.py
+++ b/mmdet/models/dense_heads/rpn_head.py
@@ -208,10 +208,10 @@ class RPNHead(AnchorHead):
             anchors, rpn_bbox_pred, max_shape=img_shape)
         ids = torch.cat(level_ids)
 
-        if cfg.min_bbox_size > 0:
+        if cfg.min_bbox_size >= 0:
             w = proposals[:, 2] - proposals[:, 0]
             h = proposals[:, 3] - proposals[:, 1]
-            valid_mask = (w >= cfg.min_bbox_size) & (h >= cfg.min_bbox_size)
+            valid_mask = (w > cfg.min_bbox_size) & (h > cfg.min_bbox_size)
             if not valid_mask.all():
                 proposals = proposals[valid_mask]
                 scores = scores[valid_mask]


### PR DESCRIPTION
## Motivation

There is an error in the rpn filtering minimum bbox logic.

## Modification

1. Fix rpn and cascade rpn head errors of filtering minimum bbox logic
2. Modify ga rpn head to unify the writing of filtering minimum bbox logic
 
