### PR TITLE
Use legacy coordinate in metric of VOC

### DIFF
--- a/mmdet/core/evaluation/bbox_overlaps.py
+++ b/mmdet/core/evaluation/bbox_overlaps.py
@@ -16,6 +16,9 @@ def bbox_overlaps(bboxes1,
         use_legacy_coordinate (bool): Whether to use coordinate system in
             mmdet v1.x. which means width, height should be
             calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
+            Note when function is used in `VOCDataset`, it should be
+            True to align with the official implementation
+            `http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCdevkit_18-May-2011.tar`
             Default: False.
 
     Returns:

--- a/mmdet/core/evaluation/bbox_overlaps.py
+++ b/mmdet/core/evaluation/bbox_overlaps.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6):
+def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6, extra_length=0.):
     """Calculate the ious between each bbox of bboxes1 and bboxes2.
 
     Args:
@@ -9,13 +9,17 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6):
         bboxes2(ndarray): shape (k, 4)
         mode(str): iou (intersection over union) or iof (intersection
             over foreground)
-
+        extra_length (float): `extra_length` should be added when calculate
+            the width and height, which means w, h should be computed as
+            'x2 - x1 + extra_length` and 'y2 - y1 + extra_length'.
+            Default: 0.
     Returns:
         ious(ndarray): shape (n, k)
     """
 
     assert mode in ['iou', 'iof']
-
+    assert extra_length in (0.,
+                            1.), 'Only allow the `extra_length` to be 0 or 1'
     bboxes1 = bboxes1.astype(np.float32)
     bboxes2 = bboxes2.astype(np.float32)
     rows = bboxes1.shape[0]
@@ -28,15 +32,17 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6):
         bboxes1, bboxes2 = bboxes2, bboxes1
         ious = np.zeros((cols, rows), dtype=np.float32)
         exchange = True
-    area1 = (bboxes1[:, 2] - bboxes1[:, 0]) * (bboxes1[:, 3] - bboxes1[:, 1])
-    area2 = (bboxes2[:, 2] - bboxes2[:, 0]) * (bboxes2[:, 3] - bboxes2[:, 1])
+    area1 = (bboxes1[:, 2] - bboxes1[:, 0] + extra_length) * (
+        bboxes1[:, 3] - bboxes1[:, 1] + extra_length)
+    area2 = (bboxes2[:, 2] - bboxes2[:, 0] + extra_length) * (
+        bboxes2[:, 3] - bboxes2[:, 1] + extra_length)
     for i in range(bboxes1.shape[0]):
         x_start = np.maximum(bboxes1[i, 0], bboxes2[:, 0])
         y_start = np.maximum(bboxes1[i, 1], bboxes2[:, 1])
         x_end = np.minimum(bboxes1[i, 2], bboxes2[:, 2])
         y_end = np.minimum(bboxes1[i, 3], bboxes2[:, 3])
-        overlap = np.maximum(x_end - x_start, 0) * np.maximum(
-            y_end - y_start, 0)
+        overlap = np.maximum(x_end - x_start + extra_length, 0) * np.maximum(
+            y_end - y_start + extra_length, 0)
         if mode == 'iou':
             union = area1[i] + area2 - overlap
         else:

--- a/mmdet/core/evaluation/bbox_overlaps.py
+++ b/mmdet/core/evaluation/bbox_overlaps.py
@@ -9,16 +9,17 @@ def bbox_overlaps(bboxes1,
     """Calculate the ious between each bbox of bboxes1 and bboxes2.
 
     Args:
-        bboxes1 (ndarray): shape (n, 4)
-        bboxes2 (ndarray): shape (k, 4)
-        mode (str): iou (intersection over union) or iof (intersection
+        bboxes1 (ndarray): Shape (n, 4)
+        bboxes2 (ndarray): Shape (k, 4)
+        mode (str): IOU (intersection over union) or IOF (intersection
             over foreground)
         use_legacy_coordinate (bool): Whether to use coordinate system in
             mmdet v1.x. which means width, height should be
             calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
             Default: False.
+
     Returns:
-        ious (ndarray): shape (n, k)
+        ious (ndarray): Shape (n, k)
     """
 
     assert mode in ['iou', 'iof']

--- a/mmdet/core/evaluation/bbox_overlaps.py
+++ b/mmdet/core/evaluation/bbox_overlaps.py
@@ -5,16 +5,16 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6, extra_length=0.):
     """Calculate the ious between each bbox of bboxes1 and bboxes2.
 
     Args:
-        bboxes1(ndarray): shape (n, 4)
-        bboxes2(ndarray): shape (k, 4)
-        mode(str): iou (intersection over union) or iof (intersection
+        bboxes1 (ndarray): shape (n, 4)
+        bboxes2 (ndarray): shape (k, 4)
+        mode (str): iou (intersection over union) or iof (intersection
             over foreground)
         extra_length (float): `extra_length` should be added when calculate
             the width and height, which means w, h should be computed as
             'x2 - x1 + extra_length` and 'y2 - y1 + extra_length'.
             Default: 0.
     Returns:
-        ious(ndarray): shape (n, k)
+        ious (ndarray): shape (n, k)
     """
 
     assert mode in ['iou', 'iof']

--- a/mmdet/core/evaluation/bbox_overlaps.py
+++ b/mmdet/core/evaluation/bbox_overlaps.py
@@ -1,7 +1,11 @@
 import numpy as np
 
 
