### PR TITLE
[Fix] fix a yolox bug when applying bbox rescaling in test mode

### DIFF
--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -274,7 +274,7 @@ class YOLOXHead(BaseDenseHead, BBoxTestMixin):
         flatten_bboxes = self._bbox_decode(flatten_priors, flatten_bbox_preds)
 
         if rescale:
-            flatten_bboxes[..., :4] /= flatten_bboxes.new_tensor(scale_factors)
+            flatten_bboxes[..., :4] /= flatten_bboxes.new_tensor(scale_factors).unsqueeze(1)
 
         result_list = []
         for img_id in range(len(img_metas)):


### PR DESCRIPTION
This bug is triggered only when batch_size > 1. For example, given batch_size = 20,
the tensor on the left side has shape [20, x, 4], while the tensor on the right size
has shape [20, 4]

## Motivation

fix a yolox bug when applying bbox rescaling in test mode.

## Modification

reshape a tensor so that the assignment can be carried on successfully. (code had been tested on both batch_size = 1 and batch_size > 1)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
