### PR TITLE
[Feature]Add `PatchEmbed` and `PatchMerging` with `AdaptivePadding`

### DIFF
--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -105,8 +105,8 @@ class PatchEmbed(BaseModule):
     Args:
         in_channels (int): The num of input channels. Default: 3
         embed_dims (int): The dimensions of embedding. Default: 768
-        conv_type (dict, optional): The config dict for embedding
-            conv layer type selection. Default: None.
+        conv_type (str): The config dict for embedding
+            conv layer type selection. Default: "Conv2d.
         kernel_size (int): The kernel_size of embedding conv. Default: 16.
         stride (int): The slide stride of embedding conv.
             Default: None (Would be set as `kernel_size`).
@@ -129,7 +129,7 @@ class PatchEmbed(BaseModule):
         self,
         in_channels=3,
         embed_dims=768,
-        conv_type=None,
+        conv_type='Conv2d',
         kernel_size=16,
         stride=16,
         padding='corner',
@@ -144,9 +144,6 @@ class PatchEmbed(BaseModule):
         self.embed_dims = embed_dims
         if stride is None:
             stride = kernel_size
-
-        # Use conv layer to do the patch embedding
-        conv_type = conv_type or 'Conv2d'
 
         kernel_size = to_2tuple(kernel_size)
         stride = to_2tuple(stride)

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -100,6 +100,7 @@ class PatchEmbed(BaseModule):
             of adaptive padding, support "same" and "corner" now.
             Default: "corner".
         dilation (int): The dilation rate of embedding conv. Default: 1.
+        bias (bool): Bias of embed conv. Default: False.
         norm_cfg (dict, optional): Config dict for normalization layer.
             Default: None.
         input_size (int | tuple | None): The size of input, which will be
@@ -119,6 +120,7 @@ class PatchEmbed(BaseModule):
         stride=16,
         padding='corner',
         dilation=1,
+        bias=False,
         norm_cfg=None,
         input_size=None,
         init_cfg=None,
@@ -157,7 +159,8 @@ class PatchEmbed(BaseModule):
             kernel_size=kernel_size,
             stride=stride,
             padding=padding,
-            dilation=dilation)
+            dilation=dilation,
+            bias=bias)
 
         if norm_cfg is not None:
             self.norm = build_norm_layer(norm_cfg, embed_dims)[1]
@@ -281,7 +284,7 @@ class PatchMerging(BaseModule):
                 stride=stride,
                 dilation=dilation,
                 padding=padding)
-            # diable the padding of unfold
+            # disable the padding of unfold
             padding = 0
         else:
             self.adap_padding = None
@@ -331,6 +334,7 @@ class PatchMerging(BaseModule):
 
         if self.adap_padding:
             x = self.adap_padding(x)
+            H, W = x.shape[-2:]
 
         x = self.sampler(x)
         # if kernel_size=2 and stride=2, x should has shape (B, 4*C, H/2*W/2)

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -132,7 +132,6 @@ class PatchEmbed(BaseModule):
         self,
         in_channels=3,
         embed_dims=768,
-        pad_to_stride=True,
         conv_type=None,
         kernel_size=16,
         stride=16,
@@ -146,8 +145,6 @@ class PatchEmbed(BaseModule):
         super(PatchEmbed, self).__init__(init_cfg=init_cfg)
 
         self.embed_dims = embed_dims
-        self.pad_to_stride = pad_to_stride
-
         if stride is None:
             stride = kernel_size
 

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -52,9 +52,8 @@ class AdaptivePadding(nn.Module):
         >>>     kernel_size=kernel_size,
         >>>     stride=stride,
         >>>     dilation=dilation,
-        >>>     padding="same")
+        >>>     padding="corner")
         >>> out = adap_pad(input)
-        >>> # padding to divisible by 16
         >>> assert (out.shape[2], out.shape[3]) == (16, 32)
         >>> input = torch.rand(1, 1, 16, 17)
         >>> out = adap_pad(input)
@@ -83,12 +82,10 @@ class AdaptivePadding(nn.Module):
         stride_h, stride_w = self.stride
         output_h = math.ceil(input_h / stride_h)
         output_w = math.ceil(input_w / stride_w)
