### PR TITLE
Add 'get_ann_info' to dataset_wrappers

### DIFF
--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -71,8 +71,6 @@ class ConcatDataset(_ConcatDataset):
     def get_ann_info(self, idx):
         """Get annotation of concatenated dataset by index.
 
-        This is needed by MixUp.
-
         Args:
             idx (int): Index of data.
 

--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -48,7 +48,7 @@ class ConcatDataset(_ConcatDataset):
 
     def get_cat_ids(self, idx):
         """Get category ids of concatenated dataset by index.
-
+        
         Args:
             idx (int): Index of data.
 
@@ -67,6 +67,30 @@ class ConcatDataset(_ConcatDataset):
         else:
             sample_idx = idx - self.cumulative_sizes[dataset_idx - 1]
         return self.datasets[dataset_idx].get_cat_ids(sample_idx)
+
+    def get_ann_info(self, idx):
+        """Get annotation of concatenated dataset by index.
+
+        This is needed by MixUp.
+
+        Args:
+            idx (int): Index of data.
+        
+        Returns:
+            dict: Annotation info of specified index.
+        """
+
+        if idx < 0:
+            if -idx > len(self):
+                raise ValueError(
+                    'absolute value of index should not exceed dataset length')
+            idx = len(self) + idx
+        dataset_idx = bisect.bisect_right(self.cumulative_sizes, idx)
+        if dataset_idx == 0:
+            sample_idx = idx
+        else:
+            sample_idx = idx - self.cumulative_sizes[dataset_idx - 1]
+        return self.datasets[dataset_idx].get_ann_info(sample_idx)
 
     def evaluate(self, results, logger=None, **kwargs):
         """Evaluate the results.
@@ -164,6 +188,18 @@ class RepeatDataset:
         """
 
         return self.dataset.get_cat_ids(idx % self._ori_len)
+
+    def get_ann_info(self, idx):
+        """Get annotation of repeat dataset by index.
+
+        Args:
+            idx (int): Index of data.
+
+        Returns:
+            dict: Annotation info of specified index.
+        """
+
+        return self.dataset.get_ann_info(idx % self._ori_len)
 
     def __len__(self):
         """Length after repetition."""
@@ -279,6 +315,18 @@ class ClassBalancedDataset:
     def __getitem__(self, idx):
         ori_index = self.repeat_indices[idx]
         return self.dataset[ori_index]
+
+    def get_ann_info(self, idx):
+        """Get annotation of dataset by index.
+
+        Args:
+            idx (int): Index of data.
+
+        Returns:
+            dict: Annotation info of specified index.
+        """
+        ori_index = self.repeat_indices[idx]
+        return self.dataset.get_ann_info(ori_index)
 
     def __len__(self):
         """Length after repetition."""

--- a/mmdet/datasets/dataset_wrappers.py
+++ b/mmdet/datasets/dataset_wrappers.py
@@ -48,7 +48,7 @@ class ConcatDataset(_ConcatDataset):
 
     def get_cat_ids(self, idx):
         """Get category ids of concatenated dataset by index.
-        
+
         Args:
             idx (int): Index of data.
 
@@ -75,7 +75,7 @@ class ConcatDataset(_ConcatDataset):
 
         Args:
             idx (int): Index of data.
-        
+
         Returns:
             dict: Annotation info of specified index.
         """

--- a/tests/test_data/test_datasets/test_dataset_wrapper.py
+++ b/tests/test_data/test_datasets/test_dataset_wrapper.py
@@ -20,10 +20,24 @@ def test_dataset_wrapper():
         np.random.randint(0, 80, num).tolist()
         for num in np.random.randint(1, 20, len_a)
     ]
+    ann_info_list_a = []
+    for _ in range(len_a):
+        height = np.random.randint(10, 30)
+        weight = np.random.randint(10, 30)
+        img = np.ones((height, weight, 3))
+        gt_bbox = np.concatenate([
+            np.random.randint(1, 5, (2, 2)),
+            np.random.randint(1, 5, (2, 2)) + 5
+        ],
+                                 axis=1)
+        gt_labels = np.random.randint(0, 80, 2)
+        ann_info_list_a.append(dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
     dataset_a.data_infos = MagicMock()
     dataset_a.data_infos.__len__.return_value = len_a
     dataset_a.get_cat_ids = MagicMock(
         side_effect=lambda idx: cat_ids_list_a[idx])
+    dataset_a.get_ann_info = MagicMock(
+        side_effect=lambda idx: ann_info_list_a[idx])
     dataset_b = CustomDataset(
         ann_file=MagicMock(), pipeline=[], test_mode=True, img_prefix='')
     len_b = 20
@@ -31,16 +45,32 @@ def test_dataset_wrapper():
         np.random.randint(0, 80, num).tolist()
         for num in np.random.randint(1, 20, len_b)
     ]
