### PR TITLE
[BugFixed] fix wrong trunc_normal_init use

### DIFF
--- a/mmdet/models/backbones/pvt.py
+++ b/mmdet/models/backbones/pvt.py
@@ -6,7 +6,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import (Conv2d, build_activation_layer, build_norm_layer,
-                      constant_init, normal_init, trunc_normal_init)
+                      constant_init, normal_init, trunc_normal_,
+                      trunc_normal_init)
 from mmcv.cnn.bricks.drop import build_dropout
 from mmcv.cnn.bricks.transformer import MultiheadAttention
 from mmcv.runner import (BaseModule, ModuleList, Sequential, _load_checkpoint,
@@ -275,7 +276,7 @@ class AbsolutePositionEmbedding(BaseModule):
         self.drop = nn.Dropout(p=drop_rate)
 
     def init_weights(self):
-        trunc_normal_init(self.pos_embed, std=0.02)
+        trunc_normal_(self.pos_embed, std=0.02)
 
     def resize_pos_embed(self, pos_embed, input_shape, mode='bilinear'):
         """Resize pos_embed weights.
@@ -486,9 +487,7 @@ class PyramidVisionTransformer(BaseModule):
                         f'training start from scratch')
             for m in self.modules():
                 if isinstance(m, nn.Linear):
-                    trunc_normal_init(m.weight, std=.02)
-                    if m.bias is not None:
-                        constant_init(m.bias, 0)
+                    trunc_normal_init(m, std=.02, bias=0.)
                 elif isinstance(m, nn.LayerNorm):
                     constant_init(m.bias, 0)
                     constant_init(m.weight, 1.0)

--- a/mmdet/models/backbones/pvt.py
+++ b/mmdet/models/backbones/pvt.py
@@ -6,10 +6,10 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from mmcv.cnn import (Conv2d, build_activation_layer, build_norm_layer,
-                      constant_init, normal_init, trunc_normal_,
-                      trunc_normal_init)
+                      constant_init, normal_init, trunc_normal_init)
 from mmcv.cnn.bricks.drop import build_dropout
 from mmcv.cnn.bricks.transformer import MultiheadAttention
+from mmcv.cnn.utils.weight_init import trunc_normal_
 from mmcv.runner import (BaseModule, ModuleList, Sequential, _load_checkpoint,
                          load_state_dict)
 from torch.nn.modules.utils import _pair as to_2tuple

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -6,7 +6,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as cp
-from mmcv.cnn import build_norm_layer, constant_init, trunc_normal_init
+from mmcv.cnn import (build_norm_layer, constant_init, trunc_normal_,
+                      trunc_normal_init)
 from mmcv.cnn.bricks.transformer import FFN, build_dropout
 from mmcv.runner import BaseModule, ModuleList, _load_checkpoint
 from mmcv.utils import to_2tuple
@@ -74,7 +75,7 @@ class WindowMSA(BaseModule):
         self.softmax = nn.Softmax(dim=-1)
 
     def init_weights(self):
-        trunc_normal_init(self.relative_position_bias_table, std=0.02)
+        trunc_normal_(self.relative_position_bias_table, std=0.02)
 
     def forward(self, x, mask=None):
         """
@@ -672,12 +673,10 @@ class SwinTransformer(BaseModule):
                         f'{self.__class__.__name__}, '
                         f'training start from scratch')
             if self.use_abs_pos_embed:
-                trunc_normal_init(self.absolute_pos_embed, std=0.02)
+                trunc_normal_(self.absolute_pos_embed, std=0.02)
             for m in self.modules():
                 if isinstance(m, nn.Linear):
-                    trunc_normal_init(m.weight, std=.02)
-                    if m.bias is not None:
-                        constant_init(m.bias, 0)
+                    trunc_normal_init(m, std=.02, bias=0.)
                 elif isinstance(m, nn.LayerNorm):
                     constant_init(m.bias, 0)
                     constant_init(m.weight, 1.0)

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -6,9 +6,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as cp
-from mmcv.cnn import (build_norm_layer, constant_init, trunc_normal_,
-                      trunc_normal_init)
+from mmcv.cnn import build_norm_layer, constant_init, trunc_normal_init
 from mmcv.cnn.bricks.transformer import FFN, build_dropout
+from mmcv.cnn.utils.weight_init import trunc_normal_
 from mmcv.runner import BaseModule, ModuleList, _load_checkpoint
 from mmcv.utils import to_2tuple
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Implementation of SwinTransformer and PVT use trunc_normal_init incorrectly which may decrease the performance when training from scratch.

## Modification

The use of trunc_normal_init of SwinTransformer and PVT

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
