### PR TITLE
fix the error of polt map when the logs in training time.

### DIFF
--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -58,6 +58,7 @@ def plot_curve(log_dicts, args):
                 ys = []
                 for epoch in epochs:
                     ys += log_dict[epoch][metric]
+                xs = xs[:len(ys)]
                 ax = plt.gca()
                 ax.set_xticks(xs)
                 plt.xlabel('epoch')


### PR DESCRIPTION

## Motivation

fix the error of polt map when the logs in training time.

## Modification

In training time it appears error "raise ValueError(f"x and y must have same first dimension, but " when you plot the curve about mAP. It is because the epoch is greater than the length of ys, while the length of ys is equal to epoch -1.
Then we add a code "xs = xs[:len(ys)]" that can solve it and does not affect ploting curve in finished training time.

