### PR TITLE
[Feature]: Support export onnx models without post process.

### DIFF
--- a/docs/tutorials/pytorch2onnx.md
+++ b/docs/tutorials/pytorch2onnx.md
@@ -59,7 +59,7 @@ python tools/deployment/pytorch2onnx.py \
 - `--verify`: Determines whether to verify the correctness of an exported model. If not specified, it will be set to `False`.
 - `--simplify`: Determines whether to simplify the exported ONNX model. If not specified, it will be set to `False`.
 - `--cfg-options`: Override some settings in the used config file, the key-value pair in `xxx=yyy` format will be merged into config file.
-- `--skip-postprocess`: Determines whether export model without post process. If not specified, it will be set to `False`. Notice: This is an Experimental option. Only work for some single stage models. Users need to implement the post-process by themselves. We do not guarantee the correctness of the exported model.
+- `--skip-postprocess`: Determines whether export model without post process. If not specified, it will be set to `False`. Notice: This is an experimental option. Only work for some single stage models. Users need to implement the post-process by themselves. We do not guarantee the correctness of the exported model.
 
 Example:
 

--- a/docs/tutorials/pytorch2onnx.md
+++ b/docs/tutorials/pytorch2onnx.md
@@ -59,6 +59,7 @@ python tools/deployment/pytorch2onnx.py \
 - `--verify`: Determines whether to verify the correctness of an exported model. If not specified, it will be set to `False`.
 - `--simplify`: Determines whether to simplify the exported ONNX model. If not specified, it will be set to `False`.
 - `--cfg-options`: Override some settings in the used config file, the key-value pair in `xxx=yyy` format will be merged into config file.
+- `--skip-postprocess`: Determines whether export model without post process. If not specified, it will be set to `False`. Notice: This is an Experimental option. Only work for some single stage models. Users need to implement the post-process by themselves. We do not guarantee the correctness of the exported model.
 
 Example:
 

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -276,7 +276,9 @@ def parse_args():
     parser.add_argument(
         '--skip-postprocess',
         action='store_true',
-        help='Whether to export model without post process.')
+        help='Whether to export model without post process. Experimental '
+        'option. We do not guarantee the correctness of the exported '
+        'model.')
     args = parser.parse_args()
     return args
 

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -22,7 +22,8 @@ def pytorch2onnx(model,
                  verify=False,
                  test_img=None,
                  do_simplify=False,
-                 dynamic_export=None):
+                 dynamic_export=None,
+                 skip_postprocess=False):
 
     input_config = {
         'input_shape': input_shape,
@@ -32,6 +33,26 @@ def pytorch2onnx(model,
     # prepare input
     one_img, one_meta = preprocess_example_input(input_config)
     img_list, img_meta_list = [one_img], [[one_meta]]
+
+    if skip_postprocess:
+        warnings.warn('Not all models support export onnx without post '
+                      'process, especially two stage detectors!')
+        model.forward = model.forward_dummy
+        torch.onnx.export(
+            model,
+            one_img,
+            output_file,
+            input_names=['input'],
+            export_params=True,
+            keep_initializers_as_inputs=True,
+            do_constant_folding=True,
+            verbose=show,
+            opset_version=opset_version)
+
+        print(f'Successfully exported ONNX model without '
+              f'post process: {output_file}')
+        return
+
     # replace original forward function
     origin_forward = model.forward
     model.forward = partial(
@@ -252,6 +273,10 @@ def parse_args():
         '--dynamic-export',
         action='store_true',
         help='Whether to export onnx with dynamic axis.')
+    parser.add_argument(
+        '--skip-postprocess',
+        action='store_true',
+        help='Whether to export model without post process.')
     args = parser.parse_args()
     return args
 
@@ -305,4 +330,5 @@ if __name__ == '__main__':
         verify=args.verify,
         test_img=args.test_img,
         do_simplify=args.simplify,
-        dynamic_export=args.dynamic_export)
+        dynamic_export=args.dynamic_export,
+        skip_postprocess=args.skip_postprocess)


### PR DESCRIPTION
# Motivation

Many users ask for supporting export raw models without post-process. This is useful when they want to convert the onnx to other formats such as caffe and ncnn, and implement post-process by themselves.

## Usage

When run `tools/deployment/pytorch2onnx.py`, add `--skip-postprocess`. For example:

```
python tools/deployment/pytorch2onnx.py configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py \
checkpoints/yolov3_mobilenetv2_mstrain-416_300e_coco_20210718_010823-f68a07b3.pth --output-file \
yolov3_mobilenetv2_no_post.onnx --shape 416 416 --skip-postprocess
```

## Notice

Exporting models without post-process only works on some one-stage models.
