### PR TITLE
add annotations for instaboost

### DIFF
--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -10,6 +10,19 @@ class InstaBoost:
     <https://arxiv.org/abs/1908.07801>`_.
 
     Refer to https://github.com/GothicAi/Instaboost for implementation details.
+
+    Args:
+        action_candidate (tuple): action candidates. "normal", "horizontal", \
+            "vertical", "skip" are supported.
+        action_prob (tuple): corresponding action probabilities. Should be the \
+            same length as action_candidate.
+        scale (tuple): (min scale, max scale)
+        dx (int): the maximum x-axis shift will be (instance width) / dx
+        dy (int): the maximum y-axis shift will be (instance height) / dy
+        theta (tuple): (min rotation degree, max rotation degree)
+        color_prob (float): probability of images for color augmentation
+        heatmap_flag (bool): whether to use heatmap guided
+        aug_ratio (float): probability of applying this transformation
     """
 
     def __init__(self,

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -13,13 +13,17 @@ class InstaBoost:
 
     Args:
         action_candidate (tuple): Action candidates. "normal", "horizontal", \
-            "vertical", "skip" are supported.
+            "vertical", "skip" are supported. Default: ('normal', \
+            'horizontal', 'skip').
         action_prob (tuple): Corresponding action probabilities. Should be \
-            the same length as action_candidate.
-        scale (tuple): (min scale, max scale)
+            the same length as action_candidate. Default: (1, 0, 0).
+        scale (tuple): (min scale, max scale). Default: (0.8, 1.2).
         dx (int): The maximum x-axis shift will be (instance width) / dx.
+            Default 15.
         dy (int): The maximum y-axis shift will be (instance height) / dy.
-        theta (tuple): (min rotation degree, max rotation degree)
+            Default 15.
+        theta (tuple): (min rotation degree, max rotation degree). \
+            Default: (-1, 1).
         color_prob (float): Probability of images for color augmentation.
             Default 0.5.
         heatmap_flag (bool): Whether to use heatmap guided. Default False.

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -14,15 +14,17 @@ class InstaBoost:
     Args:
         action_candidate (tuple): action candidates. "normal", "horizontal", \
             "vertical", "skip" are supported.
-        action_prob (tuple): corresponding action probabilities. Should be the \
-            same length as action_candidate.
+        action_prob (tuple): corresponding action probabilities. Should be \
+            the same length as action_candidate.
         scale (tuple): (min scale, max scale)
-        dx (int): the maximum x-axis shift will be (instance width) / dx
-        dy (int): the maximum y-axis shift will be (instance height) / dy
+        dx (int): The maximum x-axis shift will be (instance width) / dx.
+        dy (int): The maximum y-axis shift will be (instance height) / dy.
         theta (tuple): (min rotation degree, max rotation degree)
-        color_prob (float): probability of images for color augmentation
-        heatmap_flag (bool): whether to use heatmap guided
-        aug_ratio (float): probability of applying this transformation
+        color_prob (float): Probability of images for color augmentation.
+            Default 0.5.
+        heatmap_flag (bool): Whether to use heatmap guided. Default False.
+        aug_ratio (float): Probability of applying this transformation. \
+            Default 0.5.
     """
 
     def __init__(self,

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -13,9 +13,9 @@ class InstaBoost:
 
     Args:
         action_candidate (tuple): action candidates. "normal", "horizontal", \
-            "vertical", "skip" are supported.
+            "vertical", "skip" are supported
         action_prob (tuple): corresponding action probabilities. Should be the \
-            same length as action_candidate.
+            same length as action_candidate
         scale (tuple): (min scale, max scale)
         dx (int): the maximum x-axis shift will be (instance width) / dx
         dy (int): the maximum y-axis shift will be (instance height) / dy

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -13,9 +13,9 @@ class InstaBoost:
 
     Args:
         action_candidate (tuple): action candidates. "normal", "horizontal", \
-            "vertical", "skip" are supported
+            "vertical", "skip" are supported.
         action_prob (tuple): corresponding action probabilities. Should be the \
-            same length as action_candidate
+            same length as action_candidate.
         scale (tuple): (min scale, max scale)
         dx (int): the maximum x-axis shift will be (instance width) / dx
         dy (int): the maximum y-axis shift will be (instance height) / dy

--- a/mmdet/datasets/pipelines/instaboost.py
+++ b/mmdet/datasets/pipelines/instaboost.py
@@ -12,9 +12,9 @@ class InstaBoost:
     Refer to https://github.com/GothicAi/Instaboost for implementation details.
 
     Args:
-        action_candidate (tuple): action candidates. "normal", "horizontal", \
+        action_candidate (tuple): Action candidates. "normal", "horizontal", \
             "vertical", "skip" are supported.
-        action_prob (tuple): corresponding action probabilities. Should be \
+        action_prob (tuple): Corresponding action probabilities. Should be \
             the same length as action_candidate.
         scale (tuple): (min scale, max scale)
         dx (int): The maximum x-axis shift will be (instance width) / dx.


### PR DESCRIPTION
## Motivation

add annotations for instaboost, referencing https://github.com/GothicAi/InstaBoost-pypi#instaboostconfig

```
Args:
        action_candidate (tuple): action candidates. "normal", "horizontal", \
            "vertical", "skip" are supported.
        action_prob (tuple): corresponding action probabilities. Should be the \
            same length as action_candidate.
        scale (tuple): (min scale, max scale)
        dx (int): the maximum x-axis shift will be (instance width) / dx
        dy (int): the maximum y-axis shift will be (instance height) / dy
        theta (tuple): (min rotation degree, max rotation degree)
        color_prob (float): probability of images for color augmentation
        heatmap_flag (bool): whether to use heatmap guided
        aug_ratio (float): probability of applying this transformation
```






