### PR TITLE
YOLACT supports val workflow

### DIFF
--- a/mmdet/models/dense_heads/yolact_head.py
+++ b/mmdet/models/dense_heads/yolact_head.py
@@ -694,10 +694,10 @@ class YOLACTProtonet(BaseModule):
         # val workflow will have a dimension mismatch error.
         # Note that this writing method is very tricky.
         # Fix https://github.com/open-mmlab/mmdetection/issues/5978
-        is_training = (coeff_pred[0].dim() == 4)
+        is_train_or_val_workflow = (coeff_pred[0].dim() == 4)
 
-        # Training state
-        if is_training:
+        # Train or val workflow
+        if is_train_or_val_workflow:
             coeff_pred_list = []
             for coeff_pred_per_level in coeff_pred:
                 coeff_pred_per_level = \
@@ -714,7 +714,7 @@ class YOLACTProtonet(BaseModule):
             cur_img_meta = img_meta[idx]
 
             # Testing state
-            if not is_training:
+            if not is_train_or_val_workflow:
                 bboxes_for_cropping = cur_bboxes
             else:
                 cur_sampling_results = sampling_results[idx]

--- a/mmdet/models/dense_heads/yolact_head.py
+++ b/mmdet/models/dense_heads/yolact_head.py
@@ -689,8 +689,15 @@ class YOLACTProtonet(BaseModule):
         prototypes = prototypes.permute(0, 2, 3, 1).contiguous()
 
         num_imgs = x.size(0)
+
+        # The reason for not using self.is_training is that
+        # val workflow will have a dimension mismatch error.
+        # Note that this writing method is very tricky.
+        # Fix https://github.com/open-mmlab/mmdetection/issues/5978
+        is_training = (coeff_pred[0].dim() == 4)
+
         # Training state
-        if self.training:
+        if is_training:
             coeff_pred_list = []
             for coeff_pred_per_level in coeff_pred:
                 coeff_pred_per_level = \
@@ -707,7 +714,7 @@ class YOLACTProtonet(BaseModule):
             cur_img_meta = img_meta[idx]
 
             # Testing state
-            if not self.training:
+            if not is_training:
                 bboxes_for_cropping = cur_bboxes
             else:
                 cur_sampling_results = sampling_results[idx]

--- a/mmdet/models/dense_heads/yolact_head.py
+++ b/mmdet/models/dense_heads/yolact_head.py
@@ -690,7 +690,7 @@ class YOLACTProtonet(BaseModule):
 
         num_imgs = x.size(0)
 
-        # The reason for not using self.is_training is that
+        # The reason for not using self.training is that
         # val workflow will have a dimension mismatch error.
         # Note that this writing method is very tricky.
         # Fix https://github.com/open-mmlab/mmdetection/issues/5978


### PR DESCRIPTION
## Motivation

When `workflow = [('train',1),('val',1)]` is set, YOLACT will report an error.

Resolve:  https://github.com/open-mmlab/mmdetection/issues/5978
Resolve: https://github.com/open-mmlab/mmdetection/issues/5362