### PR TITLE
Always map location to cpu when load checkpoint

### DIFF
--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -39,8 +39,7 @@ def init_detector(config, checkpoint=None, device='cuda:0', cfg_options=None):
     config.model.train_cfg = None
     model = build_detector(config.model, test_cfg=config.get('test_cfg'))
     if checkpoint is not None:
-        map_loc = 'cpu' if device == 'cpu' else None
-        checkpoint = load_checkpoint(model, checkpoint, map_location=map_loc)
+        checkpoint = load_checkpoint(model, checkpoint, map_location='cpu')
         if 'CLASSES' in checkpoint.get('meta', {}):
             model.CLASSES = checkpoint['meta']['CLASSES']
         else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In the multi-GPU environment, `init_detector()` may have potential memory leak or crash with a device error.

Assume we have a model whose weights was saved in `cuda:0` during training. And we want to load this model on a 2-GPU machine with the following code:

```python
from mmdet import apis

model = apis.init_detector(config, checkpoint, device='cuda:1')
```

See line 42, 43 in `mmdet/apis/inference.py`. `init_detector()` won't remap the location. So, the checkpoint will be loaded to `cuda:0` (The device where checkpoint was saved in during training). 

```python
41     if checkpoint is not None:
42         map_loc = 'cpu' if device == 'cpu' else None
43         checkpoint = load_checkpoint(model, checkpoint, map_location=map_loc)
```

And then, `init_detector()` transfer the weights to the device we specific (`cuda:1`).

```python
52     model.to(device)
```

After `init_detector()` done, we get a model located on `cuda:1`. But `cuda:0` still keep a copy of its weights. So, the gpu memory leak. 

In another case, if we have a model saved in `cuda:1` and we want to load it on a single-GPU machine, this may raise a runtime error because `cuda:1` doesn't exist.

I also traced the code of `init_segmentor()` in mmsegmentation. It always remaps checkpoints to cpu. So, this problem won't happen in mmsegmentation. I think modifying the behavior of `init_detector()` to make it work as `init_segmentor()` can resolve this issue.

## Modification

Always set `map_location` to cpu in `init_detector()` when initialize a model with a checkpoint.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