-def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6, extra_length=0.):
+def bbox_overlaps(bboxes1,
+                  bboxes2,
+                  mode='iou',
+                  eps=1e-6,
+                  use_legacy_coordinate=False):
     """Calculate the ious between each bbox of bboxes1 and bboxes2.
 
     Args:
@@ -9,17 +13,19 @@ def bbox_overlaps(bboxes1, bboxes2, mode='iou', eps=1e-6, extra_length=0.):
         bboxes2 (ndarray): shape (k, 4)
         mode (str): iou (intersection over union) or iof (intersection
             over foreground)
-        extra_length (float): `extra_length` should be added when calculate
-            the width and height, which means w, h should be computed as
-            'x2 - x1 + extra_length` and 'y2 - y1 + extra_length'.
-            Default: 0.
+        use_legacy_coordinate (bool): Whether to use coordinate system in
+            mmdet v1.x. which means width, height should be
+            calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
+            Default: False.
     Returns:
         ious (ndarray): shape (n, k)
     """
 
     assert mode in ['iou', 'iof']
-    assert extra_length in (0.,
-                            1.), 'Only allow the `extra_length` to be 0 or 1'
+    if not use_legacy_coordinate:
+        extra_length = 0.
+    else:
+        extra_length = 1.
     bboxes1 = bboxes1.astype(np.float32)
     bboxes2 = bboxes2.astype(np.float32)
     rows = bboxes1.shape[0]

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -115,7 +115,8 @@ def tpfp_imagenet(det_bboxes,
             for i, (min_area, max_area) in enumerate(area_ranges):
                 fp[i, (det_areas >= min_area) & (det_areas < max_area)] = 1
         return tp, fp
-    ious = bbox_overlaps(det_bboxes, gt_bboxes - 1, extra_length=extra_length)
+    ious = bbox_overlaps(
+        det_bboxes, gt_bboxes - 1, use_legacy_coordinate=use_legacy_coordinate)
     gt_w = gt_bboxes[:, 2] - gt_bboxes[:, 0] + extra_length
     gt_h = gt_bboxes[:, 3] - gt_bboxes[:, 1] + extra_length
     iou_thrs = np.minimum((gt_w * gt_h) / ((gt_w + 10.0) * (gt_h + 10.0)),

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -226,7 +226,8 @@ def tpfp_default(det_bboxes,
                 fp[i, (det_areas >= min_area) & (det_areas < max_area)] = 1
         return tp, fp
 
-    ious = bbox_overlaps(det_bboxes, gt_bboxes, extra_length=extra_length)
+    ious = bbox_overlaps(
+        det_bboxes, gt_bboxes, use_legacy_coordinate=use_legacy_coordinate)
     # for each det, the max iou with all gts
     ious_max = ious.max(axis=1)
     # for each det, which gt overlaps most with it

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -60,7 +60,8 @@ def tpfp_imagenet(det_bboxes,
                   gt_bboxes,
                   gt_bboxes_ignore=None,
                   default_iou_thr=0.5,
-                  area_ranges=None):
+                  area_ranges=None,
+                  Legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -73,11 +74,20 @@ def tpfp_imagenet(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
+        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
+            "1" was added to both height and width which means should be
+             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
 
     Returns:
         tuple[np.ndarray]: (tp, fp) whose elements are 0 and 1. The shape of
             each array is (num_scales, m).
     """
+
+    if not Legacy_coordinate:
+        extra_length = 0.
+    else:
+        extra_length = 1.
+
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
         (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
@@ -98,14 +108,15 @@ def tpfp_imagenet(det_bboxes,
         if area_ranges == [(None, None)]:
             fp[...] = 1
         else:
-            det_areas = (det_bboxes[:, 2] - det_bboxes[:, 0]) * (
-                det_bboxes[:, 3] - det_bboxes[:, 1])
+            det_areas = (
+                det_bboxes[:, 2] - det_bboxes[:, 0] + extra_length) * (
+                    det_bboxes[:, 3] - det_bboxes[:, 1] + extra_length)
             for i, (min_area, max_area) in enumerate(area_ranges):
                 fp[i, (det_areas >= min_area) & (det_areas < max_area)] = 1
         return tp, fp
-    ious = bbox_overlaps(det_bboxes, gt_bboxes - 1)
-    gt_w = gt_bboxes[:, 2] - gt_bboxes[:, 0]
-    gt_h = gt_bboxes[:, 3] - gt_bboxes[:, 1]
+    ious = bbox_overlaps(det_bboxes, gt_bboxes - 1, extra_length=extra_length)
+    gt_w = gt_bboxes[:, 2] - gt_bboxes[:, 0] + extra_length
+    gt_h = gt_bboxes[:, 3] - gt_bboxes[:, 1] + extra_length
     iou_thrs = np.minimum((gt_w * gt_h) / ((gt_w + 10.0) * (gt_h + 10.0)),
                           default_iou_thr)
     # sort all detections by scores in descending order
@@ -144,7 +155,8 @@ def tpfp_imagenet(det_bboxes,
                 fp[k, i] = 1
             else:
                 bbox = det_bboxes[i, :4]
-                area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+                area = (bbox[2] - bbox[0] + extra_length) * (
+                    bbox[3] - bbox[1] + extra_length)
                 if area >= min_area and area < max_area:
                     fp[k, i] = 1
     return tp, fp
@@ -154,7 +166,8 @@ def tpfp_default(det_bboxes,
                  gt_bboxes,
                  gt_bboxes_ignore=None,
                  iou_thr=0.5,
-                 area_ranges=None):
+                 area_ranges=None,
+                 Legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -166,11 +179,22 @@ def tpfp_default(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
+        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
+            "1" was added to both height and width which means h, w should be
+             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
+             The `Legacy_coordinate` should be Ture
+             when evaluate the VOC dataset.
 
     Returns:
         tuple[np.ndarray]: (tp, fp) whose elements are 0 and 1. The shape of
             each array is (num_scales, m).
     """
+
+    if not Legacy_coordinate:
+        extra_length = 0.
+    else:
+        extra_length = 1.
+
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
         (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
@@ -194,13 +218,14 @@ def tpfp_default(det_bboxes,
         if area_ranges == [(None, None)]:
             fp[...] = 1
         else:
-            det_areas = (det_bboxes[:, 2] - det_bboxes[:, 0]) * (
-                det_bboxes[:, 3] - det_bboxes[:, 1])
+            det_areas = (
+                det_bboxes[:, 2] - det_bboxes[:, 0] + extra_length) * (
+                    det_bboxes[:, 3] - det_bboxes[:, 1] + extra_length)
             for i, (min_area, max_area) in enumerate(area_ranges):
                 fp[i, (det_areas >= min_area) & (det_areas < max_area)] = 1
         return tp, fp
 
-    ious = bbox_overlaps(det_bboxes, gt_bboxes)
+    ious = bbox_overlaps(det_bboxes, gt_bboxes, extra_length=extra_length)
     # for each det, the max iou with all gts
     ious_max = ious.max(axis=1)
     # for each det, which gt overlaps most with it
@@ -213,8 +238,8 @@ def tpfp_default(det_bboxes,
         if min_area is None:
             gt_area_ignore = np.zeros_like(gt_ignore_inds, dtype=bool)
         else:
-            gt_areas = (gt_bboxes[:, 2] - gt_bboxes[:, 0]) * (
-                gt_bboxes[:, 3] - gt_bboxes[:, 1])
+            gt_areas = (gt_bboxes[:, 2] - gt_bboxes[:, 0] + extra_length) * (
+                gt_bboxes[:, 3] - gt_bboxes[:, 1] + extra_length)
             gt_area_ignore = (gt_areas < min_area) | (gt_areas >= max_area)
         for i in sort_inds:
             if ious_max[i] >= iou_thr:
@@ -231,7 +256,8 @@ def tpfp_default(det_bboxes,
                 fp[k, i] = 1
             else:
                 bbox = det_bboxes[i, :4]
-                area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+                area = (bbox[2] - bbox[0] + extra_length) * (
+                    bbox[3] - bbox[1] + extra_length)
                 if area >= min_area and area < max_area:
                     fp[k, i] = 1
     return tp, fp
@@ -271,7 +297,8 @@ def eval_map(det_results,
              dataset=None,
              logger=None,
              tpfp_fn=None,
-             nproc=4):
+             nproc=4,
+             Legacy_coordinate=False):
     """Evaluate mAP of a dataset.
 
     Args:
@@ -303,11 +330,18 @@ def eval_map(det_results,
             to evaluate tp & fp. Default None.
         nproc (int): Processes used for computing TP and FP.
             Default: 4.
+        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
+            "1" was added to both height and width which means should be
+             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
 
     Returns:
         tuple: (mAP, [dict, dict, ...])
     """
     assert len(det_results) == len(annotations)
+    if not Legacy_coordinate:
+        extra_length = 0.
+    else:
+        extra_length = 1.
 
     num_imgs = len(det_results)
     num_scales = len(scale_ranges) if scale_ranges is not None else 1
@@ -336,7 +370,8 @@ def eval_map(det_results,
             tpfp_fn,
             zip(cls_dets, cls_gts, cls_gts_ignore,
                 [iou_thr for _ in range(num_imgs)],
-                [area_ranges for _ in range(num_imgs)]))
+                [area_ranges for _ in range(num_imgs)],
+                [Legacy_coordinate for _ in range(num_imgs)]))
         tp, fp = tuple(zip(*tpfp))
         # calculate gt number of each scale
         # ignored gts or gts beyond the specific scale are not counted
@@ -345,8 +380,8 @@ def eval_map(det_results,
             if area_ranges is None:
                 num_gts[0] += bbox.shape[0]
             else:
-                gt_areas = (bbox[:, 2] - bbox[:, 0]) * (
-                    bbox[:, 3] - bbox[:, 1])
+                gt_areas = (bbox[:, 2] - bbox[:, 0] + extra_length) * (
+                    bbox[:, 3] - bbox[:, 1] + extra_length)
                 for k, (min_area, max_area) in enumerate(area_ranges):
                     num_gts[k] += np.sum((gt_areas >= min_area)
                                          & (gt_areas < max_area))

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -61,7 +61,7 @@ def tpfp_imagenet(det_bboxes,
                   gt_bboxes_ignore=None,
                   default_iou_thr=0.5,
                   area_ranges=None,
-                  legacy_coordinate=False):
+                  use_legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -74,7 +74,7 @@ def tpfp_imagenet(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
-        legacy_coordinate (bool): Whether to use coordinate system in
+        use_legacy_coordinate (bool): Whether to use coordinate system in
             mmdet v1.x. which means width, height should be
             calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
             Default: False.
@@ -84,7 +84,7 @@ def tpfp_imagenet(det_bboxes,
             each array is (num_scales, m).
     """
 
-    if not legacy_coordinate:
+    if not use_legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -168,7 +168,7 @@ def tpfp_default(det_bboxes,
                  gt_bboxes_ignore=None,
                  iou_thr=0.5,
                  area_ranges=None,
-                 legacy_coordinate=False):
+                 use_legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -181,7 +181,7 @@ def tpfp_default(det_bboxes,
         area_ranges (list[tuple] | None): Range of bbox areas to be
             evaluated, in the format [(min1, max1), (min2, max2), ...].
             Default: None.
-        legacy_coordinate (bool): Whether to use coordinate system in
+        use_legacy_coordinate (bool): Whether to use coordinate system in
             mmdet v1.x. which means width, height should be
             calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
             Default: False.
@@ -191,7 +191,7 @@ def tpfp_default(det_bboxes,
             each array is (num_scales, m).
     """
 
-    if not legacy_coordinate:
+    if not use_legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -299,7 +299,7 @@ def eval_map(det_results,
              logger=None,
              tpfp_fn=None,
              nproc=4,
-             legacy_coordinate=False):
+             use_legacy_coordinate=False):
     """Evaluate mAP of a dataset.
 
     Args:
@@ -331,7 +331,7 @@ def eval_map(det_results,
             to evaluate tp & fp. Default None.
         nproc (int): Processes used for computing TP and FP.
             Default: 4.
-        legacy_coordinate (bool): Whether to use coordinate system in
+        use_legacy_coordinate (bool): Whether to use coordinate system in
             mmdet v1.x. which means width, height should be
             calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
             Default: False.
@@ -340,7 +340,7 @@ def eval_map(det_results,
         tuple: (mAP, [dict, dict, ...])
     """
     assert len(det_results) == len(annotations)
-    if not legacy_coordinate:
+    if not use_legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -373,7 +373,7 @@ def eval_map(det_results,
             zip(cls_dets, cls_gts, cls_gts_ignore,
                 [iou_thr for _ in range(num_imgs)],
                 [area_ranges for _ in range(num_imgs)],
-                [legacy_coordinate for _ in range(num_imgs)]))
+                [use_legacy_coordinate for _ in range(num_imgs)]))
         tp, fp = tuple(zip(*tpfp))
         # calculate gt number of each scale
         # ignored gts or gts beyond the specific scale are not counted

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -61,7 +61,7 @@ def tpfp_imagenet(det_bboxes,
                   gt_bboxes_ignore=None,
                   default_iou_thr=0.5,
                   area_ranges=None,
-                  Legacy_coordinate=False):
+                  legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -74,16 +74,17 @@ def tpfp_imagenet(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
-        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
-            "1" was added to both height and width which means w, h should be
-             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
+        legacy_coordinate (bool): Whether to use coordinate system in
+            mmdet v1.x. which means width, height should be
+            calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
+            Default: False.
 
     Returns:
         tuple[np.ndarray]: (tp, fp) whose elements are 0 and 1. The shape of
             each array is (num_scales, m).
     """
 
-    if not Legacy_coordinate:
+    if not legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -167,7 +168,7 @@ def tpfp_default(det_bboxes,
                  gt_bboxes_ignore=None,
                  iou_thr=0.5,
                  area_ranges=None,
-                 Legacy_coordinate=False):
+                 legacy_coordinate=False):
     """Check if detected bboxes are true positive or false positive.
 
     Args:
@@ -177,20 +178,20 @@ def tpfp_default(det_bboxes,
             of shape (k, 4). Default: None
         iou_thr (float): IoU threshold to be considered as matched.
             Default: 0.5.
-        area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
-            in the format [(min1, max1), (min2, max2), ...]. Default: None.
-        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
-            "1" was added to both height and width which means w, h should be
-             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
-             The `Legacy_coordinate` should be Ture
-             when evaluate the VOC dataset.
+        area_ranges (list[tuple] | None): Range of bbox areas to be
+            evaluated, in the format [(min1, max1), (min2, max2), ...].
+            Default: None.
+        legacy_coordinate (bool): Whether to use coordinate system in
+            mmdet v1.x. which means width, height should be
+            calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
+            Default: False.
 
     Returns:
         tuple[np.ndarray]: (tp, fp) whose elements are 0 and 1. The shape of
             each array is (num_scales, m).
     """
 
-    if not Legacy_coordinate:
+    if not legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -298,7 +299,7 @@ def eval_map(det_results,
              logger=None,
              tpfp_fn=None,
              nproc=4,
-             Legacy_coordinate=False):
+             legacy_coordinate=False):
     """Evaluate mAP of a dataset.
 
     Args:
@@ -330,15 +331,16 @@ def eval_map(det_results,
             to evaluate tp & fp. Default None.
         nproc (int): Processes used for computing TP and FP.
             Default: 4.
-        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
-            "1" was added to both height and width which means w, h should be
-             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
+        legacy_coordinate (bool): Whether to use coordinate system in
+            mmdet v1.x. which means width, height should be
+            calculated as 'x2 - x1 + 1` and 'y2 - y1 + 1' respectively.
+            Default: False.
 
     Returns:
         tuple: (mAP, [dict, dict, ...])
     """
     assert len(det_results) == len(annotations)
-    if not Legacy_coordinate:
+    if not legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.
@@ -371,7 +373,7 @@ def eval_map(det_results,
             zip(cls_dets, cls_gts, cls_gts_ignore,
                 [iou_thr for _ in range(num_imgs)],
                 [area_ranges for _ in range(num_imgs)],
-                [Legacy_coordinate for _ in range(num_imgs)]))
+                [legacy_coordinate for _ in range(num_imgs)]))
         tp, fp = tuple(zip(*tpfp))
         # calculate gt number of each scale
         # ignored gts or gts beyond the specific scale are not counted

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -74,8 +74,8 @@ def tpfp_imagenet(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
-        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
-            "1" was added to both height and width which means should be
+        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
+            "1" was added to both height and width which means w, h should be
              computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
 
     Returns:
@@ -179,8 +179,8 @@ def tpfp_default(det_bboxes,
             Default: 0.5.
         area_ranges (list[tuple] | None): Range of bbox areas to be evaluated,
             in the format [(min1, max1), (min2, max2), ...]. Default: None.
-        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
-            "1" was added to both height and width which means h, w should be
+        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
+            "1" was added to both height and width which means w, h should be
              computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
              The `Legacy_coordinate` should be Ture
              when evaluate the VOC dataset.
@@ -330,8 +330,8 @@ def eval_map(det_results,
             to evaluate tp & fp. Default None.
         nproc (int): Processes used for computing TP and FP.
             Default: 4.
-        Legacy_coordinate (bool): Whether use Coordinate System in mmdet v1.x.
-            "1" was added to both height and width which means should be
+        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
+            "1" was added to both height and width which means w, h should be
              computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
 
     Returns:

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -65,7 +65,8 @@ def eval_recalls(gts,
                  proposals,
                  proposal_nums=None,
                  iou_thrs=0.5,
-                 logger=None):
+                 logger=None,
+                 Legacy_coordinate=True):
     """Calculate recalls.
 
     Args:
@@ -75,10 +76,19 @@ def eval_recalls(gts,
         iou_thrs (float | Sequence[float]): IoU thresholds. Default: 0.5.
         logger (logging.Logger | str | None): The way to print the recall
             summary. See `mmcv.utils.print_log()` for details. Default: None.
+        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
+            "1" was added to both height and width which means w, h should be
+             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
+
 
     Returns:
         ndarray: recalls of different ious and proposal nums
     """
+
+    if not Legacy_coordinate:
+        extra_length = 0.
+    else:
+        extra_length = 1.
 
     img_num = len(gts)
     assert img_num == len(proposals)
@@ -97,7 +107,8 @@ def eval_recalls(gts,
         if gts[i] is None or gts[i].shape[0] == 0:
             ious = np.zeros((0, img_proposal.shape[0]), dtype=np.float32)
         else:
-            ious = bbox_overlaps(gts[i], img_proposal[:prop_num, :4])
+            ious = bbox_overlaps(
+                gts[i], img_proposal[:prop_num, :4], extra_length=extra_length)
         all_ious.append(ious)
     all_ious = np.array(all_ious)
     recalls = _recalls(all_ious, proposal_nums, iou_thrs)

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -66,7 +66,7 @@ def eval_recalls(gts,
                  proposal_nums=None,
                  iou_thrs=0.5,
                  logger=None,
-                 legacy_coordinate=False):
+                 use_legacy_coordinate=False):
     """Calculate recalls.
 
     Args:
@@ -76,16 +76,17 @@ def eval_recalls(gts,
         iou_thrs (float | Sequence[float]): IoU thresholds. Default: 0.5.
         logger (logging.Logger | str | None): The way to print the recall
             summary. See `mmcv.utils.print_log()` for details. Default: None.
-        legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
-            "1" was added to both height and width which means w, h should be
-             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'. Default: False.
+        use_legacy_coordinate (bool): Whether use coordinate system
+            in mmdet v1.x. "1" was added to both height and width
+            which means w, h should be
+            computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'. Default: False.
 
 
     Returns:
         ndarray: recalls of different ious and proposal nums
     """
 
-    if not legacy_coordinate:
+    if not use_legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -66,7 +66,7 @@ def eval_recalls(gts,
                  proposal_nums=None,
                  iou_thrs=0.5,
                  logger=None,
-                 Legacy_coordinate=False):
+                 legacy_coordinate=False):
     """Calculate recalls.
 
     Args:
@@ -76,7 +76,7 @@ def eval_recalls(gts,
         iou_thrs (float | Sequence[float]): IoU thresholds. Default: 0.5.
         logger (logging.Logger | str | None): The way to print the recall
             summary. See `mmcv.utils.print_log()` for details. Default: None.
-        Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
+        legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
             "1" was added to both height and width which means w, h should be
              computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'. Default: False.
 
@@ -85,7 +85,7 @@ def eval_recalls(gts,
         ndarray: recalls of different ious and proposal nums
     """
 
-    if not Legacy_coordinate:
+    if not legacy_coordinate:
         extra_length = 0.
     else:
         extra_length = 1.

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -86,11 +86,6 @@ def eval_recalls(gts,
         ndarray: recalls of different ious and proposal nums
     """
 
-    if not use_legacy_coordinate:
-        extra_length = 0.
-    else:
-        extra_length = 1.
-
     img_num = len(gts)
     assert img_num == len(proposals)
     proposal_nums, iou_thrs = set_recall_param(proposal_nums, iou_thrs)
@@ -107,7 +102,9 @@ def eval_recalls(gts,
             ious = np.zeros((0, img_proposal.shape[0]), dtype=np.float32)
         else:
             ious = bbox_overlaps(
-                gts[i], img_proposal[:prop_num, :4], extra_length=extra_length)
+                gts[i],
+                img_proposal[:prop_num, :4],
+                use_legacy_coordinate=use_legacy_coordinate)
         all_ious.append(ious)
     all_ious = np.array(all_ious)
     recalls = _recalls(all_ious, proposal_nums, iou_thrs)

--- a/mmdet/core/evaluation/recall.py
+++ b/mmdet/core/evaluation/recall.py
@@ -66,7 +66,7 @@ def eval_recalls(gts,
                  proposal_nums=None,
                  iou_thrs=0.5,
                  logger=None,
-                 Legacy_coordinate=True):
+                 Legacy_coordinate=False):
     """Calculate recalls.
 
     Args:
@@ -78,7 +78,7 @@ def eval_recalls(gts,
             summary. See `mmcv.utils.print_log()` for details. Default: None.
         Legacy_coordinate (bool): Whether use coordinate system in mmdet v1.x.
             "1" was added to both height and width which means w, h should be
-             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'.
+             computed as 'x2 - x1 + 1` and 'y2 - y1 + 1'. Default: False.
 
 
     Returns:
@@ -92,9 +92,7 @@ def eval_recalls(gts,
 
     img_num = len(gts)
     assert img_num == len(proposals)
-
     proposal_nums, iou_thrs = set_recall_param(proposal_nums, iou_thrs)
-
     all_ious = []
     for i in range(img_num):
         if proposals[i].ndim == 2 and proposals[i].shape[1] == 5:

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -88,7 +88,12 @@ class VOCDataset(XMLDataset):
         elif metric == 'recall':
             gt_bboxes = [ann['bboxes'] for ann in annotations]
             recalls = eval_recalls(
-                gt_bboxes, results, proposal_nums, iou_thrs, logger=logger)
+                gt_bboxes,
+                results,
+                proposal_nums,
+                iou_thrs,
+                logger=logger,
+                Legacy_coordinate=True)
             for i, num in enumerate(proposal_nums):
                 for j, iou_thr in enumerate(iou_thrs):
                     eval_results[f'recall@{num}@{iou_thr}'] = recalls[i, j]

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+import numpy as np
 from mmcv.utils import print_log
 
 from mmdet.core import eval_map, eval_recalls
@@ -87,9 +88,10 @@ class VOCDataset(XMLDataset):
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
         elif metric == 'recall':
             gt_bboxes = [ann['bboxes'] for ann in annotations]
+            class_agnostic_results = [np.concatenate(item) for item in results]
             recalls = eval_recalls(
                 gt_bboxes,
-                results,
+                class_agnostic_results,
                 proposal_nums,
                 iou_thrs,
                 logger=logger,

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -71,8 +71,8 @@ class VOCDataset(XMLDataset):
                 print_log(f'\n{"-" * 15}iou_thr: {iou_thr}{"-" * 15}')
                 # Follow the official implementation,
                 # http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCdevkit_18-May-2011.tar
-                # we should use the  Legacy coordinate system in mmdet 1.x,
-                # which means h, w should be computed as 'x2 - x1 + 1` and
+                # we should use the legacy coordinate system in mmdet 1.x,
+                # which means w, h should be computed as 'x2 - x1 + 1` and
                 # `y2 - y1 + 1`
                 mean_ap, _ = eval_map(
                     results,

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -81,7 +81,7 @@ class VOCDataset(XMLDataset):
                     iou_thr=iou_thr,
                     dataset=ds_name,
                     logger=logger,
-                    legacy_coordinate=True)
+                    use_legacy_coordinate=True)
                 mean_aps.append(mean_ap)
                 eval_results[f'AP{int(iou_thr * 100):02d}'] = round(mean_ap, 3)
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
@@ -93,7 +93,7 @@ class VOCDataset(XMLDataset):
                 proposal_nums,
                 iou_thrs,
                 logger=logger,
-                legacy_coordinate=True)
+                use_legacy_coordinate=True)
             for i, num in enumerate(proposal_nums):
                 for j, iou_thr in enumerate(iou_thrs):
                     eval_results[f'recall@{num}@{iou_thr}'] = recalls[i, j]

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -69,13 +69,19 @@ class VOCDataset(XMLDataset):
             mean_aps = []
             for iou_thr in iou_thrs:
                 print_log(f'\n{"-" * 15}iou_thr: {iou_thr}{"-" * 15}')
+                # Follow the official implementation,
+                # http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCdevkit_18-May-2011.tar
+                # we should use the  Legacy coordinate system in mmdet 1.x,
+                # which means h, w should be computed as 'x2 - x1 + 1` and
+                # `y2 - y1 + 1`
                 mean_ap, _ = eval_map(
                     results,
                     annotations,
                     scale_ranges=None,
                     iou_thr=iou_thr,
                     dataset=ds_name,
-                    logger=logger)
+                    logger=logger,
+                    Legacy_coordinate=True)
                 mean_aps.append(mean_ap)
                 eval_results[f'AP{int(iou_thr * 100):02d}'] = round(mean_ap, 3)
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-import numpy as np
 from mmcv.utils import print_log
 
 from mmdet.core import eval_map, eval_recalls
@@ -88,10 +87,9 @@ class VOCDataset(XMLDataset):
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
         elif metric == 'recall':
             gt_bboxes = [ann['bboxes'] for ann in annotations]
-            class_agnostic_results = [np.concatenate(item) for item in results]
             recalls = eval_recalls(
                 gt_bboxes,
-                class_agnostic_results,
+                results,
                 proposal_nums,
                 iou_thrs,
                 logger=logger,

--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -81,7 +81,7 @@ class VOCDataset(XMLDataset):
                     iou_thr=iou_thr,
                     dataset=ds_name,
                     logger=logger,
-                    Legacy_coordinate=True)
+                    legacy_coordinate=True)
                 mean_aps.append(mean_ap)
                 eval_results[f'AP{int(iou_thr * 100):02d}'] = round(mean_ap, 3)
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
@@ -93,7 +93,7 @@ class VOCDataset(XMLDataset):
                 proposal_nums,
                 iou_thrs,
                 logger=logger,
-                Legacy_coordinate=True)
+                legacy_coordinate=True)
             for i, num in enumerate(proposal_nums):
                 for j, iou_thr in enumerate(iou_thrs):
                     eval_results[f'recall@{num}@{iou_thr}'] = recalls[i, j]

--- a/tests/test_metrics/test_box_overlap.py
+++ b/tests/test_metrics/test_box_overlap.py
@@ -3,6 +3,8 @@ import pytest
 import torch
 
 from mmdet.core import BboxOverlaps2D, bbox_overlaps
+from mmdet.core.evaluation.bbox_overlaps import \
+    bbox_overlaps as recall_overlaps
 
 
 def test_bbox_overlaps_2d(eps=1e-7):
@@ -103,3 +105,34 @@ def test_bbox_overlaps_2d(eps=1e-7):
     ious = bbox_overlaps(bboxes1, bboxes2, 'iof', eps=eps)
     assert torch.all(ious >= -1) and torch.all(ious <= 1)
     assert ious.size() == (bboxes1.size(0), bboxes2.size(0))
+
+
+def test_recall_overlaps():
+
+    def _construct_bbox(num_bbox=None):
+        img_h = int(np.random.randint(3, 1000))
+        img_w = int(np.random.randint(3, 1000))
+        if num_bbox is None:
+            num_bbox = np.random.randint(1, 10)
+        x1y1 = torch.rand((num_bbox, 2))
+        x2y2 = torch.max(torch.rand((num_bbox, 2)), x1y1)
+        bboxes = torch.cat((x1y1, x2y2), -1)
+        bboxes[:, 0::2] *= img_w
+        bboxes[:, 1::2] *= img_h
+        return bboxes.numpy(), num_bbox
+
+    bboxes1, num_bbox = _construct_bbox()
+    bboxes2, _ = _construct_bbox(num_bbox)
+    ious = recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=0)
+    assert ious.shape == (num_bbox, num_bbox)
+    assert np.all(ious >= -1) and np.all(ious <= 1)
+
+    ious = recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=1)
+    assert ious.shape == (num_bbox, num_bbox)
+    assert np.all(ious >= -1) and np.all(ious <= 1)
+
+    # extra_length should be in (1,2)
+    with pytest.raises(AssertionError):
+        recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=2)
+    with pytest.raises(AssertionError):
+        recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=1.5)

--- a/tests/test_metrics/test_box_overlap.py
+++ b/tests/test_metrics/test_box_overlap.py
@@ -123,16 +123,11 @@ def test_recall_overlaps():
 
     bboxes1, num_bbox = _construct_bbox()
     bboxes2, _ = _construct_bbox(num_bbox)
-    ious = recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=0)
+    ious = recall_overlaps(
+        bboxes1, bboxes2, 'iou', use_legacy_coordinate=False)
     assert ious.shape == (num_bbox, num_bbox)
     assert np.all(ious >= -1) and np.all(ious <= 1)
 
-    ious = recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=1)
+    ious = recall_overlaps(bboxes1, bboxes2, 'iou', use_legacy_coordinate=True)
     assert ious.shape == (num_bbox, num_bbox)
     assert np.all(ious >= -1) and np.all(ious <= 1)
-
-    # extra_length should be in (1,2)
-    with pytest.raises(AssertionError):
-        recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=2)
-    with pytest.raises(AssertionError):
-        recall_overlaps(bboxes1, bboxes2, 'iou', extra_length=1.5)

--- a/tests/test_metrics/test_box_overlap.py
+++ b/tests/test_metrics/test_box_overlap.py
@@ -107,7 +107,7 @@ def test_bbox_overlaps_2d(eps=1e-7):
     assert ious.size() == (bboxes1.size(0), bboxes2.size(0))
 
 
-def test_recall_overlaps():
+def test_voc_recall_overlaps():
 
     def _construct_bbox(num_bbox=None):
         img_h = int(np.random.randint(3, 1000))

--- a/tests/test_metrics/test_mean_ap.py
+++ b/tests/test_metrics/test_mean_ap.py
@@ -1,0 +1,57 @@
+import numpy as np
+
+from mmdet.core.evaluation.mean_ap import eval_map, tpfp_default, tpfp_imagenet
+
+det_bboxes = np.array([
+    [0, 0, 10, 10],
+    [10, 10, 20, 20],
+    [32, 32, 38, 42],
+])
+gt_bboxes = np.array([[0, 0, 10, 20], [0, 10, 10, 19], [10, 10, 20, 20]])
+gt_ignore = np.array([[5, 5, 10, 20], [6, 10, 10, 19]])
+
+
+def test_tpfp_imagenet():
+
+    tpfp_imagenet(
+        det_bboxes,
+        gt_bboxes,
+        gt_bboxes_ignore=gt_ignore,
+        use_legacy_coordinate=True)
+    tpfp_imagenet(
+        det_bboxes,
+        gt_bboxes,
+        gt_bboxes_ignore=gt_ignore,
+        use_legacy_coordinate=False)
+
+
+def test_tpfp_default():
+
+    tpfp_default(
+        det_bboxes,
+        gt_bboxes,
+        gt_bboxes_ignore=gt_ignore,
+        use_legacy_coordinate=True)
+    tpfp_default(
+        det_bboxes,
+        gt_bboxes,
+        gt_bboxes_ignore=gt_ignore,
+        use_legacy_coordinate=False)
+
+
+def test_eval_map():
+
+    # 2 image and 2 classes
+    det_results = [[det_bboxes, det_bboxes], [det_bboxes, det_bboxes]]
+
+    labels = np.array([0, 1, 1])
+    labels_ignore = np.array([0, 1])
+    gt_info = {
+        'bboxes': gt_bboxes,
+        'bboxes_ignore': gt_ignore,
+        'labels': labels,
+        'labels_ignore': labels_ignore
+    }
+    annotations = [gt_info, gt_info]
+    eval_map(det_results, annotations, use_legacy_coordinate=True)
+    eval_map(det_results, annotations, use_legacy_coordinate=False)

--- a/tests/test_metrics/test_mean_ap.py
+++ b/tests/test_metrics/test_mean_ap.py
@@ -13,30 +13,57 @@ gt_ignore = np.array([[5, 5, 10, 20], [6, 10, 10, 19]])
 
 def test_tpfp_imagenet():
 
-    tpfp_imagenet(
+    result = tpfp_imagenet(
         det_bboxes,
         gt_bboxes,
         gt_bboxes_ignore=gt_ignore,
         use_legacy_coordinate=True)
-    tpfp_imagenet(
+    tp = result[0]
+    fp = result[1]
+    assert tp.shape == (1, 3)
+    assert fp.shape == (1, 3)
+    assert (tp == np.array([[1, 1, 0]])).all()
+    assert (fp == np.array([[0, 0, 1]])).all()
+
+    result = tpfp_imagenet(
         det_bboxes,
         gt_bboxes,
         gt_bboxes_ignore=gt_ignore,
         use_legacy_coordinate=False)
+    tp = result[0]
+    fp = result[1]
+    assert tp.shape == (1, 3)
+    assert fp.shape == (1, 3)
+    assert (tp == np.array([[1, 1, 0]])).all()
+    assert (fp == np.array([[0, 0, 1]])).all()
 
 
 def test_tpfp_default():
 
-    tpfp_default(
+    result = tpfp_default(
         det_bboxes,
         gt_bboxes,
         gt_bboxes_ignore=gt_ignore,
         use_legacy_coordinate=True)
-    tpfp_default(
+
+    tp = result[0]
+    fp = result[1]
+    assert tp.shape == (1, 3)
+    assert fp.shape == (1, 3)
+    assert (tp == np.array([[1, 1, 0]])).all()
+    assert (fp == np.array([[0, 0, 1]])).all()
+    result = tpfp_default(
         det_bboxes,
         gt_bboxes,
         gt_bboxes_ignore=gt_ignore,
         use_legacy_coordinate=False)
+
+    tp = result[0]
+    fp = result[1]
+    assert tp.shape == (1, 3)
+    assert fp.shape == (1, 3)
+    assert (tp == np.array([[1, 1, 0]])).all()
+    assert (fp == np.array([[0, 0, 1]])).all()
 
 
 def test_eval_map():
@@ -53,5 +80,8 @@ def test_eval_map():
         'labels_ignore': labels_ignore
     }
     annotations = [gt_info, gt_info]
-    eval_map(det_results, annotations, use_legacy_coordinate=True)
+    mean_ap, eval_results = eval_map(
+        det_results, annotations, use_legacy_coordinate=True)
+    assert 0.291 < mean_ap < 0.293
     eval_map(det_results, annotations, use_legacy_coordinate=False)
+    assert 0.291 < mean_ap < 0.293

--- a/tests/test_metrics/test_recall.py
+++ b/tests/test_metrics/test_recall.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from mmdet.core.evaluation.recall import eval_recalls
+
+det_bboxes = np.array([
+    [0, 0, 10, 10],
+    [10, 10, 20, 20],
+    [32, 32, 38, 42],
+])
+gt_bboxes = np.array([[0, 0, 10, 20], [0, 10, 10, 19], [10, 10, 20, 20]])
+gt_ignore = np.array([[5, 5, 10, 20], [6, 10, 10, 19]])
+
+
+def test_eval_recalls():
+    gts = [gt_bboxes, gt_bboxes, gt_bboxes]
+    proposals = [det_bboxes, det_bboxes, det_bboxes]
+
+    eval_recalls(gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
+    eval_recalls(gts, proposals, proposal_nums=2, use_legacy_coordinate=False)

--- a/tests/test_metrics/test_recall.py
+++ b/tests/test_metrics/test_recall.py
@@ -15,5 +15,32 @@ def test_eval_recalls():
     gts = [gt_bboxes, gt_bboxes, gt_bboxes]
     proposals = [det_bboxes, det_bboxes, det_bboxes]
 
-    eval_recalls(gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
-    eval_recalls(gts, proposals, proposal_nums=2, use_legacy_coordinate=False)
+    recall = eval_recalls(
+        gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
+    assert recall.shape == (1, 1)
+    assert 0 < recall[0][0] < 0.668
+    recall = eval_recalls(
+        gts, proposals, proposal_nums=2, use_legacy_coordinate=False)
+    assert recall.shape == (1, 1)
+    assert 0 < recall[0][0] < 0.668
+
+    recall = eval_recalls(
+        gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
+    assert recall.shape == (1, 1)
+    assert 0 < recall[0][0] < 0.668
+    recall = eval_recalls(
+        gts,
+        proposals,
+        iou_thrs=[0.1, 0.9],
+        proposal_nums=2,
+        use_legacy_coordinate=False)
+    assert recall.shape == (1, 2)
+    assert recall[0][1] <= recall[0][0]
+    recall = eval_recalls(
+        gts,
+        proposals,
+        iou_thrs=[0.1, 0.9],
+        proposal_nums=2,
+        use_legacy_coordinate=True)
+    assert recall.shape == (1, 2)
+    assert recall[0][1] <= recall[0][0]

--- a/tests/test_metrics/test_recall.py
+++ b/tests/test_metrics/test_recall.py
@@ -18,16 +18,16 @@ def test_eval_recalls():
     recall = eval_recalls(
         gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
     assert recall.shape == (1, 1)
-    assert 0 < recall[0][0] < 0.668
+    assert 0.66 < recall[0][0] < 0.667
     recall = eval_recalls(
         gts, proposals, proposal_nums=2, use_legacy_coordinate=False)
     assert recall.shape == (1, 1)
-    assert 0 < recall[0][0] < 0.668
+    assert 0.66 < recall[0][0] < 0.667
 
     recall = eval_recalls(
         gts, proposals, proposal_nums=2, use_legacy_coordinate=True)
     assert recall.shape == (1, 1)
-    assert 0 < recall[0][0] < 0.668
+    assert 0.66 < recall[0][0] < 0.667
     recall = eval_recalls(
         gts,
         proposals,


### PR DESCRIPTION
## Motivation
In the official [metric implementation](http://host.robots.ox.ac.uk/pascal/VOC/voc2012/VOCdevkit_18-May-2011.tar) of VOC dataset, it adopts the  Legacy coordinate system in mmdet 1.x, which means h, w should be computed as `x2 - x1 + 1` and `y2 - y1 + 1`.

## Modification
I add argument `Legacy_coordinate` to `eval_map`， `tpfp_default` and `tpfp_imagenet`，`bbox_overlaps`  to control whether to use legacy coordinate system when caculate the width and length.

## BC-breaking 
None

<!DOCTYPE html><meta http-equiv="content-type" content="text/html; charset=utf-8">

before/after | faster
-- | --
mAP | 79.5/79.6
recall | 93.4/93.5