+    ann_info_list_b = []
+    for _ in range(len_b):
+        height = np.random.randint(10, 30)
+        weight = np.random.randint(10, 30)
+        img = np.ones((height, weight, 3))
+        gt_bbox = np.concatenate([
+            np.random.randint(1, 5, (2, 2)),
+            np.random.randint(1, 5, (2, 2)) + 5
+        ],
+                                 axis=1)
+        gt_labels = np.random.randint(0, 80, 2)
+        ann_info_list_b.append(dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
     dataset_b.data_infos = MagicMock()
     dataset_b.data_infos.__len__.return_value = len_b
     dataset_b.get_cat_ids = MagicMock(
         side_effect=lambda idx: cat_ids_list_b[idx])
+    dataset_b.get_ann_info = MagicMock(
+        side_effect=lambda idx: ann_info_list_b[idx])
 
     concat_dataset = ConcatDataset([dataset_a, dataset_b])
     assert concat_dataset[5] == 5
     assert concat_dataset[25] == 15
     assert concat_dataset.get_cat_ids(5) == cat_ids_list_a[5]
     assert concat_dataset.get_cat_ids(25) == cat_ids_list_b[15]
+    assert concat_dataset.get_ann_info(5) == ann_info_list_a[5]
+    assert concat_dataset.get_ann_info(25) == ann_info_list_b[15]
     assert len(concat_dataset) == len(dataset_a) + len(dataset_b)
 
     repeat_dataset = RepeatDataset(dataset_a, 10)
@@ -50,6 +80,9 @@ def test_dataset_wrapper():
     assert repeat_dataset.get_cat_ids(5) == cat_ids_list_a[5]
     assert repeat_dataset.get_cat_ids(15) == cat_ids_list_a[5]
     assert repeat_dataset.get_cat_ids(27) == cat_ids_list_a[7]
+    assert repeat_dataset.get_ann_info(5) == ann_info_list_a[5]
+    assert repeat_dataset.get_ann_info(15) == ann_info_list_a[5]
+    assert repeat_dataset.get_ann_info(27) == ann_info_list_a[7]
     assert len(repeat_dataset) == 10 * len(dataset_a)
 
     category_freq = defaultdict(int)
@@ -79,6 +112,8 @@ def test_dataset_wrapper():
     for idx in np.random.randint(0, len(repeat_factor_dataset), 3):
         assert repeat_factor_dataset[idx] == bisect.bisect_right(
             repeat_factors_cumsum, idx)
+        assert repeat_factor_dataset.get_ann_info(idx) == ann_info_list_a[bisect.bisect_right(
+            repeat_factors_cumsum, idx)]
 
     img_scale = (60, 60)
     dynamic_scale = (80, 80)

--- a/tests/test_data/test_datasets/test_dataset_wrapper.py
+++ b/tests/test_data/test_datasets/test_dataset_wrapper.py
@@ -31,7 +31,8 @@ def test_dataset_wrapper():
         ],
                                  axis=1)
         gt_labels = np.random.randint(0, 80, 2)
-        ann_info_list_a.append(dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
+        ann_info_list_a.append(
+            dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
     dataset_a.data_infos = MagicMock()
     dataset_a.data_infos.__len__.return_value = len_a
     dataset_a.get_cat_ids = MagicMock(
@@ -56,7 +57,8 @@ def test_dataset_wrapper():
         ],
                                  axis=1)
         gt_labels = np.random.randint(0, 80, 2)
-        ann_info_list_b.append(dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
+        ann_info_list_b.append(
+            dict(gt_bboxes=gt_bbox, gt_labels=gt_labels, img=img))
     dataset_b.data_infos = MagicMock()
     dataset_b.data_infos.__len__.return_value = len_b
     dataset_b.get_cat_ids = MagicMock(
@@ -112,8 +114,8 @@ def test_dataset_wrapper():
     for idx in np.random.randint(0, len(repeat_factor_dataset), 3):
         assert repeat_factor_dataset[idx] == bisect.bisect_right(
             repeat_factors_cumsum, idx)
-        assert repeat_factor_dataset.get_ann_info(idx) == ann_info_list_a[bisect.bisect_right(
-            repeat_factors_cumsum, idx)]
+        assert repeat_factor_dataset.get_ann_info(idx) == ann_info_list_a[
+            bisect.bisect_right(repeat_factors_cumsum, idx)]
 
     img_scale = (60, 60)
     dynamic_scale = (80, 80)


### PR DESCRIPTION
## Motivation

When the parameter dataset in MultiImageMixDataset is ConcatDataset/RepeatDataset/ClassBalancedDataset and mixup is added in the pipeline, the get_indexes in mixup will crash since there are no get_ann_info in ConcatDataset/RepeatDataset/ClassBalancedDataset.

I submitted a PR before, but it was closed by me. I added a unit test on the basis of the previous PR
Related PR：
https://github.com/open-mmlab/mmdetection/pull/6352
https://github.com/open-mmlab/mmdetection/pull/6516
## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
