### PR TITLE
[Fix] Fix the log error when `IterBasedRunner` is used

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -147,7 +147,10 @@ def train_detector(model,
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook
-        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
+        # In this PR (https://github.com/open-mmlab/mmcv/pull/1193), the
+        # priority of IterTimerHook has been modified from 'NORMAL' to 'LOW'.
+        runner.register_hook(
+            eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 
     # user-defined hooks
     if cfg.get('custom_hooks', None):


### PR DESCRIPTION
## Motivation

If the priority of `EvalHook` is higher than `IterTimerHook`, it will cause `KeyError: 'data_time'` (https://github.com/open-mmlab/mmsegmentation/issues/758, https://github.com/open-mmlab/mmcv/issues/1261).
Since the time key will add to the output of `log_buffer` after `IterTimeHook`, the `TextLoggerHook` will print the time and `data_time` at the same time.

This PR is based on https://github.com/open-mmlab/mmsegmentation/pull/766.

This PR will be useful for models that uses `IterBasedRunner`, e.g., yolof.

## Modification

Set the priority of `EvalHook` to `LOW`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.