### PR TITLE
Adapt browse_dataset for concatenated datasets.

### DIFF
--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+from collections import Sequence
 from pathlib import Path
 
 import mmcv
@@ -45,6 +46,12 @@ def parse_args():
 
 
 def retrieve_data_cfg(config_path, skip_type, cfg_options):
+
+    def skip_pipeline_steps(config):
+        config['pipeline'] = [
+            x for x in config.pipeline if x['type'] not in skip_type
+        ]
+
     cfg = Config.fromfile(config_path)
     if cfg_options is not None:
         cfg.merge_from_dict(cfg_options)
@@ -56,9 +63,11 @@ def retrieve_data_cfg(config_path, skip_type, cfg_options):
     while 'dataset' in train_data_cfg and train_data_cfg[
             'type'] != 'MultiImageMixDataset':
         train_data_cfg = train_data_cfg['dataset']
-    train_data_cfg['pipeline'] = [
-        x for x in train_data_cfg.pipeline if x['type'] not in skip_type
-    ]
+
+    if isinstance(train_data_cfg, Sequence):
+        [skip_pipeline_steps(c) for c in train_data_cfg]
+    else:
+        skip_pipeline_steps(train_data_cfg)
 
     return cfg
 


### PR DESCRIPTION
## Motivation

browse_dataset script is very useful to check your dataset, have a look to a few images and see if the pipeline seems to be ok. But not all datasets are supported, this PR is to make the script support concatenated datasets too.

## Modification

One method in the script skips some pipeline steps. Now if the config is a list, it will skip them in the pipelines of its elements.

## BC-breaking (Optional)

It's compatible with previous version.

## Use cases (Optional)

Run browse dataset for a concatenated dataset configuration.