### PR TITLE
Fix missing '**kwargs' parameters passing to imshow_bboxes()

### DIFF
--- a/mmdet/models/detectors/rpn.py
+++ b/mmdet/models/detectors/rpn.py
@@ -152,4 +152,4 @@ class RPN(BaseDetector):
         Returns:
             np.ndarray: The image with bboxes drawn on it.
         """
-        mmcv.imshow_bboxes(data, result, top_k=top_k)
+        mmcv.imshow_bboxes(data, result, top_k=top_k, **kwargs)


### PR DESCRIPTION
'**kwargs' parameters haven't passed to mmcv.imshow_bboxes() in show_result() of mmdetection/mmdet/models/detectors/rpn.py
close #6033 