### PR TITLE
[Enchance] Add filter rules of Mosaic transform

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -1965,14 +1965,14 @@ class Mosaic:
         center_ratio_range (Sequence[float]): Center ratio range of mosaic
            output. Default to (0.5, 1.5).
         min_bbox_size (int | float): The minimum pixel for filtering
-            invalid bboxes after the mosaic pipeline. Default to 1.
+            invalid bboxes after the mosaic pipeline. Default to 0.
         pad_val (int): Pad value. Default to 114.
     """
 
     def __init__(self,
                  img_scale=(640, 640),
                  center_ratio_range=(0.5, 1.5),
-                 min_bbox_size=1,
+                 min_bbox_size=0,
                  pad_val=114):
         assert isinstance(img_scale, tuple)
         self.img_scale = img_scale

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2079,6 +2079,11 @@ class Mosaic:
             mosaic_bboxes[:, 1::2] = np.clip(mosaic_bboxes[:, 1::2], 0,
                                              2 * self.img_scale[0])
             mosaic_labels = np.concatenate(mosaic_labels, 0)
+            
+            mosaic_filter = np.prod(mosaic_bboxes[:, 2:4] - \
+                                    mosaic_bboxes[:, 0:2] > 2,  axis=1) == 1
+            mosaic_bboxes = mosaic_bboxes[mosaic_filter]
+            mosaic_labels = mosaic_labels[mosaic_filter]
 
         results['img'] = mosaic_img
         results['img_shape'] = mosaic_img.shape

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2162,7 +2162,7 @@ class Mosaic:
         bbox_w = bboxes[:, 2] - bboxes[:, 0]
         bbox_h = bboxes[:, 3] - bboxes[:, 1]
         valid_inds = (bbox_w > self.min_bbox_size) & \
-                     (box_h > self.min_bbox_size)
+                     (bbox_h > self.min_bbox_size)
         valid_inds = np.nonzero(valid_inds)[0]
         return bboxes[valid_inds], labels[valid_inds]
 

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2131,7 +2131,7 @@ class Mosaic:
             x1, y1, x2, y2 = max(center_position_xy[0] - img_shape_wh[0], 0), \
                              center_position_xy[1], \
                              center_position_xy[0], \
-                             min(self.img_scale[1] * 2, center_position_xy[1] +
+                             min(self.img_scale[0] * 2, center_position_xy[1] +
                                  img_shape_wh[1])
             crop_coord = img_shape_wh[0] - (x2 - x1), 0, img_shape_wh[0], min(
                 y2 - y1, img_shape_wh[1])

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2138,7 +2138,7 @@ class Mosaic:
             x1, y1, x2, y2 = max(center_position_xy[0] - img_shape_wh[0], 0), \
                              center_position_xy[1], \
                              center_position_xy[0], \
-                             min(self.img_scale[0] * 2, center_position_xy[1] +
+                             min(self.img_scale[1] * 2, center_position_xy[1] +
                                  img_shape_wh[1])
             crop_coord = img_shape_wh[0] - (x2 - x1), 0, img_shape_wh[0], min(
                 y2 - y1, img_shape_wh[1])

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2083,7 +2083,7 @@ class Mosaic:
             mosaic_bboxes[:, 1::2] = np.clip(mosaic_bboxes[:, 1::2], 0,
                                              2 * self.img_scale[0])
             mosaic_labels = np.concatenate(mosaic_labels, 0)
-            
+
             mosaic_bboxes, mosaic_labels = \
                 self._filter_box_candidates(mosaic_bboxes, mosaic_labels)
 
@@ -2156,13 +2156,13 @@ class Mosaic:
 
         paste_coord = x1, y1, x2, y2
         return paste_coord, crop_coord
-    
+
     def _filter_box_candidates(self, bboxes, labels):
         """Filter out bboxes too small after Mosaic."""
-        bbox_w =bboxes[:, 2] - bboxes[:, 0]
+        bbox_w = bboxes[:, 2] - bboxes[:, 0]
         bbox_h = bboxes[:, 3] - bboxes[:, 1]
         valid_inds = (bbox_w > self.min_bbox_size) & \
-                        (bbox_h > self.min_bbox_size)
+                     (box_h > self.min_bbox_size)
         valid_inds = np.nonzero(valid_inds)[0]
         return bboxes[valid_inds], labels[valid_inds]
 


### PR DESCRIPTION
## Motivation

Fix two errors of Masaic.

## Modification

1. self.img_scale denotes (h,w). The "self.img_scale[1]"  should be changed to "self.img_scale[0]" in the formula of "y2" at line 2134 and 2135 when " loc == 'bottom_left' ". 
```python
                             min(self.img_scale[0] * 2, center_position_xy[1] +
                                 img_shape_wh[1])
```
2. To avoid NaN loss during training. The code should get rid of the mosaic_bboxes with small area (even zero area). In this submission, after line 2081, the bboxes with a short side smaller than 3 are abandoned.
```python
            mosaic_filter = np.prod(mosaic_bboxes[:, 2:4] - \
                                    mosaic_bboxes[:, 0:2] > 2,  axis=1) == 1
            mosaic_bboxes = mosaic_bboxes[mosaic_filter]
            mosaic_labels = mosaic_labels[mosaic_filter]
```