### PR TITLE
[Feature] Add ConvUpsample module and its unit test

### DIFF
--- a/mmdet/models/utils/__init__.py
+++ b/mmdet/models/utils/__init__.py
@@ -1,4 +1,5 @@
 from .builder import build_linear_layer, build_transformer
+from .conv_upsample import ConvUpsample
 from .gaussian_target import gaussian_radius, gen_gaussian_target
 from .inverted_residual import InvertedResidual
 from .make_divisible import make_divisible
@@ -16,5 +17,5 @@ __all__ = [
     'build_transformer', 'build_linear_layer', 'SinePositionalEncoding',
     'LearnedPositionalEncoding', 'DynamicConv', 'SimplifiedBasicBlock',
     'NormedLinear', 'NormedConv2d', 'make_divisible', 'InvertedResidual',
-    'SELayer'
+    'SELayer', 'ConvUpsample'
 ]

--- a/mmdet/models/utils/conv_upsample.py
+++ b/mmdet/models/utils/conv_upsample.py
@@ -6,8 +6,9 @@ from mmcv.runner import BaseModule, ModuleList
 class ConvUpsample(BaseModule):
     """ConvUpsample performs 2x upsampling after Conv.
 
-    This module performs 2x upsampling after Conv. Upsampling will be applied
-    after the first few layers of convolution.
+    There are several `ConvModule` layers. In the first few layers, upsampling
+    will be applied after each layer of convolution. The number of upsampling
+    must be no more than the number of ConvModule layers.
 
     Args:
         in_channels (int): Number of channels in the input feature map.
@@ -15,7 +16,7 @@ class ConvUpsample(BaseModule):
         num_layers (int): Number of convolution layers.
         num_upsample (int | optional): Number of upsampling layer. Must be no
             more than num_layers. Upsampling will be applied after the first
-            'num_upsample' layers of convolution. Default: num_layers.
+            ``num_upsample`` layers of convolution. Default: ``num_layers``.
         conv_cfg (dict): Config dict for convolution layer. Default: None,
             which means using conv2d.
         norm_cfg (dict): Config dict for normalization layer. Default: None.

--- a/mmdet/models/utils/conv_upsample.py
+++ b/mmdet/models/utils/conv_upsample.py
@@ -21,7 +21,7 @@ class ConvUpsample(BaseModule):
             which means using conv2d.
         norm_cfg (dict): Config dict for normalization layer. Default: None.
         init_cfg (dict): Config dict for initialization. Default: None.
-        kwargs (dict): Other augments used in ConvModule.
+        kwargs (key word augments): Other augments used in ConvModule.
     """
 
     def __init__(self,

--- a/mmdet/models/utils/conv_upsample.py
+++ b/mmdet/models/utils/conv_upsample.py
@@ -1,0 +1,66 @@
+import torch.nn.functional as F
+
+from mmcv.cnn import ConvModule
+from mmcv.runner import BaseModule, ModuleList
+
+
+class ConvUpsample(BaseModule):
+    """ConvUpsample performs 2x upsampling after Conv.
+
+    This module performs 2x upsampling after Conv. Upsampling will be applied
+    after the first few layers of convolution.
+
+    Args:
+        in_channels (int): Number of channels in the input feature map.
+        inner_channels (int): Number of channels produced by the convolution.
+        num_layers (int): Number of convolution layers.
+        num_upsample (int | optional): Number of upsampling layer. Must be no
+            more than num_layers. Upsampling will be applied after the first
+            'num_upsample' layers of convolution. Default: num_layers.
+        conv_cfg (dict): Config dict for convolution layer. Default: None,
+            which means using conv2d.
+        norm_cfg (dict): Config dict for normalization layer. Default: None.
+        init_cfg (dict): Config dict for initialization. Default: None.
+        kwargs (dict): Other augments used in ConvModule.
+    """
+
+    def __init__(self,
+                 in_channels,
+                 inner_channels,
+                 num_layers=1,
+                 num_upsample=None,
+                 conv_cfg=None,
+                 norm_cfg=None,
+                 init_cfg=None,
+                 **kwargs):
+        super(ConvUpsample, self).__init__(init_cfg)
+        if num_upsample is None:
+            num_upsample = num_layers
+        assert num_upsample <= num_layers, \
+            f'num_upsample({num_upsample})must be no more than ' \
+            f'num_layers({num_layers})'
+        self.num_layers = num_layers
+        self.num_upsample = num_upsample
+        self.conv = ModuleList()
+        for i in range(num_layers):
+            self.conv.append(
+                ConvModule(
+                    in_channels,
+                    inner_channels,
+                    3,
+                    padding=1,
+                    stride=1,
+                    conv_cfg=conv_cfg,
+                    norm_cfg=norm_cfg,
+                    **kwargs))
+            in_channels = inner_channels
+
+    def forward(self, x):
+        num_upsample = self.num_upsample
+        for i in range(self.num_layers):
+            x = self.conv[i](x)
+            if num_upsample > 0:
+                num_upsample -= 1
+                x = F.interpolate(
+                    x, scale_factor=2, mode='bilinear', align_corners=False)
+        return x

--- a/mmdet/models/utils/conv_upsample.py
+++ b/mmdet/models/utils/conv_upsample.py
@@ -1,5 +1,4 @@
 import torch.nn.functional as F
-
 from mmcv.cnn import ConvModule
 from mmcv.runner import BaseModule, ModuleList
 

--- a/tests/test_models/test_utils/test_conv_upsample.py
+++ b/tests/test_models/test_utils/test_conv_upsample.py
@@ -14,8 +14,7 @@ def test_conv_upsample(num_layers):
         num_layers=num_layers,
         num_upsample=num_upsample,
         conv_cfg=None,
-        norm_cfg=None,
-    )
+        norm_cfg=None)
 
     size = 5
     x = torch.randn((1, 10, size, size))

