### PR TITLE
[Fix]: Change YOLOX init weights to PyTorch default.

### DIFF
--- a/configs/yolox/yolox_s.py
+++ b/configs/yolox/yolox_s.py
@@ -4,7 +4,7 @@ _base_ = ['../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py']
 init_cfg = dict(type='Kaiming',
                 layer='Conv2d',
                 a=2.23606797749979,  # sqrt(5)
-                distribution='normal',
+                distribution='uniform',
                 mode='fan_in',
                 nonlinearity='leaky_relu')
 model = dict(

--- a/configs/yolox/yolox_s.py
+++ b/configs/yolox/yolox_s.py
@@ -1,16 +1,23 @@
 _base_ = ['../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py']
 
 # model settings
+init_cfg = dict(type='Kaiming',
+                layer='Conv2d',
+                a=2.23606797749979,  # sqrt(5)
+                distribution='normal',
+                mode='fan_in',
+                nonlinearity='leaky_relu')
 model = dict(
     type='YOLOX',
-    backbone=dict(type='CSPDarknet', deepen_factor=0.33, widen_factor=0.5),
+    backbone=dict(type='CSPDarknet', deepen_factor=0.33, widen_factor=0.5, init_cfg=init_cfg),
     neck=dict(
         type='YOLOXPAFPN',
         in_channels=[128, 256, 512],
         out_channels=128,
-        csp_num_blocks=1),
+        csp_num_blocks=1,
+        init_cfg=init_cfg),
     bbox_head=dict(
-        type='YOLOXHead', num_classes=80, in_channels=128, feat_channels=128),
+        type='YOLOXHead', num_classes=80, in_channels=128, feat_channels=128, init_cfg=init_cfg),
     # test
     test_cfg=dict(
         nms_pre=1000,

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -156,6 +156,7 @@ class YOLOXHead(BaseDenseHead, BBoxTestMixin):
         return conv_cls, conv_reg, conv_obj
 
     def init_weights(self):
+        super(YOLOXHead, self).init_weights()
         # Use prior in model initialization to improve stability
         bias_init = bias_init_with_prob(0.01)
         for conv_cls, conv_obj in zip(self.multi_level_conv_cls,

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -156,12 +156,6 @@ class YOLOXHead(BaseDenseHead, BBoxTestMixin):
         return conv_cls, conv_reg, conv_obj
 
     def init_weights(self):
-        for m in self.modules():
-            if isinstance(m, nn.Conv2d):
-                normal_init(m, mean=0, std=0.01)
-            if is_norm(m):
-                constant_init(m, 1)
-
         # Use prior in model initialization to improve stability
         bias_init = bias_init_with_prob(0.01)
         for conv_cls, conv_obj in zip(self.multi_level_conv_cls,


### PR DESCRIPTION
YOLOX uses PyTorch's default Kaiming uniform init, but in mmdet, the default weight init function of Conv module is Kaiming normal.
This PR fixes this.