### PR TITLE
make output result of ImageToTensor contiguous

### DIFF
--- a/mmdet/datasets/pipelines/formating.py
+++ b/mmdet/datasets/pipelines/formating.py
@@ -92,7 +92,7 @@ class ImageToTensor:
             img = results[key]
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-            results[key] = to_tensor(img.transpose(2, 0, 1))
+            results[key] = (to_tensor(img.transpose(2, 0, 1))).contiguous()
         return results
 
     def __repr__(self):


### PR DESCRIPTION
In order to reduce the series of hidden dangers caused by discontinuous memory


Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When ONNX's detection model encounters discontinuous data, there will be abnormal performance, and the source is in this ImageToTensor tool. The transpose operation makes the memory discontinuous, which will not affect the operation of pytorch but will affect ONNX. In order to eliminate the risk, the function can directly output a continuous tensor.

## Modification
make
results[key] = to_tensor(img.transpose(2, 0, 1))
to
results[key] = (to_tensor(img.transpose(2, 0, 1))).contiguous()
in ImageToTensor.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
