### PR TITLE
extra_repr for DropBlock layer

### DIFF
--- a/mmdet/models/plugins/dropblock.py
+++ b/mmdet/models/plugins/dropblock.py
@@ -79,3 +79,8 @@ class DropBlock(nn.Module):
         factor = (1.0 if self.iter_cnt > self.warmup_iters else self.iter_cnt /
                   self.warmup_iters)
         return gamma * factor
+
+    def extra_repr(self):
+        s = ('drop_prob={drop_prob}, block_size={block_size}, '
+             'warmup_iters={warmup_iters}')
+        return s.format(**self.__dict__)

--- a/mmdet/models/plugins/dropblock.py
+++ b/mmdet/models/plugins/dropblock.py
@@ -81,6 +81,5 @@ class DropBlock(nn.Module):
         return gamma * factor
 
     def extra_repr(self):
-        s = ('drop_prob={drop_prob}, block_size={block_size}, '
-             'warmup_iters={warmup_iters}')
-        return s.format(**self.__dict__)
+        return (f'drop_prob={self.drop_prob}, block_size={self.block_size}, '
+                f'warmup_iters={self.warmup_iters}')


### PR DESCRIPTION
## Motivation

Add `extra_repr` in DropBlock layer to get details in the model print.

```
print(model)

# before
(dropblock1): DropBlock()

# now
(dropblock1): DropBlock(drop_prob=0.1, block_size=7, warmup_iters=2000)
```

## Modification

Add `extra_repr` in DropBlock layer

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
