### PR TITLE
fix dynamic_shape bug of SyncRandomSizeHook

### DIFF
--- a/configs/yolox/yolox_s_8x8_300e_coco.py
+++ b/configs/yolox/yolox_s_8x8_300e_coco.py
@@ -129,7 +129,6 @@ custom_hooks = [
         type='SyncRandomSizeHook',
         ratio_range=(14, 26),
         img_scale=img_scale,
-        interval=interval,
         priority=48),
     dict(
         type='SyncNormHook',

--- a/configs/yolox/yolox_tiny_8x8_300e_coco.py
+++ b/configs/yolox/yolox_tiny_8x8_300e_coco.py
@@ -66,7 +66,6 @@ custom_hooks = [
         type='SyncRandomSizeHook',
         ratio_range=(10, 20),
         img_scale=img_scale,
-        interval=interval,
         priority=48),
     dict(
         type='SyncNormHook',

--- a/mmdet/core/hook/sync_random_size_hook.py
+++ b/mmdet/core/hook/sync_random_size_hook.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import random
+import warnings
 
 import torch
 from mmcv.runner import get_dist_info
@@ -17,7 +18,7 @@ class SyncRandomSizeHook(Hook):
             by 32, and then change the dataset output image size.
             Default: (14, 26).
         img_scale (tuple[int]): Size of input image. Default: (640, 640).
-        interval (int): The interval of change image size. Default: 10.
+        interval (int): The epoch interval of change image size. Default: 1.
         device (torch.device | str): device for returned tensors.
             Default: 'cuda'.
     """
@@ -25,8 +26,15 @@ class SyncRandomSizeHook(Hook):
     def __init__(self,
                  ratio_range=(14, 26),
                  img_scale=(640, 640),
-                 interval=10,
+                 interval=1,
                  device='cuda'):
+        warnings.warn('DeprecationWarning: SyncRandomSizeHook is deprecated. '
+                      'Please use Resize class to achieve similar functions. '
+                      'Due to the multi-process dataloader, its behavior is '
+                      'different from YOLOX\'s official implementation, '
+                      'the official is to change the size every fixed '
+                      'iteration interval and what we achieved is a fixed '
+                      'epoch interval.')
         self.rank, world_size = get_dist_info()
         self.is_distributed = world_size > 1
         self.ratio_range = ratio_range
@@ -34,9 +42,9 @@ class SyncRandomSizeHook(Hook):
         self.interval = interval
         self.device = device
 
-    def after_train_iter(self, runner):
+    def after_train_epoch(self, runner):
         """Change the dataset output image size."""
-        if self.ratio_range is not None and (runner.iter +
+        if self.ratio_range is not None and (runner.epoch +
                                              1) % self.interval == 0:
             # Due to DDP and DP get the device behavior inconsistent,
             # so we did not get the device from runner.model.

--- a/mmdet/core/hook/sync_random_size_hook.py
+++ b/mmdet/core/hook/sync_random_size_hook.py
@@ -10,8 +10,8 @@ from torch import distributed as dist
 
 @HOOKS.register_module()
 class SyncRandomSizeHook(Hook):
-    """Change and synchronize the random image size across ranks, currently
-    used in YOLOX. SyncRandomSizeHook is deprecated. Please use Resize pipeline
+    """Change and synchronize the random image size across ranks.
+    SyncRandomSizeHook is deprecated, please use Resize pipeline
     to achieve similar functions. Such as `dict(type='Resize', img_scale=[(448,
     448), (832, 832)], multiscale_mode='range', keep_ratio=True)`.
 

--- a/mmdet/core/hook/sync_random_size_hook.py
+++ b/mmdet/core/hook/sync_random_size_hook.py
@@ -11,7 +11,14 @@ from torch import distributed as dist
 @HOOKS.register_module()
 class SyncRandomSizeHook(Hook):
     """Change and synchronize the random image size across ranks, currently
-    used in YOLOX.
+    used in YOLOX. SyncRandomSizeHook is deprecated. Please use Resize pipeline
+    to achieve similar functions. Such as `dict(type='Resize', img_scale=[(448,
+    448), (832, 832)], multiscale_mode='range', keep_ratio=True)`.
+
+    Note: Due to the multi-process dataloader, its behavior is different
+    from YOLOX's official implementation, the official is to change the
+    size every fixed iteration interval and what we achieved is a fixed
+    epoch interval.
 
     Args:
         ratio_range (tuple[int]): Random ratio range. It will be multiplied
@@ -29,12 +36,12 @@ class SyncRandomSizeHook(Hook):
                  interval=1,
                  device='cuda'):
         warnings.warn('DeprecationWarning: SyncRandomSizeHook is deprecated. '
-                      'Please use Resize class to achieve similar functions. '
-                      'Due to the multi-process dataloader, its behavior is '
-                      'different from YOLOX\'s official implementation, '
-                      'the official is to change the size every fixed '
-                      'iteration interval and what we achieved is a fixed '
-                      'epoch interval.')
+                      'Please use Resize pipeline to achieve similar '
+                      'functions. Due to the multi-process dataloader, '
+                      'its behavior is different from YOLOX\'s official '
+                      'implementation, the official is to change the size '
+                      'every fixed iteration interval and what we achieved '
+                      'is a fixed epoch interval.')
         self.rank, world_size = get_dist_info()
         self.is_distributed = world_size > 1
         self.ratio_range = ratio_range

