### PR TITLE
Change input order -- Fixing #6096

### DIFF
--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -71,8 +71,8 @@ def pytorch2onnx(model,
         dynamic_axes = {
             input_name: {
                 0: 'batch',
-                2: 'width',
-                3: 'height'
+                2: 'height',
+                3: 'width'
             },
             'dets': {
                 0: 'batch',


### PR DESCRIPTION
The input order should be bs x c x h x w

## Motivation

Fix #6096 Simple change to the names of the dynamic shapes in onnx

## Modification

The input order should be `bs x c x h x w` NOT `bs x c w x h`

