### PR TITLE
Fixed typo

### DIFF
--- a/mmdet/datasets/utils.py
+++ b/mmdet/datasets/utils.py
@@ -116,7 +116,7 @@ class NumClassCheckHook(Hook):
 
     def _check_head(self, runner):
         """Check whether the `num_classes` in head matches the length of
-        `CLASSSES` in `dataset`.
+        `CLASSES` in `dataset`.
 
         Args:
             runner (obj:`EpochBasedRunner`): Epoch based Runner.


### PR DESCRIPTION
CLASSSES to CLASSES

## Motivation

Correct typo

## Modification

I changed CLASSSES to CLASSES in a docstring of  NumClassCheckHook

