### PR TITLE
[Enhance]: Optimize augmentation pipeline to speed up training.

### DIFF
--- a/configs/pascal_voc/ssd300_voc0712.py
+++ b/configs/pascal_voc/ssd300_voc0712.py
@@ -11,14 +11,8 @@ dataset_type = 'VOCDataset'
 data_root = 'data/VOCdevkit/'
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -29,8 +23,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(300, 300), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
 ]

--- a/configs/pascal_voc/ssd512_voc0712.py
+++ b/configs/pascal_voc/ssd512_voc0712.py
@@ -10,14 +10,8 @@ model = dict(
             ratios=([2], [2, 3], [2, 3], [2, 3], [2, 3], [2], [2]))))
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -28,8 +22,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(512, 512), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
 ]

--- a/configs/ssd/ssd300_coco.py
+++ b/configs/ssd/ssd300_coco.py
@@ -7,14 +7,8 @@ dataset_type = 'CocoDataset'
 data_root = 'data/coco/'
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -25,8 +19,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(300, 300), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
 ]

--- a/configs/ssd/ssd512_coco.py
+++ b/configs/ssd/ssd512_coco.py
@@ -20,14 +20,8 @@ dataset_type = 'CocoDataset'
 data_root = 'data/coco/'
 img_norm_cfg = dict(mean=[123.675, 116.28, 103.53], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -38,8 +32,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(512, 512), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
 ]

--- a/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
+++ b/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
@@ -70,14 +70,8 @@ data_root = 'data/coco/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -88,8 +82,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(320, 320), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=320),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),

--- a/configs/yolact/yolact_r50_1x8_coco.py
+++ b/configs/yolact/yolact_r50_1x8_coco.py
@@ -90,15 +90,9 @@ data_root = 'data/coco/'
 img_norm_cfg = dict(
     mean=[123.68, 116.78, 103.94], std=[58.40, 57.12, 57.38], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(type='FilterAnnotations', min_gt_bbox_wh=(4.0, 4.0)),
-    dict(
-        type='PhotoMetricDistortion',
-        brightness_delta=32,
-        contrast_range=(0.5, 1.5),
-        saturation_range=(0.5, 1.5),
-        hue_delta=18),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -109,8 +103,14 @@ train_pipeline = [
         min_ious=(0.1, 0.3, 0.5, 0.7, 0.9),
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(img_size, img_size), keep_ratio=False),
-    dict(type='Normalize', **img_norm_cfg),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(
+        type='PhotoMetricDistortion',
+        brightness_delta=32,
+        contrast_range=(0.5, 1.5),
+        saturation_range=(0.5, 1.5),
+        hue_delta=18),
+    dict(type='Normalize', **img_norm_cfg),
     dict(type='DefaultFormatBundle'),
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]

