### PR TITLE
Fix scores not contiguous in centernet_head.

### DIFF
--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -368,7 +368,7 @@ class CenterNetHead(BaseDenseHead, BBoxTestMixin):
         if labels.numel() == 0:
             return bboxes, labels
 
-        out_bboxes, keep = batched_nms(bboxes[:, :4], bboxes[:, -1], labels,
+        out_bboxes, keep = batched_nms(bboxes[:, :4], bboxes[:, -1].contiguous(), labels,
                                        cfg.nms_cfg)
         out_labels = labels[keep]
 

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -8,10 +8,10 @@ from mmcv.runner import force_fp32
 from mmdet.core import multi_apply
 from mmdet.models import HEADS, build_loss
 from mmdet.models.utils import gaussian_radius, gen_gaussian_target
-from .base_dense_head import BaseDenseHead
-from .dense_test_mixins import BBoxTestMixin
 from ..utils.gaussian_target import (get_local_maximum, get_topk_from_heatmap,
                                      transpose_and_gather_feat)
+from .base_dense_head import BaseDenseHead
+from .dense_test_mixins import BBoxTestMixin
 
 
 @HEADS.register_module()

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -368,7 +368,9 @@ class CenterNetHead(BaseDenseHead, BBoxTestMixin):
         if labels.numel() == 0:
             return bboxes, labels
 
-        out_bboxes, keep = batched_nms(bboxes[:, :4], bboxes[:, -1].contiguous(), labels,
+        out_bboxes, keep = batched_nms(bboxes[:, :4].contiguous(), 
+                                       bboxes[:, -1].contiguous(), 
+                                       labels,
                                        cfg.nms_cfg)
         out_labels = labels[keep]
 

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -369,8 +369,7 @@ class CenterNetHead(BaseDenseHead, BBoxTestMixin):
             return bboxes, labels
 
         out_bboxes, keep = batched_nms(bboxes[:, :4].contiguous(),
-                                       bboxes[:, -1].contiguous(),
-                                       labels,
+                                       bboxes[:, -1].contiguous(), labels,
                                        cfg.nms_cfg)
         out_labels = labels[keep]
 

--- a/mmdet/models/dense_heads/centernet_head.py
+++ b/mmdet/models/dense_heads/centernet_head.py
@@ -8,10 +8,10 @@ from mmcv.runner import force_fp32
 from mmdet.core import multi_apply
 from mmdet.models import HEADS, build_loss
 from mmdet.models.utils import gaussian_radius, gen_gaussian_target
-from ..utils.gaussian_target import (get_local_maximum, get_topk_from_heatmap,
-                                     transpose_and_gather_feat)
 from .base_dense_head import BaseDenseHead
 from .dense_test_mixins import BBoxTestMixin
+from ..utils.gaussian_target import (get_local_maximum, get_topk_from_heatmap,
+                                     transpose_and_gather_feat)
 
 
 @HEADS.register_module()
@@ -368,8 +368,8 @@ class CenterNetHead(BaseDenseHead, BBoxTestMixin):
         if labels.numel() == 0:
             return bboxes, labels
 
-        out_bboxes, keep = batched_nms(bboxes[:, :4].contiguous(), 
-                                       bboxes[:, -1].contiguous(), 
+        out_bboxes, keep = batched_nms(bboxes[:, :4].contiguous(),
+                                       bboxes[:, -1].contiguous(),
                                        labels,
                                        cfg.nms_cfg)
         out_labels = labels[keep]


### PR DESCRIPTION
## Motivation

Fix scores not contiguous in centernet_head.

## Reproduction

Add nms_cfg in model to enable nms:

```py
model = dict(
    type='CenterNet',
    ...
    test_cfg=dict(
        topk=1000, local_maximum_kernel=1, max_per_img=1000,
        nms_cfg=dict(iou_threshold=0.01)))
```

Then run: `result = inference_detector(model, image_path)`

## Environment

```
sys.platform: linux
Python: 3.8.5 (default, Sep  4 2020, 07:30:14) [GCC 7.3.0]
CUDA available: True
GPU 0,1,2,3,4,5,6,7: NVIDIA GeForce RTX 3090
CUDA_HOME: /usr/local/cuda
NVCC: Build cuda_11.1.TC455_06.29190527_0
GCC: gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
PyTorch: 1.9.0+cu111
PyTorch compiling details: PyTorch built with:
  - GCC 7.3
  - C++ Version: 201402
  - Intel(R) Math Kernel Library Version 2020.0.0 Product Build 20191122 for Intel(R) 64 architecture applications
  - Intel(R) MKL-DNN v2.1.2 (Git Hash 98be7e8afa711dc9b66c8ff3504129cb82013cdb)
  - OpenMP 201511 (a.k.a. OpenMP 4.5)
  - NNPACK is enabled
  - CPU capability usage: AVX2
  - CUDA Runtime 11.1
  - NVCC architecture flags: -gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_60,code=sm_60;-gencode;arch=compute_70,code=sm_70;-gencode;arch=compute_75,code=sm_75;-gencode;arch=compute_80,code=sm_80;-gencode;arch=compute_86,code=sm_86
  - CuDNN 8.0.5
  - Magma 2.5.2
  - Build settings: BLAS_INFO=mkl, BUILD_TYPE=Release, CUDA_VERSION=11.1, CUDNN_VERSION=8.0.5, CXX_COMPILER=/opt/rh/devtoolset-7/root/usr/bin/c++, CXX_FLAGS= -Wno-deprecated -fvisibility-inlines-hidden -DUSE_PTHREADPOOL -fopenmp -DNDEBUG -DUSE_KINETO -DUSE_FBGEMM -DUSE_QNNPACK -DUSE_PYTORCH_QNNPACK -DUSE_XNNPACK -DSYMBOLICATE_MOBILE_DEBUG_HANDLE -O2 -fPIC -Wno-narrowing -Wall -Wextra -Werror=return-type -Wno-missing-field-initializers -Wno-type-limits -Wno-array-bounds -Wno-unknown-pragmas -Wno-sign-compare -Wno-unused-parameter -Wno-unused-variable -Wno-unused-function -Wno-unused-result -Wno-unused-local-typedefs -Wno-strict-overflow -Wno-strict-aliasing -Wno-error=deprecated-declarations -Wno-stringop-overflow -Wno-psabi -Wno-error=pedantic -Wno-error=redundant-decls -Wno-error=old-style-cast -fdiagnostics-color=always -faligned-new -Wno-unused-but-set-variable -Wno-maybe-uninitialized -fno-math-errno -fno-trapping-math -Werror=format -Wno-stringop-overflow, LAPACK_INFO=mkl, PERF_WITH_AVX=1, PERF_WITH_AVX2=1, PERF_WITH_AVX512=1, TORCH_VERSION=1.9.0, USE_CUDA=ON, USE_CUDNN=ON, USE_EXCEPTION_PTR=1, USE_GFLAGS=OFF, USE_GLOG=OFF, USE_MKL=ON, USE_MKLDNN=ON, USE_MPI=OFF, USE_NCCL=ON, USE_NNPACK=ON, USE_OPENMP=ON,

TorchVision: 0.10.0+cu111
OpenCV: 4.5.2
MMCV: 1.3.12
MMCV Compiler: GCC 7.3
MMCV CUDA Compiler: 11.1
MMDetection: 2.16.0+
```

## Error traceback

```
Traceback (most recent call last):
  File "predict_test.py", line 82, in <module>
    result = inference_detector(model, image_path)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/apis/inference.py", line 148, in inference_detector
    results = model(return_loss=False, rescale=True, **data)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1051, in _call_impl
    return forward_call(*input, **kwargs)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmcv/runner/fp16_utils.py", line 98, in new_func
    return old_func(*args, **kwargs)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/models/detectors/base.py", line 174, in forward
    return self.forward_test(img, img_metas, **kwargs)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/models/detectors/base.py", line 154, in forward_test
    return self.aug_test(imgs, img_metas, **kwargs)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/models/detectors/centernet.py", line 106, in aug_test
    bbox_list = [self.merge_aug_results(aug_results, with_nms)]
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/models/detectors/centernet.py", line 47, in merge_aug_results
    out_bboxes, out_labels = self.bbox_head._bboxes_nms(
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmdet/models/dense_heads/centernet_head.py", line 371, in _bboxes_nms
    out_bboxes, keep = batched_nms(bboxes[:, :4], bboxes[:, -1], labels, #.contiguous(), labels,
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmcv/ops/nms.py", line 307, in batched_nms
    dets, keep = nms_op(boxes_for_nms, scores, **nms_cfg_)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmcv/utils/misc.py", line 330, in new_func
    output = old_func(*args, **kwargs)
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmcv/ops/nms.py", line 171, in nms
    inds = NMSop.apply(boxes, scores, iou_threshold, offset,
  File "/home/ypw/miniconda3/lib/python3.8/site-packages/mmcv/ops/nms.py", line 26, in forward
    inds = ext_module.nms(
RuntimeError: scores must be contiguous
```

## Modification

Added `.contiguous()` after split bboxes:

https://github.com/open-mmlab/mmdetection/blob/e876171cdf6cf09cb45fb7e62051365e35fca167/mmdet/models/dense_heads/centernet_head.py#L371

```py
        out_bboxes, keep = batched_nms(bboxes[:, :4], bboxes[:, -1].contiguous(), labels,
                                       cfg.nms_cfg)
```