-        pad_h = (
-            max((output_h - 1) * stride_h + (kernel_h - 1) * self.dilation[0] +
-                1 - input_h, 0))
-        pad_w = (
-            max((output_w - 1) * stride_w + (kernel_w - 1) * self.dilation[1] +
-                1 - input_w, 0))
+        pad_h = max((output_h - 1) * stride_h +
+                    (kernel_h - 1) * self.dilation[0] + 1 - input_h, 0)
+        pad_w = max((output_w - 1) * stride_w +
+                    (kernel_w - 1) * self.dilation[1] + 1 - input_w, 0)
         if pad_h > 0 or pad_w > 0:
             if self.padding == 'corner':
                 x = F.pad(x, [0, pad_w, 0, pad_h])
@@ -148,7 +145,7 @@ class PatchEmbed(BaseModule):
         if stride is None:
             stride = kernel_size
 
-        # Use conv layer to embed
+        # Use conv layer to do the patch embedding
         conv_type = conv_type or 'Conv2d'
 
         kernel_size = to_2tuple(kernel_size)
@@ -194,14 +191,12 @@ class PatchEmbed(BaseModule):
                 stride_h, stride_w = self.adap_padding.stride
                 output_h = math.ceil(input_h / stride_h)
                 output_w = math.ceil(input_w / stride_w)
-                pad_h = (
-                    max((output_h - 1) * stride_h +
-                        (kernel_h - 1) * self.adap_padding.dilation[0] + 1 -
-                        input_h, 0))
-                pad_w = (
-                    max((output_w - 1) * stride_w +
-                        (kernel_w - 1) * self.adap_padding.dilation[1] + 1 -
-                        input_w, 0))
+                pad_h = max((output_h - 1) * stride_h +
+                            (kernel_h - 1) * self.adap_padding.dilation[0] +
+                            1 - input_h, 0)
+                pad_w = max((output_w - 1) * stride_w +
+                            (kernel_w - 1) * self.adap_padding.dilation[1] +
+                            1 - input_w, 0)
                 input_h = input_h + pad_h
                 input_w = input_w + pad_w
                 input_size = (input_h, input_w)

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -44,26 +44,27 @@ class PatchEmbed(BaseModule):
         padding (int): The padding length of embedding conv. Default: 0.
         dilation (int): The dilation rate of embedding conv. Default: 1.
         norm_cfg (dict, optional): Config dict for normalization layer.
-        init_cfg (`mmcv.ConfigDict`, optional): The Config for initialization.
             Default: None.
-        use_dynamic_size (bool): Whether to use dynamic outsize, corresponding
-            to use the dynamic image size during training. Default: True.
         input_size (int | tuple): The size of input, which will be
             used to calculate the out size. Only work when `dynamic_size`
             is False. Default: None.
+        init_cfg (`mmcv.ConfigDict`, optional): The Config for initialization.
+            Default: None.
     """
 
-    def __init__(self,
-                 in_channels=3,
-                 embed_dims=768,
-                 conv_type=None,
-                 kernel_size=16,
-                 stride=None,
-                 padding=0,
-                 dilation=1,
-                 norm_cfg=None,
-                 init_cfg=None,
-                 input_size=None):
+    def __init__(
+        self,
+        in_channels=3,
+        embed_dims=768,
+        conv_type=None,
+        kernel_size=16,
+        stride=None,
+        padding=0,
+        dilation=1,
+        norm_cfg=None,
+        input_size=None,
+        init_cfg=None,
+    ):
         super(PatchEmbed, self).__init__(init_cfg=init_cfg)
 
         self.embed_dims = embed_dims
@@ -110,7 +111,7 @@ class PatchEmbed(BaseModule):
     def forward(self, x):
         """
         Args:
-            x (Tensor): Has shape (B, H*W, in_channels).
+            x (Tensor): Has shape (B, C, H, W). In most case, C is 3.
 
         Returns:
             tuple: Contains merged results and its spatial shape.

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -48,16 +48,16 @@ class AdaptivePadding(nn.Module):
         >>> stride = 16
         >>> dilation = 1
         >>> input = torch.rand(1, 1, 15, 17)
