### PR TITLE
Fix type error in imshow_bboxes of RPN

### DIFF
--- a/mmdet/models/detectors/rpn.py
+++ b/mmdet/models/detectors/rpn.py
@@ -153,10 +153,7 @@ class RPN(BaseDetector):
             np.ndarray: The image with bboxes drawn on it.
         """
         if kwargs is not None:
-            if 'score_thr' in kwargs:
-                kwargs.pop('score_thr')
-            if 'text_color' in kwargs:
-                kwargs.pop('text_color')
-            if 'bbox_color' in kwargs:
-                kwargs['colors'] = kwargs.pop('bbox_color')
+            kwargs.pop('score_thr', None)
+            kwargs.pop('text_color', None)
+            kwargs['colors'] = kwargs.pop('bbox_color', 'green')
         mmcv.imshow_bboxes(data, result, top_k=top_k, **kwargs)


### PR DESCRIPTION
## Motivation

The predicted value of RPN shows an error when running the demo script. The error message is `TypeError: imshow_bboxes() got an unexpected keyword argument 'score_thr'`

## Modification

Exclude inconsistent keys.


