### PR TITLE
Make OHEM work with seesaw loss

### DIFF
--- a/mmdet/core/bbox/samplers/ohem_sampler.py
+++ b/mmdet/core/bbox/samplers/ohem_sampler.py
@@ -19,6 +19,7 @@ class OHEMSampler(BaseSampler):
                  context,
                  neg_pos_ub=-1,
                  add_gt_as_proposals=True,
+                 loss_key='loss_cls',
                  **kwargs):
         super(OHEMSampler, self).__init__(num, pos_fraction, neg_pos_ub,
                                           add_gt_as_proposals)
@@ -27,6 +28,8 @@ class OHEMSampler(BaseSampler):
             self.bbox_head = self.context.bbox_head
         else:
             self.bbox_head = self.context.bbox_head[self.context.current_stage]
+
+        self.loss_key = loss_key
 
     def hard_mining(self, inds, num_expected, bboxes, labels, feats):
         with torch.no_grad():
@@ -45,7 +48,7 @@ class OHEMSampler(BaseSampler):
                 label_weights=cls_score.new_ones(cls_score.size(0)),
                 bbox_targets=None,
                 bbox_weights=None,
-                reduction_override='none')['loss_cls']
+                reduction_override='none')[self.loss_key]
             _, topk_loss_inds = loss.topk(num_expected)
         return inds[topk_loss_inds]
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Since seesaw loss's return_dict does not contain the key `loss_cls`, `OHEMSampler` does not work with seesaw loss.

## Modification

Make the key for return_dict to be controllable.

## BC-breaking (Optional)

By making default key for return_dict be `loss_cls`, users only need to change the key for return_dict for some specific losses like seesaw loss.

## Use cases (Optional)

Specify the key for loss's return_dict like below:

```python
# Using seesaw loss
sampler=dict(
    type='OHEMSampler',
    num=512,
    pos_fraction=0.25,
    neg_pos_ub=-1,
    add_gt_as_proposals=True,
    loss_key='loss_cls_objectness',
),
```

