### PR TITLE
[Tools] Add swin convert weight scripts

### DIFF
--- a/docs/useful_tools.md
+++ b/docs/useful_tools.md
@@ -315,6 +315,14 @@ python tools/model_converters/upgrade_model_version.py ${IN_FILE} ${OUT_FILE} [-
 python tools/model_converters/regnet2mmdet.py ${SRC} ${DST} [-h]
 ```
 
+### Swin Transformer model to MMDetection
+
+ `tools/model_converters/swim2mmdet.py` convert keys in official pretrained Swin models to MMDetection style.
+
+```shell
+python tools/model_converters/swim2mmdet.py ${SRC} ${DST} [-h]
+```
+
 ### Detectron ResNet to Pytorch
 
 `tools/model_converters/detectron2pytorch.py` converts keys in the original detectron pretrained

--- a/tools/model_converters/swim2mmdet.py
+++ b/tools/model_converters/swim2mmdet.py
@@ -1,0 +1,91 @@
+import argparse
+from collections import OrderedDict
+
+import torch
+
+
+def convert_swin(ckpt):
+    new_ckpt = OrderedDict()
+
+    def correct_unfold_reduction_order(x):
+        out_channel, in_channel = x.shape
+        x = x.reshape(out_channel, 4, in_channel // 4)
+        x = x[:, [0, 2, 1, 3], :].transpose(1,
+                                            2).reshape(out_channel, in_channel)
+        return x
+
+    def correct_unfold_norm_order(x):
+        in_channel = x.shape[0]
+        x = x.reshape(4, in_channel // 4)
+        x = x[[0, 2, 1, 3], :].transpose(0, 1).reshape(in_channel)
+        return x
+
+    for k, v in ckpt.items():
+        if k.startswith('backbone.head'):
+            continue
+        elif k.startswith('backbone.layers'):
+            new_v = v
+            if 'attn.' in k:
+                new_k = k.replace('attn.', 'attn.w_msa.')
+            elif 'mlp.' in k:
+                if 'mlp.fc1.' in k:
+                    new_k = k.replace('mlp.fc1.', 'ffn.layers.0.0.')
+                elif 'mlp.fc2.' in k:
+                    new_k = k.replace('mlp.fc2.', 'ffn.layers.1.')
+                else:
+                    new_k = k.replace('mlp.', 'ffn.')
+            elif 'downsample' in k:
+                new_k = k
+                if 'reduction.' in k:
+                    new_v = correct_unfold_reduction_order(v)
+                elif 'norm.' in k:
+                    new_v = correct_unfold_norm_order(v)
+            else:
+                new_k = k
+            new_k = new_k.replace('layers', 'stages', 1)
+        elif k.startswith('backbone.patch_embed'):
+            new_v = v
+            if 'proj' in k:
+                new_k = k.replace('proj', 'projection')
+            else:
+                new_k = k
+        else:
+            new_v = v
+            new_k = k
+
+        new_ckpt[new_k] = new_v
+
+    return new_ckpt
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert keys in official pretrained swin models to'
+        'MMDetection style.')
+    parser.add_argument('src', help='src detection model path')
+    # The dst path must be a full path of the new checkpoint.
+    parser.add_argument('dst', help='save path')
+    args = parser.parse_args()
+
+    checkpoint = torch.load(args.src, map_location='cpu')
+    if 'state_dict' in checkpoint:
+        state_dict = checkpoint['state_dict']
+    elif 'model' in checkpoint:
+        state_dict = checkpoint['model']
+    else:
+        state_dict = checkpoint
+
+    weight = convert_swin(state_dict)
+
+    if 'state_dict' in checkpoint:
+        checkpoint['state_dict'] = weight
+    elif 'model' in checkpoint:
+        checkpoint['model'] = weight
+    else:
+        checkpoint = weight
+    with open(args.dst, 'wb') as f:
+        torch.save(checkpoint, f)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Motivation

Support load the model from origin https://github.com/SwinTransformer/Swin-Transformer-Object-Detection
https://github.com/SwinTransformer/storage/releases/download/v1.0.2/mask_rcnn_swin_tiny_patch4_window7.pth
by mask_rcnn_swin-t-p4-w7_fpn_ms-crop-3x_coco.py

## Modification

Added `tools/model_converters/swim2mmdet.py` reference by https://github.com/open-mmlab/mmsegmentation/pull/783

## BC-breaking (Optional)

No

## Use cases (Optional)

```shell
python ./tools/model_converters/swim2mmdet.py checkpoints/mask_rcnn_swin_tiny_patch4_window7.pth checkpoints/mask_rcnn_swin-t-p4-w7_fpn_fp16_ms-crop-3x_coco.pth
```
