### PR TITLE
[Fix] Fix a bug for loading swin weight

### DIFF
--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -700,8 +700,11 @@ class SwinTransformer(BaseModule):
 
             state_dict = OrderedDict()
             for k, v in _state_dict.items():
+                # support trained weight from object detection
                 if k.startswith('backbone.'):
                     state_dict[k[9:]] = v
+                else:
+                    state_dict[k] = v
 
             # strip prefix of state_dict
             if list(state_dict.keys())[0].startswith('module.'):


### PR DESCRIPTION
## Motivation

Current code cannot initialize a swin-transformer backbone weight properly if it is from original repo.
ex) https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_tiny_patch4_window7_224.pth

It is due to [this line](https://github.com/open-mmlab/mmdetection/blob/1a90fa80a761fe15e69111a625d82874ed783f7b/mmdet/models/backbones/swin.py#L703).
If **_state_dict** does not have 'backbone' keys,
**state_dict**, which is an empty OrderedDict, goes on to next lines.

## Modification

I added a condition which accepts weights without 'backbone' keys.