--- a/tests/test_models/test_utils/test_conv_upsample.py
+++ b/tests/test_models/test_utils/test_conv_upsample.py
@@ -4,8 +4,7 @@ import torch
 from mmdet.models.utils import ConvUpsample
 
 
-@pytest.mark.parametrize(
-    'num_layers', [0, 1, 2])
+@pytest.mark.parametrize('num_layers', [0, 1, 2])
 def test_conv_upsample(num_layers):
     num_upsample = num_layers if num_layers > 0 else 0
     num_layers = num_layers if num_layers > 0 else 1

--- a/tests/test_models/test_utils/test_conv_upsample.py
+++ b/tests/test_models/test_utils/test_conv_upsample.py
@@ -1,0 +1,16 @@
+import pytest
+import torch
+
+from mmdet.models.utils import ConvUpsample
+
+@pytest.mark.parametrize(
+    'num_upsample', [2, 3, 4])
+def test_conv_upsample(num_upsample):
+    layer = ConvUpsample(
+        10,
+        5,
+        num_layers=3,
+        num_upsample=num_upsample,
+        conv_cfg=None,
+        norm_cfg=None,
+    )

--- a/tests/test_models/test_utils/test_conv_upsample.py
+++ b/tests/test_models/test_utils/test_conv_upsample.py
@@ -3,14 +3,23 @@ import torch
 
 from mmdet.models.utils import ConvUpsample
 
+
 @pytest.mark.parametrize(
-    'num_upsample', [2, 3, 4])
-def test_conv_upsample(num_upsample):
+    'num_layers', [0, 1, 2])
+def test_conv_upsample(num_layers):
+    num_upsample = num_layers if num_layers > 0 else 0
+    num_layers = num_layers if num_layers > 0 else 1
     layer = ConvUpsample(
         10,
         5,
-        num_layers=3,
+        num_layers=num_layers,
         num_upsample=num_upsample,
         conv_cfg=None,
         norm_cfg=None,
     )
+
+    size = 5
+    x = torch.randn((1, 10, size, size))
+    size = size * pow(2, num_upsample)
+    x = layer(x)
+    assert x.shape[-2:] == (size, size)


### PR DESCRIPTION
Convupsample performs 2x upsampling after Conv.

There are several `ConvModule` layers. In the first few layers, upsampling will be applied after each layer of convolution. The number of upsampling must be no more than the number of ConvModule layers.

`num_layer` means the number of convolutional layers.  
`num_upsample` means the number of upsampling, it must be no more than `num_layers`.