### PR TITLE
auto_augment: img_shape broken

### DIFF
--- a/mmdet/datasets/pipelines/auto_augment.py
+++ b/mmdet/datasets/pipelines/auto_augment.py
@@ -625,7 +625,6 @@ class Translate:
                 img, offset, direction, self.img_fill_val).astype(img.dtype)
             results['img_shape'] = results[key].shape
 
-
     def _translate_bboxes(self, results, offset):
         """Shift bboxes horizontally or vertically, according to offset."""
         h, w, c = results['img_shape']


### PR DESCRIPTION
## Motivation

Rotate, Shear, and Translate classes change the shape of `results['img']` when applied to the image data, but do not update `results['img_shape']`. This happens in methods `_rotate_img()`, `_shear_img`, and `_translate_img`.

In consequence, methods like `_rotate_bboxes`, `_rotate_masks` get the wrong image shape from `results['img_shape']`.
The bboxes don't complain but pipeline raises a ValueError: "cannot reshape array of size 196249 into shape (358,358)" when applied to datasets with masks.

## Modification

I added a similar line of code as in `transforms.Resize._resize_img`:

`results['img_shape'] = results[key].shape`

where `key` would default to `img`.

## BC-breaking (Optional)

None (unless inconsistent shapes where somehow intended).

## Use cases (Optional)

train MRCNNs with Resize, Shear, Translate from auto_augment.py
