### PR TITLE
[Feature] Ignore vim *.swp files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ work_dirs/
 *.pth
 *.py~
 *.sh~
+
+# vim
+*.swp


### PR DESCRIPTION
*.swp files are vi/vim tempfiles. I ignore them in .gitignore.