### PR TITLE
[Fix]: fix panoptic dependency issue when publishing to pypi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,9 @@ jobs:
           pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install unittest dependencies
-        run: pip install -r requirements/tests.txt -r requirements/optional.txt
+        run: |
+          pip install -r requirements/tests.txt -r requirements/optional.txt
+          pip install git+https://github.com/cocodataset/panopticapi.git
       - name: Build and install
         run: rm -rf .eggs && pip install -e .
       - name: Run unittests and generate coverage report
@@ -140,6 +142,7 @@ jobs:
         run: |
           pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/${{matrix.torch_version}}/index.html
           pip install -r requirements.txt
+          pip install git+https://github.com/cocodataset/panopticapi.git
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Build and install
         run: |

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -125,7 +125,6 @@ Or you can still install MMDetection manually:
     pip install git+https://github.com/cocodataset/panopticapi.git
     # for LVIS dataset
     pip install git+https://github.com/lvis-dataset/lvis-api.git
-
     ```
 
 **Note:**

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -116,6 +116,18 @@ Or you can still install MMDetection manually:
     pip install -v -e .  # or "python setup.py develop"
     ```
 
+3. Install extra dependencies for Instaboost, Panoptic Segmentation, or LVIS dataset
+
+    ```shell
+    # for instaboost
+    pip install instaboostfast
+    # for panoptic segmentation
+    pip install git+https://github.com/cocodataset/panopticapi.git
+    # for LVIS dataset
+    pip install git+https://github.com/lvis-dataset/lvis-api.git
+
+    ```
+
 **Note:**
 
 a. When specifying `-e` or `develop`, MMDetection is installed on dev mode

--- a/docs_zh-CN/get_started.md
+++ b/docs_zh-CN/get_started.md
@@ -105,24 +105,32 @@ MIM 能够自动地安装 OpenMMLab 的项目以及对应的依赖包。
     pip install mmcv-full
     ```
 
-2. 将 MMDetection 仓库克隆至本地：
+2. 安装 MMDetection：
+
+    你可以直接通过如下命令从 pip 安装使用 mmdetection:
+
+    ```shell
+    pip install mmdet
+    ```
+
+    或者从 git 仓库编译源码
 
     ```shell
     git clone https://github.com/open-mmlab/mmdetection.git
     cd mmdetection
-    ```
-
-3. 首先安装需要的依赖包，然后安装 MMDetection：
-
-    ```shell
     pip install -r requirements/build.txt
-    pip install -v -e .  # 或者使用 "python setup.py develop"
+    pip install -v -e .  # or "python setup.py develop"
     ```
 
-    或者，可以使用更简单的命令安装 MMDetection：
+3. 安装额外的依赖以使用 Instaboost, 全景分割, 或者 LVIS 数据集
 
     ```shell
-    pip install mmdet
+    # for instaboost
+    pip install instaboostfast
+    # for panoptic segmentation
+    pip install git+https://github.com/cocodataset/panopticapi.git
+    # for LVIS dataset
+    pip install git+https://github.com/lvis-dataset/lvis-api.git
     ```
 
 **注意：**

--- a/docs_zh-CN/get_started.md
+++ b/docs_zh-CN/get_started.md
@@ -125,11 +125,11 @@ MIM 能够自动地安装 OpenMMLab 的项目以及对应的依赖包。
 3. 安装额外的依赖以使用 Instaboost, 全景分割, 或者 LVIS 数据集
 
     ```shell
-    # for instaboost
+    # 安装 instaboost 依赖
     pip install instaboostfast
-    # for panoptic segmentation
+    # 安装全景分割依赖
     pip install git+https://github.com/cocodataset/panopticapi.git
-    # for LVIS dataset
+    # 安装 LVIS 数据集依赖
     pip install git+https://github.com/lvis-dataset/lvis-api.git
     ```
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,5 @@
 matplotlib
 numpy
-panopticapi @ git+https://github.com/cocodataset/panopticapi.git
 pycocotools; platform_system == "Linux"
 pycocotools-windows; platform_system == "Windows"
 six


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When publishing this package to PyPi, PyPi will reject this package because it includes the URL of `panopticapi` outside PyPi.

## Modification

Remove `panopticapi` from the runtime.txt and add documentation to tell users to manually install panoptic API if they want to use it.

## BC-breaking (Optional)

N/A

## Use cases (Optional)
N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
