### PR TITLE
[BUG]fix init of convfc head

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/convfc_bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/convfc_bbox_head.py
@@ -97,10 +97,16 @@ class ConvFCBBoxHead(BBoxHead):
                 out_features=out_dim_reg)
 
         if init_cfg is None:
+            # when init_cfg is None,
+            # It has been set to
+            # [[dict(type='Normal', std=0.01, override=dict(name='fc_cls'))],
+            #  [dict(type='Normal', std=0.001, override=dict(name='fc_reg'))]
+            # after `super(ConvFCBBoxHead, self).__init__()`
+            # we only need to append additional configuration
+            # for `shared_fcs`, `cls_fcs` and `reg_fcs`
             self.init_cfg += [
                 dict(
                     type='Xavier',
-                    layer='Linear',
                     override=[
                         dict(name='shared_fcs'),
                         dict(name='cls_fcs'),


### PR DESCRIPTION
# Motivation
https://github.com/open-mmlab/mmdetection/blob/c88509cb9a73d6bd1edcba64eb924d3cf3cfe85d/mmdet/models/roi_heads/bbox_heads/convfc_bbox_head.py#L103

This line will override initializers for fc_cls and fc_reg because they are also `nn.Linear`. 
which is not consistent with the old way to initialize `fc_cls` and `fc_reg` before #4750.

Closes #6238 

# BC breaking
None