### PR TITLE
[Fix] The interface `multiscale_output` is defined but not used 

### DIFF
--- a/mmdet/models/backbones/hrnet.py
+++ b/mmdet/models/backbones/hrnet.py
@@ -223,11 +223,11 @@ class HRNet(BaseModule):
         norm_cfg (dict): Dictionary to construct and config norm layer.
         norm_eval (bool): Whether to set norm layers to eval mode, namely,
             freeze running stats (mean and var). Note: Effect on Batch Norm
-            and its variants only.
+            and its variants only. Default: True.
         with_cp (bool): Use checkpoint or not. Using checkpoint will save some
-            memory while slowing down the training speed.
+            memory while slowing down the training speed. Default: False.
         zero_init_residual (bool): Whether to use zero init for last norm layer
-            in resblocks to let them behave as identity.
+            in resblocks to let them behave as identity. Default: False.
         multiscale_output (bool): Whether to output multi-level features
             produced by multiple branches. If False, only the first level
             feature will be output. Default: True.

--- a/mmdet/models/backbones/hrnet.py
+++ b/mmdet/models/backbones/hrnet.py
@@ -231,7 +231,7 @@ class HRNet(BaseModule):
         multiscale_output (bool): Whether to output multi-level features
             produced by multiple branches. If False, only the first level
             feature will be output. Default: True.
-        pretrained (str, optional): Model pretrained path. Default: None
+        pretrained (str, optional): Model pretrained path. Default: None.
         init_cfg (dict or list[dict], optional): Initialization config dict.
             Default: None.
 

--- a/mmdet/models/backbones/hrnet.py
+++ b/mmdet/models/backbones/hrnet.py
@@ -203,8 +203,8 @@ class HRModule(BaseModule):
 class HRNet(BaseModule):
     """HRNet backbone.
 
-    High-Resolution Representations for Labeling Pixels and Regions
-    arXiv: https://arxiv.org/abs/1904.04514
+    `High-Resolution Representations for Labeling Pixels and Regions
+    arXiv: <https://arxiv.org/abs/1904.04514>`_.
 
     Args:
         extra (dict): Detailed configuration for each stage of HRNet.
@@ -233,7 +233,7 @@ class HRNet(BaseModule):
             feature will be output. Default: True.
         pretrained (str, optional): Model pretrained path. Default: None
         init_cfg (dict or list[dict], optional): Initialization config dict.
-            Default: None
+            Default: None.
 
     Example:
         >>> from mmdet.models import HRNet

--- a/mmdet/models/backbones/hrnet.py
+++ b/mmdet/models/backbones/hrnet.py
@@ -216,7 +216,7 @@ class HRNet(BaseModule):
                 - block(str): The type of convolution block.
                 - num_blocks(tuple): The number of blocks in each branch.
                     The length must be equal to num_branches.
-                - num_channels(tuple): the number of channels in each branch.
+                - num_channels(tuple): The number of channels in each branch.
                     The length must be equal to num_branches.
         in_channels (int): Number of input image channels. Default: 3.
         conv_cfg (dict): Dictionary to construct and config conv layer.

--- a/mmdet/models/backbones/hrnet.py
+++ b/mmdet/models/backbones/hrnet.py
@@ -218,6 +218,8 @@ class HRNet(BaseModule):
             memory while slowing down the training speed.
         zero_init_residual (bool): whether to use zero init for last norm layer
             in resblocks to let them behave as identity.
+        multiscale_output (bool): whether to output multi-level features. If
+            False, only the first level feature will be output. Default: True.
         pretrained (str, optional): model pretrained path. Default: None
         init_cfg (dict or list[dict], optional): Initialization config dict.
             Default: None
@@ -272,6 +274,7 @@ class HRNet(BaseModule):
                  norm_eval=True,
                  with_cp=False,
                  zero_init_residual=False,
+                 multiscale_output=True,
                  pretrained=None,
                  init_cfg=None):
         super(HRNet, self).__init__(init_cfg)
@@ -372,7 +375,7 @@ class HRNet(BaseModule):
         self.transition3 = self._make_transition_layer(pre_stage_channels,
                                                        num_channels)
         self.stage4, pre_stage_channels = self._make_stage(
-            self.stage4_cfg, num_channels)
+            self.stage4_cfg, num_channels, multiscale_output=multiscale_output)
 
     @property
     def norm1(self):

--- a/tests/test_models/test_backbones/test_hrnet.py
+++ b/tests/test_models/test_backbones/test_hrnet.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import pytest
 import torch
 

--- a/tests/test_models/test_backbones/test_hrnet.py
+++ b/tests/test_models/test_backbones/test_hrnet.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+from mmdet.models.backbones.hrnet import HRNet
+
+
+def test_hourglass_backbone():
+    # only have 3 stages
+    extra = dict(
+        stage1=dict(
+            num_modules=1,
+            num_branches=1,
+            block='BOTTLENECK',
+            num_blocks=(4, ),
+            num_channels=(64, )),
+        stage2=dict(
+            num_modules=1,
+            num_branches=2,
+            block='BASIC',
+            num_blocks=(4, 4),
+            num_channels=(32, 64)),
+        stage3=dict(
+            num_modules=4,
+            num_branches=3,
+            block='BASIC',
+            num_blocks=(4, 4, 4),
+            num_channels=(32, 64, 128)))
+
+    with pytest.raises(AssertionError):
+        # HRNet now only support 4 stages
+        HRNet(extra=extra)
+    extra['stage4'] = dict(
+        num_modules=3,
+        num_branches=3,  # should be 4
+        block='BASIC',
+        num_blocks=(4, 4, 4, 4),
+        num_channels=(32, 64, 128, 256))
+
+    with pytest.raises(AssertionError):
+        # len(num_blocks) should equal num_branches
+        HRNet(extra=extra)
+
+    extra['stage4']['num_branches'] = 4
+
+    # Test hrnetv2p_w32
+    model = HRNet(extra=extra)
+    model.init_weights()
+    model.train()
+
+    imgs = torch.randn(1, 3, 256, 256)
+    feat = model(imgs)
+    assert len(feat) == 4
+    assert feat[0].shape == torch.Size([1, 32, 64, 64])
+    assert feat[3].shape == torch.Size([1, 256, 8, 8])
+
+    # Test single scale output
+    model = HRNet(extra=extra, multiscale_output=False)
+    model.init_weights()
+    model.train()
+
+    imgs = torch.randn(1, 3, 256, 256)
+    feat = model(imgs)
+    assert len(feat) == 1
+    assert feat[0].shape == torch.Size([1, 32, 64, 64])


### PR DESCRIPTION
The interface `multiscale_output` is defined in `_make_stage` but never used.

HRNet should be allowed to output a one-level feature in stage 4.
So we should use `multiscale_output` while making stage 4 and add interface  `multiscale_output` in the initialization function of HRNet.

Add unit test for HRNet in this PR, too.