### PR TITLE
[Feature] Ignore vim *.swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ work_dirs/
 *.pth
 *.py~
 *.sh~
+
+# vim
+*.swp


### PR DESCRIPTION
*.swp files will be created when I open a file with vi/vim. In this pr, I ignored *.swp files.