### PR TITLE
[Enhance] Refactor the loss function in HTC and SCNet

### DIFF
--- a/configs/htc/htc_r50_fpn_1x_coco.py
+++ b/configs/htc/htc_r50_fpn_1x_coco.py
@@ -14,8 +14,8 @@ model = dict(
             in_channels=256,
             conv_out_channels=256,
             num_classes=183,
-            ignore_label=255,
-            loss_weight=0.2)))
+            loss_seg=dict(
+                type='CrossEntropyLoss', ignore_index=255, loss_weight=0.2))))
 data_root = 'data/coco/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)

--- a/configs/scnet/scnet_r50_fpn_1x_coco.py
+++ b/configs/scnet/scnet_r50_fpn_1x_coco.py
@@ -94,8 +94,8 @@ model = dict(
             in_channels=256,
             conv_out_channels=256,
             num_classes=183,
-            ignore_label=255,
-            loss_weight=0.2,
+            loss_seg=dict(
+                type='CrossEntropyLoss', ignore_index=255, loss_weight=0.2),
             conv_to_res=True),
         glbctx_head=dict(
             type='GlobalContextHead',

--- a/mmdet/models/roi_heads/mask_heads/fused_semantic_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fused_semantic_head.py
@@ -1,3 +1,5 @@
+import warnings
+
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
@@ -32,6 +34,8 @@ class FusedSemanticHead(BaseModule):
                  num_classes=183,
                  conv_cfg=None,
                  norm_cfg=None,
+                 ignore_label=None,
+                 loss_weight=None,
                  loss_seg=dict(
                      type='CrossEntropyLoss',
                      ignore_index=255,
@@ -78,7 +82,14 @@ class FusedSemanticHead(BaseModule):
             conv_cfg=self.conv_cfg,
             norm_cfg=self.norm_cfg)
         self.conv_logits = nn.Conv2d(conv_out_channels, self.num_classes, 1)
-
+        if ignore_label:
+            loss_seg['ignore_index'] = ignore_label
+        if loss_weight:
+            loss_seg['loss_weight'] = loss_weight
+        if ignore_label or loss_weight:
+            warnings.warn('``ignore_label`` and ``loss_weight`` would be '
+                          'deprecated soon. Please set ``ingore_index`` and '
+                          '``loss_weight`` in ``loss_seg`` instead.')
         self.criterion = build_loss(loss_seg)
 
     @auto_fp16()


### PR DESCRIPTION
Now we support `ignore_index` in `CrossEntropyLoss`.

We should refactor the loss function in HTC and SCNet to use our own CrossEntropyLoss instead of PyTorch.