### PR TITLE
Fix kwargs parameter missing error in two_stage

### DIFF
--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -138,7 +138,8 @@ class TwoStageDetector(BaseDetector):
                 gt_bboxes,
                 gt_labels=None,
                 gt_bboxes_ignore=gt_bboxes_ignore,
-                proposal_cfg=proposal_cfg)
+                proposal_cfg=proposal_cfg,
+                **kwargs)
             losses.update(rpn_losses)
         else:
             proposal_list = proposals

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -58,7 +58,8 @@ class StandardRoIHead(BaseRoIHead, BBoxTestMixin, MaskTestMixin):
                       gt_bboxes,
                       gt_labels,
                       gt_bboxes_ignore=None,
-                      gt_masks=None):
+                      gt_masks=None,
+                      **kwargs):
         """
         Args:
             x (list[Tensor]): list of multi-level img features.


### PR DESCRIPTION
Sorry to be a bother. As the previous PR is committed with the wrong user.name, which is unable to assign CLA correctly, this new PR is launched with the same changes.

## Motivation

Fix the bug which is described in #6242.

In addition, make the embedded data from the customized pipeline available in function "forward_train" of "./mmdet/models/dense_heads/base_dense_head.py".

## Modification

Only two lines:

Line 142 in "./mmdet/models/detectors/two_stage.py". Add ", **kwargs" in "self.rpn_head.forward_train(".
Line 62 in "./mmdet/models/roi_heads/standard_roi_head.py". Add ", **kwargs" in "def forward_train(".
