### PR TITLE
[Enhance] Rename the function `upsample_like` to `interpolate_as`

### DIFF
--- a/mmdet/models/utils/__init__.py
+++ b/mmdet/models/utils/__init__.py
@@ -3,7 +3,7 @@ from .conv_upsample import ConvUpsample
 from .gaussian_target import gaussian_radius, gen_gaussian_target
 from .inverted_residual import InvertedResidual
 from .make_divisible import make_divisible
-from .misc import upsample_like
+from .misc import interpolate_as
 from .normed_predictor import NormedConv2d, NormedLinear
 from .positional_encoding import (LearnedPositionalEncoding,
                                   SinePositionalEncoding)
@@ -18,5 +18,5 @@ __all__ = [
     'build_transformer', 'build_linear_layer', 'SinePositionalEncoding',
     'LearnedPositionalEncoding', 'DynamicConv', 'SimplifiedBasicBlock',
     'NormedLinear', 'NormedConv2d', 'make_divisible', 'InvertedResidual',
-    'SELayer', 'upsample_like', 'ConvUpsample'
+    'SELayer', 'interpolate_as', 'ConvUpsample'
 ]

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -1,29 +1,29 @@
 from torch.nn import functional as F
 
 
-def upsample_like(source, target, mode='bilinear', align_corners=False):
-    """Upsample the source to the shape of the target.
+def interpolate_as(source, target, mode='bilinear', align_corners=False):
+    """Down/up samples the source to the shape of the target.
 
-    Upsample the source to the shape of target. The input must be a Tensor,
-    but the target can be a Tensor or a np.ndarray with the shape
+    Down/up samples the source to the shape of target. The input must be a
+    Tensor, but the target can be a Tensor or a np.ndarray with the shape
     (..., target_h, target_w).
 
     Args:
         source (Tensor): A 3D/4D Tensor with the shape (N, H, W) or
             (N, C, H, W).
-        target (Tensor | np.ndarray): The upsampling target with the shape
+        target (Tensor | np.ndarray): The interpolation target with the shape
             (..., target_h, target_w).
-        mode (str): Algorithm used for upsampling. The options are the same
-            as those in F.interpolate(). Default: ``'bilinear'``.
+        mode (str): Algorithm used for interpolation. The options are the
+            same as those in F.interpolate(). Default: ``'bilinear'``.
         align_corners (bool): The same as the argument in F.interpolate().
 
     Returns:
-        Tensor: The upsampled source Tensor.
+        Tensor: The interpolated source Tensor.
     """
     assert len(target.shape) >= 2
 
-    def _upsample_like(source, target, mode='bilinear', align_corners=False):
-        """Upsample the source (4D) to the shape of the target."""
+    def _interpolate_as(source, target, mode='bilinear', align_corners=False):
+        """Down/up samples the source (4D) to the shape of the target."""
         target_h, target_w = target.shape[-2:]
         source_h, source_w = source.shape[-2:]
         if target_h != source_h or target_w != source_w:
@@ -36,7 +36,7 @@ def upsample_like(source, target, mode='bilinear', align_corners=False):
 
     if len(source.shape) == 3:
         source = source[:, None, :, :]
-        source = _upsample_like(source, target, mode, align_corners)
+        source = _interpolate_as(source, target, mode, align_corners)
         return source[:, 0, :, :]
     else:
-        return _upsample_like(source, target, mode, align_corners)
+        return _interpolate_as(source, target, mode, align_corners)

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -2,9 +2,9 @@ from torch.nn import functional as F
 
 
 def interpolate_as(source, target, mode='bilinear', align_corners=False):
-    """Down/up samples the source to the shape of the target.
+    """Interpolate the source to the shape of the target.
 
-    Down/up samples the source to the shape of target. The input must be a
+    Interpolate the source to the shape of target. The input must be a
     Tensor, but the target can be a Tensor or a np.ndarray with the shape
     (..., target_h, target_w).
 
@@ -23,7 +23,7 @@ def interpolate_as(source, target, mode='bilinear', align_corners=False):
     assert len(target.shape) >= 2
 
     def _interpolate_as(source, target, mode='bilinear', align_corners=False):
-        """Down/up samples the source (4D) to the shape of the target."""
+        """Interpolate the source (4D) to the shape of the target."""
         target_h, target_w = target.shape[-2:]
         source_h, source_w = source.shape[-2:]
         if target_h != source_h or target_w != source_w:

--- a/tests/test_models/test_utils/test_model_misc.py
+++ b/tests/test_models/test_utils/test_model_misc.py
@@ -1,26 +1,26 @@
 import numpy as np
 import torch
 
-from mmdet.models.utils import upsample_like
+from mmdet.models.utils import interpolate_as
 
 
-def test_upsample_like():
+def test_interpolate_as():
     logits = torch.rand((1, 5, 4, 4))
     targets = torch.rand((1, 1, 16, 16))
 
     # Test 4D logits and targets
-    result = upsample_like(logits, targets)
+    result = interpolate_as(logits, targets)
     assert result.shape == torch.Size((1, 5, 16, 16))
 
     # Test 3D targets
-    result = upsample_like(logits, targets.squeeze(0))
+    result = interpolate_as(logits, targets.squeeze(0))
     assert result.shape == torch.Size((1, 5, 16, 16))
 
     # Test 3D logits
-    result = upsample_like(logits.squeeze(0), targets)
+    result = interpolate_as(logits.squeeze(0), targets)
     assert result.shape == torch.Size((5, 16, 16))
 
     # Test type(target) == np.ndarray
     targets = np.random.rand(16, 16)
-    result = upsample_like(logits.squeeze(0), targets)
+    result = interpolate_as(logits.squeeze(0), targets)
     assert result.shape == torch.Size((5, 16, 16))


### PR DESCRIPTION
Actually, this function can not only upsample the input Tensor but also downsample the input.
So we should rename it to reflect its real function.