### PR TITLE
[Fix] Add size divisor in get flops to avoid some potential bug

### DIFF
--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 
+import numpy as np
 import torch
 from mmcv import Config, DictAction
 
@@ -31,6 +32,12 @@ def parse_args():
         'It also allows nested list/tuple values, e.g. key="[(a,b),(c,d)]" '
         'Note that the quotation marks are necessary and that no white space '
         'is allowed.')
+    parser.add_argument(
+        '--size-divisor',
+        type=int,
+        default=32,
+        help='Pad the input image, the minimum size that is divisible '
+        'by size_divisor, -1 means do not pad the image.')
     args = parser.parse_args()
     return args
 
@@ -40,11 +47,18 @@ def main():
     args = parse_args()
 
     if len(args.shape) == 1:
-        input_shape = (3, args.shape[0], args.shape[0])
+        h = w = args.shape[0]
     elif len(args.shape) == 2:
-        input_shape = (3, ) + tuple(args.shape)
+        h, w = args.shape
     else:
         raise ValueError('invalid input shape')
+    orig_shape = (3, h, w)
+    divisor = args.size_divisor
+    if divisor > 0:
+        h = int(np.ceil(h / divisor)) * divisor
+        w = int(np.ceil(w / divisor)) * divisor
+
+    input_shape = (3, h, w)
 
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
@@ -71,6 +85,11 @@ def main():
 
     flops, params = get_model_complexity_info(model, input_shape)
     split_line = '=' * 30
+
+    if divisor > 0 and \
+            input_shape != orig_shape:
+        print(f'{split_line}\nUse size divisor set input shape '
+              f'from {orig_shape} to {input_shape}\n')
     print(f'{split_line}\nInput shape: {input_shape}\n'
           f'Flops: {flops}\nParams: {params}\n{split_line}')
     print('!!!Please be cautious if you use the results in papers. '


### PR DESCRIPTION
Add a parameter named `size_divisor`, which will pad the input image can divisible by size_divisor, -1 means do not use size divisor to padding the input image. 

Can avoid some potential bugs such as in HRNet:
The size of input `h = 201`, using 2x downsample and get `h_down = 100`. Then using 2x upsample and get `h_up = 200`. 
**`h_up` cannot match `h`**.

Relate Issue:
#4536