### PR TITLE
Fix the bug: 'Upsample' object has no attribute 'weight'

### DIFF
--- a/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
+++ b/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py
@@ -119,7 +119,7 @@ class FCNMaskHead(BaseModule):
                 continue
             elif isinstance(m, CARAFEPack):
                 m.init_weights()
-            else:
+            elif hasattr(m, 'weight') and hasattr(m, 'bias'):
                 nn.init.kaiming_normal_(
                     m.weight, mode='fan_out', nonlinearity='relu')
                 nn.init.constant_(m.bias, 0)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The `upsample_cfg` in the object `FCNMaskHead`  supports `bilinear`, however, in the `mmdetection/mmdet/models/roi_heads/mask_heads/fcn_mask_head.py`  L124, `torch.nn.Upsample` has no weight attribute. The goal of this PR is to fix this bug.

## Modification

L122`else:` --> `elif hasattr(m, 'weight') and hasattr(m, 'bias'):`

## BC-breaking (Optional)

No backward-compatibility was changed.

## Use cases (Optional)

No new feature was introduced.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
