### PR TITLE
update get_indexes in mixup

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2285,7 +2285,7 @@ class MixUp:
 
         for i in range(self.max_iters):
             index = random.randint(0, len(dataset))
-            gt_bboxes_i = dataset.get_ann_info(index)['bboxes']
+            gt_bboxes_i = dataset[index]['gt_bboxes']
             if len(gt_bboxes_i) != 0:
                 break
 


### PR DESCRIPTION
## Motivation

When the parameter dataset in MultiImageMixDataset is ConcatDataset/RepeatDataset/ClassBalancedDataset and mixup is added in the pipeline, the get_indexes in mixup will crash since there are no get_ann_info in ConcatDataset/RepeatDataset/ClassBalancedDataset. 

## Modification

change gt_bboxes_i = dataset.get_ann_info(index)['bboxes']
to gt_bboxes_i = dataset[index]['gt_bboxes']

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
