### PR TITLE
[Enhance] support NMS for DETR network in test mode

### DIFF
--- a/configs/detr/detr_r50_8x2_150e_coco.py
+++ b/configs/detr/detr_r50_8x2_150e_coco.py
@@ -67,7 +67,10 @@ model = dict(
             cls_cost=dict(type='ClassificationCost', weight=1.),
             reg_cost=dict(type='BBoxL1Cost', weight=5.0, box_format='xywh'),
             iou_cost=dict(type='IoUCost', iou_mode='giou', weight=2.0))),
-    test_cfg=dict(max_per_img=100))
+    test_cfg=dict(
+        score_thr=0.05,
+        nms=dict(type='nms', iou_threshold=0.6),
+        max_per_img=100))
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # train_pipeline, NOTE the img_scale and the Pad's size_divisor is different


### PR DESCRIPTION
DETR by default outputs a fixed number of bboxes during inference.
It doesn't run NMS when setting test_cfg as other networks do (say ATSS)

What I have changed:
1) add nms parameters in test_cfg in mmdet/configs/detr/detr_r50_8x2_150e_coco.py
2) running multiclass_nms() after get_bboxes() (in detr_head.py:simple_test_bboxes())

Note:
1) This modification won't affect training.
2) It applies a default set of parameters for NMS if they are not set explicitly

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

DETR by default outputs a fixed number of bboxes during inference. Developers might want it to run NMS
during test time (by setting test_cfg)

## Modification

1) add nms parameters in test_cfg in mmdet/configs/detr/detr_r50_8x2_150e_coco.py
2) running multiclass_nms() after get_bboxes() (in detr_head.py:simple_test_bboxes())

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
