### PR TITLE
[Enhance] Add ignore_index to CrossEntropyLoss

### DIFF
--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -75,7 +75,7 @@ def binary_cross_entropy(pred,
                          reduction='mean',
                          avg_factor=None,
                          class_weight=None,
-                         ignore_index=255):
+                         ignore_index=-100):
     """Calculate the binary CrossEntropy loss.
 
     Args:
@@ -88,12 +88,12 @@ def binary_cross_entropy(pred,
             the loss. Defaults to None.
         class_weight (list[float], optional): The weight for each class.
         ignore_index (int | None): The label index to be ignored.
-            If None, it will be set to default value. Default: 255.
+            If None, it will be set to default value. Default: -100.
 
     Returns:
         torch.Tensor: The calculated loss.
     """
-    ignore_index = 255 if ignore_index is None else ignore_index
+    ignore_index = -100 if ignore_index is None else ignore_index
     if pred.dim() != label.dim():
         label, weight = _expand_onehot_labels(label, weight, pred.size(-1),
                                               ignore_index)

--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -169,6 +169,7 @@ class CrossEntropyLoss(nn.Module):
                  use_mask=False,
                  reduction='mean',
                  class_weight=None,
+                 ignore_index=None,
                  loss_weight=1.0):
         """CrossEntropyLoss.
 
@@ -181,6 +182,8 @@ class CrossEntropyLoss(nn.Module):
                 Options are "none", "mean" and "sum".
             class_weight (list[float], optional): Weight of each class.
                 Defaults to None.
+            ignore_index (int | None): The label index to be ignored.
+                Defaults to None.
             loss_weight (float, optional): Weight of the loss. Defaults to 1.0.
         """
         super(CrossEntropyLoss, self).__init__()
@@ -190,6 +193,7 @@ class CrossEntropyLoss(nn.Module):
         self.reduction = reduction
         self.loss_weight = loss_weight
         self.class_weight = class_weight
+        self.ignore_index = ignore_index
 
         if self.use_sigmoid:
             self.cls_criterion = binary_cross_entropy
@@ -224,6 +228,8 @@ class CrossEntropyLoss(nn.Module):
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)
+        if ignore_index is None:
+            ignore_index = self.ignore_index
 
         if self.class_weight is not None:
             class_weight = cls_score.new_tensor(

--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -30,6 +30,7 @@ def cross_entropy(pred,
     Returns:
         torch.Tensor: The calculated loss
     """
+    # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
     # element-wise losses
     loss = F.cross_entropy(
@@ -93,6 +94,7 @@ def binary_cross_entropy(pred,
     Returns:
         torch.Tensor: The calculated loss.
     """
+    # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
     if pred.dim() != label.dim():
         label, weight = _expand_onehot_labels(label, weight, pred.size(-1),

--- a/tests/test_models/test_loss.py
+++ b/tests/test_models/test_loss.py
@@ -126,22 +126,29 @@ def test_GHMR_loss(loss_class):
 @pytest.mark.parametrize('use_sigmoid', [True, False])
 def test_loss_with_ignore_index(use_sigmoid):
     # Test cross_entropy loss
-    loss_class = CrossEntropyLoss(use_sigmoid=use_sigmoid, use_mask=False)
+    loss_class = CrossEntropyLoss(
+        use_sigmoid=use_sigmoid, use_mask=False, ignore_index=255)
     pred = torch.rand((10, 5))
     target = torch.randint(0, 5, (10, ))
 
     ignored_indices = torch.randint(0, 10, (2, ), dtype=torch.long)
     target[ignored_indices] = 255
 
-    # Test loss forward with ignore
-    loss_with_ignore = loss_class(
-        pred, target, ignore_index=255, reduction_override='sum')
+    # Test loss forward with default ignore
+    loss_with_ignore = loss_class(pred, target, reduction_override='sum')
     assert isinstance(loss_with_ignore, torch.Tensor)
 
+    # Test loss forward with forward ignore
+    target[ignored_indices] = 250
+    loss_with_forward_ignore = loss_class(
+        pred, target, ignore_index=250, reduction_override='sum')
+    assert isinstance(loss_with_forward_ignore, torch.Tensor)
+
     # Verify correctness
-    not_ignored_indices = (target != 255)
+    not_ignored_indices = (target != 250)
     pred = pred[not_ignored_indices]
     target = target[not_ignored_indices]
     loss = loss_class(pred, target, reduction_override='sum')
 
     assert torch.allclose(loss, loss_with_ignore)
+    assert torch.allclose(loss, loss_with_forward_ignore)

--- a/tests/test_models/test_loss.py
+++ b/tests/test_models/test_loss.py
@@ -126,7 +126,7 @@ def test_GHMR_loss(loss_class):
 @pytest.mark.parametrize('use_sigmoid', [True, False])
 def test_loss_with_ignore_index(use_sigmoid):
     # Test cross_entropy loss
-    loss_class = CrossEntropyLoss(use_sigmoid=True, use_mask=False)
+    loss_class = CrossEntropyLoss(use_sigmoid=use_sigmoid, use_mask=False)
     pred = torch.rand((10, 5))
     target = torch.randint(0, 5, (10, ))
 


### PR DESCRIPTION
The `CrossEntropyLoss` has no interface `ignore_index`, which makes it inconvenient to complete the segmentation task.