-        >>> pool = AdaptivePadding(
+        >>> adap_pad = AdaptivePadding(
         >>>     kernel_size=kernel_size,
         >>>     stride=stride,
         >>>     dilation=dilation,
         >>>     padding="same")
-        >>> out = pool(input)
+        >>> out = adap_pad(input)
         >>> # padding to divisible by 16
         >>> assert (out.shape[2], out.shape[3]) == (16, 32)
         >>> input = torch.rand(1, 1, 16, 17)
-        >>> out = pool(input)
+        >>> out = adap_pad(input)
         >>> assert (out.shape[2], out.shape[3]) == (16, 32)
     """
 

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -4,13 +4,16 @@ import warnings
 
 import torch
 import torch.nn as nn
-from mmcv.cnn import build_activation_layer, build_norm_layer, xavier_init
+import torch.nn.functional as F
+from mmcv.cnn import (build_activation_layer, build_conv_layer,
+                      build_norm_layer, xavier_init)
 from mmcv.cnn.bricks.registry import (TRANSFORMER_LAYER,
                                       TRANSFORMER_LAYER_SEQUENCE)
 from mmcv.cnn.bricks.transformer import (BaseTransformerLayer,
                                          TransformerLayerSequence,
                                          build_transformer_layer_sequence)
 from mmcv.runner.base_module import BaseModule
+from mmcv.utils import to_2tuple
 from torch.nn.init import normal_
 
 from mmdet.models.utils.builder import TRANSFORMER
@@ -23,6 +26,100 @@ except ImportError:
         '`MultiScaleDeformableAttention` in MMCV has been moved to '
         '`mmcv.ops.multi_scale_deform_attn`, please update your MMCV')
     from mmcv.cnn.bricks.transformer import MultiScaleDeformableAttention
+
+
+class PatchEmbed(BaseModule):
+    """Image to Patch Embedding V2.
+
+    We use a conv layer to implement PatchEmbed.
+
+    Args:
+        in_channels (int): The num of input channels. Default: 3
+        embed_dims (int): The dimensions of embedding. Default: 768
+        conv_type (dict, optional): The config dict for conv layer type
+            selection. Default: None.
+        kernel_size (int): The kernel_size of embedding conv. Default: 16.
+        stride (int): The slide stride of embedding conv.
+            Default: None (Default to be equal with kernel_size).
+        padding (int): The padding length of embedding conv. Default: 0.
+        dilation (int): The dilation rate of embedding conv. Default: 1.
+        pad_to_patch_size (bool, optional): Whether to pad feature map shape
+            to multiple patch size. Default: True.
+        norm_cfg (dict, optional): Config dict for normalization layer.
+        init_cfg (`mmcv.ConfigDict`, optional): The Config for initialization.
+            Default: None.
+    """
+
+    def __init__(self,
+                 in_channels=3,
+                 embed_dims=768,
+                 conv_type=None,
+                 kernel_size=16,
+                 stride=16,
+                 padding=0,
+                 dilation=1,
+                 pad_to_patch_size=True,
+                 norm_cfg=None,
+                 init_cfg=None):
+        super(PatchEmbed, self).__init__(init_cfg=init_cfg)
+
+        self.embed_dims = embed_dims
+
+        if stride is None:
+            stride = kernel_size
+
+        self.pad_to_patch_size = pad_to_patch_size
+
+        # The default setting of patch size is equal to kernel size.
+        patch_size = kernel_size + (dilation - 1) * 2
+        if isinstance(patch_size, int):
+            patch_size = to_2tuple(patch_size)
+        elif isinstance(patch_size, tuple):
+            if len(patch_size) == 1:
+                patch_size = to_2tuple(patch_size[0])
+            assert len(patch_size) == 2, \
+                f'The size of patch should have length 1 or 2, ' \
+                f'but got {len(patch_size)}'
+
+        self.patch_size = patch_size
+
+        # Use conv layer to embed
+        conv_type = conv_type or 'Conv2d'
+        self.projection = build_conv_layer(
+            dict(type=conv_type),
+            in_channels=in_channels,
+            out_channels=embed_dims,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation)
+
+        if norm_cfg is not None:
+            self.norm = build_norm_layer(norm_cfg, embed_dims)[1]
+        else:
+            self.norm = None
+
+    def forward(self, x):
+        H, W = x.shape[2], x.shape[3]
+
+        # TODO: Process overlapping op
+        if self.pad_to_patch_size:
+            # Modify H, W to multiple of patch size.
+            if H % self.patch_size[0] != 0:
+                x = F.pad(
+                    x, (0, 0, 0, self.patch_size[0] - H % self.patch_size[0]))
+            if W % self.patch_size[1] != 0:
+                x = F.pad(
+                    x, (0, self.patch_size[1] - W % self.patch_size[1], 0, 0))
+
+        x = self.projection(x)
+        self.DH, self.DW = x.shape[2], x.shape[3]
+        x = x.flatten(2).transpose(1, 2)
+
+        if self.norm is not None:
+            x = self.norm(x)
+
+        return x
 
 
 def inverse_sigmoid(x, eps=1e-5):

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -31,7 +31,9 @@ except ImportError:
 
 class AdaptivePadding(nn.Module):
     """Applies padding to input (if needed) so that input can get fully covered
-    by filter you specified.
+    by filter you specified. It support two modes "same" and "corner". The
+    "same" mode is same with "SAME" padding mode in TensorFlow, pad zero around
+    input. The "corner"  mode would pad zero to bottom right.
 
     Args:
         kernel_size (int | tuple): Size of the kernel:

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -109,12 +109,13 @@ class PatchEmbed(BaseModule):
 
             # Modify H, W to multiple of stride.
             if pad_to_stride:
-                H = input_size[0]
-                W = input_size[1]
-                if H % stride[0] != 0:
-                    input_size[0] = H + stride[0] - H % stride[0]
-                if W % stride[1] != 0:
-                    input_size[1] = W + stride[0] - H % stride[0]
+                padding_h = input_size[0]
+                padding_w = input_size[1]
+                if padding_h % stride[0] != 0:
+                    padding_h = padding_h + stride[0] - padding_h % stride[0]
+                if padding_w % stride[1] != 0:
+                    padding_w = padding_w + stride[0] - padding_w % stride[0]
+                input_size = (padding_h, padding_w)
 
             # https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html
             h_out = (input_size[0] + 2 * padding[0] - dilation[0] *
@@ -261,7 +262,7 @@ class PatchMerging(BaseModule):
                 H = H + stride[0] - H % stride[0]
             if W % stride[1] != 0:
                 x = F.pad(x, (0, stride[1] - W % stride[1], 0, 0))
-                W = W + stride[0] - W % stride[0]
+                W = W + stride[1] - W % stride[1]
 
         x = self.sampler(x)
         # if kernel_size=2 and stride=2, x should has shape (B, 4*C, H/2*W/2)

--- a/mmdet/models/utils/transformer.py
+++ b/mmdet/models/utils/transformer.py
@@ -43,6 +43,22 @@ class AdaptivePadding(nn.Module):
         padding (str): Support "same" and "corner", "corner" mode
             would pad zero to bottom right, and "same" mode would
             pad zero around input. Default: "corner".
+    Example:
+        >>> kernel_size = 16
+        >>> stride = 16
+        >>> dilation = 1
+        >>> input = torch.rand(1, 1, 15, 17)
+        >>> pool = AdaptivePadding(
+        >>>     kernel_size=kernel_size,
+        >>>     stride=stride,
+        >>>     dilation=dilation,
+        >>>     padding="same")
+        >>> out = pool(input)
+        >>> # padding to divisible by 16
+        >>> assert (out.shape[2], out.shape[3]) == (16, 32)
+        >>> input = torch.rand(1, 1, 16, 17)
+        >>> out = pool(input)
+        >>> assert (out.shape[2], out.shape[3]) == (16, 32)
     """
 
     def __init__(self, kernel_size=1, stride=1, dilation=1, padding='corner'):

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -118,6 +118,26 @@ def test_patch_embed():
     # the out_size shoule be equal to `init_out_size`
     assert shape == patch_merge_3.init_out_size
 
+    input_size = (H, W)
+    dummy_input = torch.rand(B, C, H, W)
+    # test stride and norm
+    patch_merge_3 = PatchEmbed(
+        in_channels=C,
+        embed_dims=embed_dims,
+        pad_to_stride=True,
+        conv_type=None,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=0,
+        dilation=2,
+        norm_cfg=dict(type='LN'),
+        input_size=input_size)
+
+    _, shape = patch_merge_3(dummy_input)
+    # when input_size equal to real input
+    # the out_size shoule be equal to `init_out_size`
+    assert shape == patch_merge_3.init_out_size
+
 
 def test_patch_merging():
     in_c = 3

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -226,6 +226,100 @@ def test_patch_embed():
     # the out_size shoule be equal to `init_out_size`
     assert shape == patch_merge_3.init_out_size
 
+    # test adap padding
+    for padding in ('same', 'corner'):
+        in_c = 2
+        embed_dims = 3
+        B = 2
+
+        # test stride is 1
+        input_size = (5, 5)
+        kernel_size = (5, 5)
+        stride = (1, 1)
+        dilation = 1
+        bias = False
+
+        x = torch.rand(B, in_c, *input_size)
+        patch_embed = PatchEmbed(
+            in_channels=in_c,
+            embed_dims=embed_dims,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_embed(x)
+        assert x_out.size() == (B, 25, 3)
+        assert out_size == (5, 5)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test kernel_size == stride
+        input_size = (5, 5)
+        kernel_size = (5, 5)
+        stride = (5, 5)
+        dilation = 1
+        bias = False
+
+        x = torch.rand(B, in_c, *input_size)
+        patch_embed = PatchEmbed(
+            in_channels=in_c,
+            embed_dims=embed_dims,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_embed(x)
+        assert x_out.size() == (B, 1, 3)
+        assert out_size == (1, 1)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test kernel_size == stride
+        input_size = (6, 5)
+        kernel_size = (5, 5)
+        stride = (5, 5)
+        dilation = 1
+        bias = False
+
+        x = torch.rand(B, in_c, *input_size)
+        patch_embed = PatchEmbed(
+            in_channels=in_c,
+            embed_dims=embed_dims,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_embed(x)
+        assert x_out.size() == (B, 2, 3)
+        assert out_size == (2, 1)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test different kernel_size with diffrent stride
+        input_size = (6, 5)
+        kernel_size = (6, 2)
+        stride = (6, 2)
+        dilation = 1
+        bias = False
+
+        x = torch.rand(B, in_c, *input_size)
+        patch_embed = PatchEmbed(
+            in_channels=in_c,
+            embed_dims=embed_dims,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_embed(x)
+        assert x_out.size() == (B, 3, 3)
+        assert out_size == (1, 3)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
 
 def test_patch_merging():
 
@@ -278,22 +372,103 @@ def test_patch_merging():
     # assert out size is consistent with real output
     assert x_out.size(1) == out_size[0] * out_size[1]
 
-    # Test the model with adaptive padding
-    patch_merge = PatchMerging(
-        in_channels=in_c,
-        out_channels=out_c,
-        kernel_size=kernel_size,
-        stride=stride,
-        padding=padding,
-        dilation=dilation,
-        bias=bias)
-    B, L, C = 1, 100, 4
-    input_size = (10, 10)
-    x = torch.rand(B, L, C)
-    x_out, out_size = patch_merge(x, input_size)
-    assert x_out.size() == (1, 4, 5)
-    assert out_size == (2, 2)
-    assert x_out.size(1) == out_size[0] * out_size[1]
+    # Test with adaptive padding
+    for padding in ('same', 'corner'):
+        in_c = 2
+        out_c = 3
+        B = 2
+
+        # test stride is 1
+        input_size = (5, 5)
+        kernel_size = (5, 5)
+        stride = (1, 1)
+        dilation = 1
+        bias = False
+        L = input_size[0] * input_size[1]
+
+        x = torch.rand(B, L, in_c)
+        patch_merge = PatchMerging(
+            in_channels=in_c,
+            out_channels=out_c,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_merge(x, input_size)
+        assert x_out.size() == (B, 25, 3)
+        assert out_size == (5, 5)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test kernel_size == stride
+        input_size = (5, 5)
+        kernel_size = (5, 5)
+        stride = (5, 5)
+        dilation = 1
+        bias = False
+        L = input_size[0] * input_size[1]
+
+        x = torch.rand(B, L, in_c)
+        patch_merge = PatchMerging(
+            in_channels=in_c,
+            out_channels=out_c,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_merge(x, input_size)
+        assert x_out.size() == (B, 1, 3)
+        assert out_size == (1, 1)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test kernel_size == stride
+        input_size = (6, 5)
+        kernel_size = (5, 5)
+        stride = (5, 5)
+        dilation = 1
+        bias = False
+        L = input_size[0] * input_size[1]
+
+        x = torch.rand(B, L, in_c)
+        patch_merge = PatchMerging(
+            in_channels=in_c,
+            out_channels=out_c,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_merge(x, input_size)
+        assert x_out.size() == (B, 2, 3)
+        assert out_size == (2, 1)
+        assert x_out.size(1) == out_size[0] * out_size[1]
+
+        # test different kernel_size with diffrent stride
+        input_size = (6, 5)
+        kernel_size = (6, 2)
+        stride = (6, 2)
+        dilation = 1
+        bias = False
+        L = input_size[0] * input_size[1]
+
+        x = torch.rand(B, L, in_c)
+        patch_merge = PatchMerging(
+            in_channels=in_c,
+            out_channels=out_c,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            dilation=dilation,
+            bias=bias)
+
+        x_out, out_size = patch_merge(x, input_size)
+        assert x_out.size() == (B, 3, 3)
+        assert out_size == (1, 3)
+        assert x_out.size(1) == out_size[0] * out_size[1]
 
 
 def test_detr_transformer_dencoder_encoder_layer():

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -33,13 +33,13 @@ def test_adaptive_padding():
         stride = (2, 2)
         dilation = (1, 1)
 
-        pool = AdaptivePadding(
+        adap_pad = AdaptivePadding(
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
             padding=padding)
         input = torch.rand(1, 1, 11, 13)
-        out = pool(input)
+        out = adap_pad(input)
         # padding to divisible by 2
         assert (out.shape[2], out.shape[3]) == (12, 14)
 
@@ -47,24 +47,24 @@ def test_adaptive_padding():
         stride = (10, 10)
         dilation = (1, 1)
 
-        pool = AdaptivePadding(
+        adap_pad = AdaptivePadding(
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
             padding=padding)
         input = torch.rand(1, 1, 10, 13)
-        out = pool(input)
+        out = adap_pad(input)
         #  no padding
         assert (out.shape[2], out.shape[3]) == (10, 13)
 
         kernel_size = (11, 11)
-        pool = AdaptivePadding(
+        adap_pad = AdaptivePadding(
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
             padding=padding)
         input = torch.rand(1, 1, 11, 13)
-        out = pool(input)
+        out = adap_pad(input)
         #  all padding
         assert (out.shape[2], out.shape[3]) == (21, 21)
 
@@ -74,21 +74,21 @@ def test_adaptive_padding():
         kernel_size = (4, 5)
         dilation = (2, 2)
         # actually (7, 9)
-        pool = AdaptivePadding(
+        adap_pad = AdaptivePadding(
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
             padding=padding)
-        dilation_out = pool(input)
+        dilation_out = adap_pad(input)
         assert (dilation_out.shape[2], dilation_out.shape[3]) == (16, 21)
         kernel_size = (7, 9)
         dilation = (1, 1)
-        pool = AdaptivePadding(
+        adap_pad = AdaptivePadding(
             kernel_size=kernel_size,
             stride=stride,
             dilation=dilation,
             padding=padding)
-        kernel79_out = pool(input)
+        kernel79_out = adap_pad(input)
         assert (kernel79_out.shape[2], kernel79_out.shape[3]) == (16, 21)
         assert kernel79_out.shape == dilation_out.shape
 

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -8,7 +8,7 @@ from mmdet.models.utils.transformer import (DetrTransformerDecoder,
                                             PatchMerging, Transformer)
 
 
-def test_patchembed():
+def test_patch_embed():
     B = 2
     H = 3
     W = 4
@@ -29,8 +29,11 @@ def test_patchembed():
     )
 
     x1, shape = patch_merge_1(dummy_input)
+    # test out shape
     assert x1.shape == (2, 2, 10)
+    # test outsize is correct
     assert shape == (1, 2)
+    # test L = out_h * out_w
     assert shape[0] * shape[1] == x1.shape[1]
 
     B = 2
@@ -54,12 +57,16 @@ def test_patchembed():
     )
 
     x2, shape = patch_merge_2(dummy_input)
+    # test out shape
     assert x2.shape == (2, 1, 10)
+    # test outsize is correct
     assert shape == (1, 1)
+    # test L = out_h * out_w
     assert shape[0] * shape[1] == x2.shape[1]
 
     stride = 2
     input_size = (10, 10)
+
     dummy_input = torch.rand(B, C, H, W)
     # test stride and norm
     patch_merge_3 = PatchEmbed(
@@ -74,13 +81,38 @@ def test_patchembed():
         input_size=input_size)
 
     x3, shape = patch_merge_3(dummy_input)
+    # test out shape
     assert x3.shape == (2, 1, 10)
+    # test outsize is correct
     assert shape == (1, 1)
+    # test L = out_h * out_w
     assert shape[0] * shape[1] == x3.shape[1]
+
+    # test thte init_out_size with nn.Unfold
     assert patch_merge_3.init_out_size[1] == (input_size[0] - 2 * 4 -
                                               1) // 2 + 1
     assert patch_merge_3.init_out_size[0] == (input_size[0] - 2 * 4 -
                                               1) // 2 + 1
+    H = 11
+    W = 12
+    input_size = (H, W)
+    dummy_input = torch.rand(B, C, H, W)
+    # test stride and norm
+    patch_merge_3 = PatchEmbed(
+        in_channels=C,
+        embed_dims=embed_dims,
+        conv_type=None,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=0,
+        dilation=2,
+        norm_cfg=dict(type='LN'),
+        input_size=input_size)
+
+    _, shape = patch_merge_3(dummy_input)
+    # when input_size equal to real input
+    # the out_size shoule be equal to `init_out_size`
+    assert shape == patch_merge_3.init_out_size
 
 
 def test_patch_merging():

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -113,13 +113,11 @@ def test_patch_embed():
     patch_merge_1 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
-        conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
         padding=0,
         dilation=1,
-        norm_cfg=None,
-    )
+        norm_cfg=None)
 
     x1, shape = patch_merge_1(dummy_input)
     # test out shape
@@ -141,7 +139,6 @@ def test_patch_embed():
     patch_merge_2 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
-        conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
         padding=0,
@@ -165,7 +162,6 @@ def test_patch_embed():
     patch_merge_3 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
-        conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
         padding=0,
@@ -194,7 +190,6 @@ def test_patch_embed():
     patch_merge_3 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
-        conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
         padding=0,
@@ -213,7 +208,6 @@ def test_patch_embed():
     patch_merge_3 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
-        conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
         padding=0,

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -1,10 +1,75 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import pytest
+import torch
 from mmcv.utils import ConfigDict
 
 from mmdet.models.utils.transformer import (DetrTransformerDecoder,
-                                            DetrTransformerEncoder,
+                                            DetrTransformerEncoder, PatchEmbed,
                                             Transformer)
+
+
+def test_patchembed():
+    B = 2
+    H = 3
+    W = 4
+    C = 3
+    embed_dims = 10
+    kernel_size = 3
+    stride = 1
+    dummy_input = torch.rand(B, C, H, W)
+    patch_merge_1 = PatchEmbed(
+        in_channels=C,
+        embed_dims=embed_dims,
+        conv_type=None,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=0,
+        dilation=1,
+        pad_to_patch_size=True,
+        norm_cfg=None,
+    )
+
+    x1 = patch_merge_1(dummy_input)
+    assert x1.shape == (2, 4, 10)
+
+    B = 2
+    H = 5
+    W = 6
+    C = 3
+    embed_dims = 10
+    kernel_size = 3
+    stride = 1
+    dummy_input = torch.rand(B, C, H, W)
+    # test dilation
+    patch_merge_2 = PatchEmbed(
+        in_channels=C,
+        embed_dims=embed_dims,
+        conv_type=None,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=0,
+        dilation=2,
+        pad_to_patch_size=True,
+        norm_cfg=None,
+    )
+
+    patch_merge_2(dummy_input)
+
+    stride = 2
+    dummy_input = torch.rand(B, C, H, W)
+    # test stride and norm
+    patch_merge_2 = PatchEmbed(
+        in_channels=C,
+        embed_dims=embed_dims,
+        conv_type=None,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=0,
+        dilation=2,
+        pad_to_patch_size=True,
+        norm_cfg=dict(type='LN'))
+
+    patch_merge_2(dummy_input)
 
 
 def test_detr_transformer_dencoder_encoder_layer():

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -20,6 +20,7 @@ def test_patch_embed():
     patch_merge_1 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
+        pad_to_stride=False,
         conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
@@ -48,6 +49,7 @@ def test_patch_embed():
     patch_merge_2 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
+        pad_to_stride=False,
         conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
@@ -72,6 +74,7 @@ def test_patch_embed():
     patch_merge_3 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
+        pad_to_stride=False,
         conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
@@ -101,6 +104,7 @@ def test_patch_embed():
     patch_merge_3 = PatchEmbed(
         in_channels=C,
         embed_dims=embed_dims,
+        pad_to_stride=False,
         conv_type=None,
         kernel_size=kernel_size,
         stride=stride,
@@ -127,6 +131,7 @@ def test_patch_merging():
     patch_merge = PatchMerging(
         in_channels=in_c,
         out_channels=out_c,
+        pad_to_stride=False,
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,
@@ -152,6 +157,7 @@ def test_patch_merging():
     patch_merge = PatchMerging(
         in_channels=in_c,
         out_channels=out_c,
+        pad_to_stride=False,
         kernel_size=kernel_size,
         stride=stride,
         padding=padding,

--- a/tests/test_models/test_utils/test_transformer.py
+++ b/tests/test_models/test_utils/test_transformer.py
@@ -25,20 +25,19 @@ def test_patchembed():
         stride=stride,
         padding=0,
         dilation=1,
-        pad_to_patch_size=True,
         norm_cfg=None,
     )
 
     x1 = patch_merge_1(dummy_input)
-    assert x1.shape == (2, 4, 10)
+    assert x1.shape == (2, 2, 10)
 
     B = 2
-    H = 5
-    W = 6
+    H = 10
+    W = 10
     C = 3
     embed_dims = 10
-    kernel_size = 3
-    stride = 1
+    kernel_size = 5
+    stride = 2
     dummy_input = torch.rand(B, C, H, W)
     # test dilation
     patch_merge_2 = PatchEmbed(
@@ -49,7 +48,6 @@ def test_patchembed():
         stride=stride,
         padding=0,
         dilation=2,
-        pad_to_patch_size=True,
         norm_cfg=None,
     )
 
@@ -66,7 +64,6 @@ def test_patchembed():
         stride=stride,
         padding=0,
         dilation=2,
-        pad_to_patch_size=True,
         norm_cfg=dict(type='LN'))
 
     patch_merge_2(dummy_input)


### PR DESCRIPTION
## Motivation

`PatchEmbed` and `PatchMerging` are basic modules that would be used in many transformer methods, such as PVT and Swin
At the same time, `AdaptivePadding` is an essential feature to deal with the dynamic shape in detection. 

## Modification

- Add `AdaptivePadding` to avoid lost pixel of input when doing the patchembed or patchmerge. 
- Add`PatchEmbed` and `PatchMerging`  to `/mmdet/models/utils/transformer.py` and add the corresponding unitests.
- Always apply adaptive padding first before doing the `PatchEmbed` and `PatchMerging` to deal with the dynamic shape in detection.

## BC-breaking (Optional)
None

