### PR TITLE
Implementation of YOLACT forward_dummy to enable get_flops

### DIFF
--- a/mmdet/models/detectors/yolact.py
+++ b/mmdet/models/detectors/yolact.py
@@ -30,15 +30,18 @@ class YOLACT(SingleStageDetector):
 
         See `mmdetection/tools/analysis_tools/get_flops.py`
         """
-        img_metas = [{'img_shape': (300, 300), 'ori_shape': (300, 300), 'scale_factor': (1, 1)} for _ in range(len(img))]
+        ## img_metas do not influence the flops calculation
+        dummy_img_metas = [
+            dict(img_shape=(300, 300), ori_shape=(300, 300), scale_factor=(1, 1)) for _ in range(len(img))
+        ]
         rescale = False
         feat = self.extract_feat(img)
         det_bboxes, det_labels, det_coeffs = self.bbox_head.simple_test(
-            feat, img_metas, rescale=rescale)
+            feat, dummy_img_metas, rescale=rescale)
         # det_bboxes will be empty for randomly generated images, generate non-empty bboxes so mask_head can be executed
-        det_bboxes = torch.rand((1, 2, 5)).cuda()
-        det_labels = torch.tensor([[0, 0]]).cuda()
-        det_coeffs = torch.rand((1, 2, 32)).cuda()
+        det_bboxes = torch.rand((1, 1, 5)).cuda()
+        det_labels = torch.tensor([[0]]).cuda()
+        det_coeffs = torch.rand((1, 1, 1)).cuda()
         bbox_results = [
             bbox2result(det_bbox, det_label, self.bbox_head.num_classes)
             for det_bbox, det_label in zip(det_bboxes, det_labels)
@@ -49,7 +52,7 @@ class YOLACT(SingleStageDetector):
             det_bboxes,
             det_labels,
             det_coeffs,
-            img_metas,
+            dummy_img_metas,
             rescale=rescale)
 
         return list(zip(bbox_results, segm_results))

--- a/mmdet/models/detectors/yolact.py
+++ b/mmdet/models/detectors/yolact.py
@@ -30,7 +30,30 @@ class YOLACT(SingleStageDetector):
 
         See `mmdetection/tools/analysis_tools/get_flops.py`
         """
-        raise NotImplementedError
+        img_metas = [{'img_shape': (300, 300), 'ori_shape': (300, 300), 'scale_factor': (1, 1)} for _ in range(len(img))]
+        rescale = False
+        feat = self.extract_feat(img)
+        det_bboxes, det_labels, det_coeffs = self.bbox_head.simple_test(
+            feat, img_metas, rescale=rescale)
+        # det_bboxes will be empty for randomly generated images, generate non-empty bboxes so mask_head can be executed
+        det_bboxes = torch.rand((1, 2, 5)).cuda()
+        det_labels = torch.tensor([[0, 0]]).cuda()
+        det_coeffs = torch.rand((1, 2, 32)).cuda()
+        bbox_results = [
+            bbox2result(det_bbox, det_label, self.bbox_head.num_classes)
+            for det_bbox, det_label in zip(det_bboxes, det_labels)
+        ]
+
+        segm_results = self.mask_head.simple_test(
+            feat,
+            det_bboxes,
+            det_labels,
+            det_coeffs,
+            img_metas,
+            rescale=rescale)
+
+        return list(zip(bbox_results, segm_results))
+
 
     def forward_train(self,
                       img,


### PR DESCRIPTION
## Motivation
To enable the `get_flops` feature on YOLACT, the `forward_dummy` needs to be implemented

## Modification
The `forward_dummy` function is implemented.

Closes #5891 