--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -368,8 +368,8 @@ class MultiImageMixDataset:
 
             if 'mix_results' in results:
                 results.pop('mix_results')
-            if 'img_scale' in results:
-                results.pop('img_scale')
+            if self._dynamic_scale is not None:
+                results.pop('scale')
 
         return results
 

--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -368,8 +368,6 @@ class MultiImageMixDataset:
 
             if 'mix_results' in results:
                 results.pop('mix_results')
-            if self._dynamic_scale is not None:
-                results.pop('scale')
 
         return results
 

--- a/tests/test_utils/test_hook.py
+++ b/tests/test_utils/test_hook.py
@@ -267,9 +267,17 @@ def test_sync_random_size_hook():
 
     loader = DataLoader(DemoDataset())
     runner = _build_demo_runner()
-    runner.register_hook_from_cfg(dict(type='SyncRandomSizeHook'))
+    runner.register_hook_from_cfg(
+        dict(type='SyncRandomSizeHook', device='cpu'))
     runner.run([loader, loader], [('train', 1), ('val', 1)])
     shutil.rmtree(runner.work_dir)
+
+    if torch.cuda.is_available():
+        runner = _build_demo_runner()
+        runner.register_hook_from_cfg(
+            dict(type='SyncRandomSizeHook', device='cuda'))
+        runner.run([loader, loader], [('train', 1), ('val', 1)])
+        shutil.rmtree(runner.work_dir)
 
 
 @pytest.mark.parametrize('set_loss', [

--- a/tests/test_utils/test_hook.py
+++ b/tests/test_utils/test_hook.py
@@ -12,7 +12,7 @@ import torch.nn as nn
 from mmcv.runner import (CheckpointHook, IterTimerHook, PaviLoggerHook,
                          build_runner)
 from torch.nn.init import constant_
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 from mmdet.core.hook import ExpMomentumEMAHook, YOLOXLrUpdaterHook
 from mmdet.core.hook.sync_norm_hook import SyncNormHook
@@ -254,7 +254,18 @@ def test_sync_random_size_hook():
     # Only used to prevent program errors
     SyncRandomSizeHook()
 
-    loader = DataLoader(torch.ones((5, 2)))
+    class DemoDataset(Dataset):
+
+        def __getitem__(self, item):
+            return torch.ones(2)
+
+        def __len__(self):
+            return 5
+
+        def update_dynamic_scale(self, dynamic_scale):
+            pass
+
+    loader = DataLoader(DemoDataset())
     runner = _build_demo_runner()
     runner.register_hook_from_cfg(dict(type='SyncRandomSizeHook'))
     runner.run([loader, loader], [('train', 1), ('val', 1)])


### PR DESCRIPTION
## Motivation

Fixed the dynamic shape bug of SyncRandomSizeHook following to https://github.com/open-mmlab/mmdetection/pull/5925. When dataloader is enabled for multiple processes, SyncRandomSizeHook cannot changing the size at a fixed iteration interval.


## Modification
Modified to change the size of every fixed epoch interval.