--- a/configs/yolo/yolov3_d53_320_273e_coco.py
+++ b/configs/yolo/yolov3_d53_320_273e_coco.py
@@ -2,9 +2,8 @@ _base_ = './yolov3_d53_mstrain-608_273e_coco.py'
 # dataset settings
 img_norm_cfg = dict(mean=[0, 0, 0], std=[255., 255., 255.], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(type='PhotoMetricDistortion'),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -16,6 +15,7 @@ train_pipeline = [
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(320, 320), keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='PhotoMetricDistortion'),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
     dict(type='DefaultFormatBundle'),

--- a/configs/yolo/yolov3_d53_mstrain-416_273e_coco.py
+++ b/configs/yolo/yolov3_d53_mstrain-416_273e_coco.py
@@ -2,9 +2,8 @@ _base_ = './yolov3_d53_mstrain-608_273e_coco.py'
 # dataset settings
 img_norm_cfg = dict(mean=[0, 0, 0], std=[255., 255., 255.], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(type='PhotoMetricDistortion'),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -16,6 +15,7 @@ train_pipeline = [
         min_crop_size=0.3),
     dict(type='Resize', img_scale=[(320, 320), (416, 416)], keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='PhotoMetricDistortion'),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
     dict(type='DefaultFormatBundle'),

--- a/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py
+++ b/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py
@@ -62,7 +62,6 @@ img_norm_cfg = dict(mean=[0, 0, 0], std=[255., 255., 255.], to_rgb=True)
 train_pipeline = [
     dict(type='LoadImageFromFile', to_float32=True),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(type='PhotoMetricDistortion'),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -74,6 +73,7 @@ train_pipeline = [
         min_crop_size=0.3),
     dict(type='Resize', img_scale=[(320, 320), (608, 608)], keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='PhotoMetricDistortion'),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
     dict(type='DefaultFormatBundle'),

--- a/configs/yolo/yolov3_mobilenetv2_320_300e_coco.py
+++ b/configs/yolo/yolov3_mobilenetv2_320_300e_coco.py
@@ -13,9 +13,8 @@ model = dict(
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(type='PhotoMetricDistortion'),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -27,6 +26,7 @@ train_pipeline = [
         min_crop_size=0.3),
     dict(type='Resize', img_scale=(320, 320), keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='PhotoMetricDistortion'),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
     dict(type='DefaultFormatBundle'),

--- a/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py
+++ b/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py
@@ -62,9 +62,8 @@ data_root = 'data/coco/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', to_float32=True),
+    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True),
-    dict(type='PhotoMetricDistortion'),
     dict(
         type='Expand',
         mean=img_norm_cfg['mean'],
@@ -80,6 +79,7 @@ train_pipeline = [
         multiscale_mode='range',
         keep_ratio=True),
     dict(type='RandomFlip', flip_ratio=0.5),
+    dict(type='PhotoMetricDistortion'),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='Pad', size_divisor=32),
     dict(type='DefaultFormatBundle'),

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -980,10 +980,7 @@ class PhotoMetricDistortion:
             assert results['img_fields'] == ['img'], \
                 'Only single img_fields is allowed'
         img = results['img']
-        assert img.dtype == np.float32, \
-            'PhotoMetricDistortion needs the input image of dtype ' \
-            'np.float32, please set "to_float32=True" in ' \
-            '"LoadImageFromFile" pipeline'
+        img = img.astype(np.float32)
         # random brightness
         if random.randint(2):
             delta = random.uniform(-self.brightness_delta,

--- a/tests/test_data/test_pipelines/test_transform/test_transform.py
+++ b/tests/test_data/test_pipelines/test_transform/test_transform.py
@@ -965,3 +965,30 @@ def test_mixup():
     assert results['gt_labels'].dtype == np.int64
     assert results['gt_bboxes'].dtype == np.float32
     assert results['gt_bboxes_ignore'].dtype == np.float32
+
+
+def test_photo_metric_distortion():
+    img = mmcv.imread(
+        osp.join(osp.dirname(__file__), '../../../data/color.jpg'), 'color')
+    transform = dict(type='PhotoMetricDistortion')
+    distortion_module = build_from_cfg(transform, PIPELINES)
+
+    # test assertion for invalid img_fields
+    with pytest.raises(AssertionError):
+        results = dict()
+        results['img'] = img
+        results['img2'] = img
+        results['img_fields'] = ['img', 'img2']
+        distortion_module(results)
+
+    # test uint8 input
+    results = dict()
+    results['img'] = img
+    results = distortion_module(results)
+    assert results['img'].dtype == np.float32
+
+    # test float32 input
+    results = dict()
+    results['img'] = img.astype(np.float32)
+    results = distortion_module(results)
+    assert results['img'].dtype == np.float32


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Speed up training and reduce memory cost when using PhotoMetricDistortion.

I benchmarked yolov3_mobilenetv2_mstrain-416_300e_coco

Training time before: 40h35m
Training time now: 32h39m

Speed up about 8 hours.

COCO metric before:
bbox_mAP: 0.2390, bbox_mAP_50: 0.4540, bbox_mAP_75: 0.2260, bbox_mAP_s: 0.1060, bbox_mAP_m: 0.2510, bbox_mAP_l: 0.3490
COCO metric now:
bbox_mAP: 0.2390, bbox_mAP_50: 0.4560, bbox_mAP_75: 0.2280, bbox_mAP_s: 0.0990, bbox_mAP_m: 0.2510, bbox_mAP_l: 0.3560

Almost no difference on mAP.

## Modification

1. Support uint8 input for PhotoMetricDistortion
2. Optimize data pipeline.
   a. Use uint8 in as many transforms as possible to reduce memory cost.
   b. Do PhotoMetricDistortion on smaller image size to reduce calculation.

## BC-breaking (Optional)

None

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
