### PR TITLE
The `multiclass_nms` should return the global indices.

### DIFF
--- a/mmdet/core/post_processing/bbox_nms.py
+++ b/mmdet/core/post_processing/bbox_nms.py
@@ -89,7 +89,7 @@ def multiclass_nms(multi_bboxes,
         keep = keep[:max_num]
 
     if return_inds:
-        return dets, labels[keep], keep
+        return dets, labels[keep], inds[keep]
     else:
         return dets, labels[keep]
 


### PR DESCRIPTION
## Motivation
This PR improves the codes for multi_class bbox NMS by returning the global indice.

Currently [multiclass_nms](https://github.com/open-mmlab/mmdetection/blob/b9dedfdc8b660804bb31ae031a251e86a4905ade/mmdet/core/post_processing/bbox_nms.py#L7-L94) returns the local indices after batched_nms:

<https://github.com/open-mmlab/mmdetection/blob/b9dedfdc8b660804bb31ae031a251e86a4905ade/mmdet/core/post_processing/bbox_nms.py#L85-L92>

The returned indices is useless outside the function unless it's a global indice w.r.t the inputs.

## Modification
The modification is quite slight: change <https://github.com/open-mmlab/mmdetection/blob/b9dedfdc8b660804bb31ae031a251e86a4905ade/mmdet/core/post_processing/bbox_nms.py#L92>

to `return dets, labels[keep], inds[keep]`