### PR TITLE
add support for resizing multiple sem segs

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -267,6 +267,7 @@ class Resize:
                     interpolation='nearest',
                     backend=self.backend)
             results['gt_semantic_seg'] = gt_seg
+            results[key] = gt_seg
 
     def __call__(self, results):
         """Call function to resize images, bounding boxes, masks, semantic


### PR DESCRIPTION
## Motivation

Add support for resizing multiple semantic segmentation. The current version of _resize_seg seems that the "seg_fields" has no use and is different rom _resize_masks.

## Modification

+.  results[key] = gt_seg

## BC-breaking (Optional)

## Use cases (Optional)

When there are multiple segmentations of a data sample need to be resized.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
Done.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
