### PR TITLE
[bug] fix bug of classwise weight in bce loss

### DIFF
--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -104,7 +104,7 @@ def binary_cross_entropy(pred,
     if weight is not None:
         weight = weight.float()
     loss = F.binary_cross_entropy_with_logits(
-        pred, label.float(), pos_weight=class_weight, reduction='none')
+        pred, label.float(), weight=class_weight, reduction='none')
     # do the reduction for the weighted loss
     loss = weight_reduce_loss(
         loss, weight, reduction=reduction, avg_factor=avg_factor)

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -30,6 +30,39 @@ def test_ce_loss():
     loss_cls = build_loss(loss_cls_cfg)
     assert torch.allclose(loss_cls(fake_pred, fake_label), torch.tensor(200.))
 
+    # test bce_loss
+    cls_score = torch.Tensor([[-200, 100], [500, -1000], [300, -300]])
+    label = torch.Tensor([[1, 0], [0, 1], [1, 0]])
+    weight = torch.Tensor([0.6, 0.4, 0.5])
+    class_weight = torch.tensor([0.1, 0.9])  # class 0: 0.1, class 1: 0.9
+
+    # test bce_loss without class weight
+    loss_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        loss_weight=1.0)
+    loss = build_loss(loss_cfg)
+    assert torch.allclose(loss(cls_score, label), torch.tensor(300.))
+    # test ce_loss with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(130.))
+
+    # test bce_loss with class weight
+    loss_cfg = dict(
+        type='CrossEntropyLoss',
+        use_sigmoid=True,
+        reduction='mean',
+        loss_weight=1.0,
+        class_weight=class_weight)
+    loss = build_loss(loss_cfg)
+    assert torch.allclose(loss(cls_score, label),
+                          torch.tensor(176.667)), loss(cls_score, label)
+    # test bce_loss with weight
+    assert torch.allclose(
+        loss(cls_score, label, weight=weight), torch.tensor(74.333)), loss(
+            cls_score, label, weight=weight)
+
 
 def test_varifocal_loss():
     # only sigmoid version of VarifocalLoss is implemented

--- a/tests/test_metrics/test_losses.py
+++ b/tests/test_metrics/test_losses.py
@@ -56,12 +56,10 @@ def test_ce_loss():
         loss_weight=1.0,
         class_weight=class_weight)
     loss = build_loss(loss_cfg)
-    assert torch.allclose(loss(cls_score, label),
-                          torch.tensor(176.667)), loss(cls_score, label)
+    assert torch.allclose(loss(cls_score, label), torch.tensor(176.667))
     # test bce_loss with weight
     assert torch.allclose(
-        loss(cls_score, label, weight=weight), torch.tensor(74.333)), loss(
-            cls_score, label, weight=weight)
+        loss(cls_score, label, weight=weight), torch.tensor(74.333))
 
 
 def test_varifocal_loss():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

 fix bug of classwise_weight in bce loss, and add unit test

## Modification

[this line](https://github.com/open-mmlab/mmdetection/blob/90e0ec78a705f26d4553503a433a5fdbc73757f2/mmdet/models/losses/cross_entropy_loss.py#L107) has a bug. the loss only scale in the location where the label is 1. The class_weight has no effect on the location where the label is 0.

my exp:
![image](https://user-images.githubusercontent.com/18586273/127992263-595797bc-dda7-4e39-ae03-d70ca29a02a0.png)

