### PR TITLE
[Fix] add --format-options arg for test to allow --eval and --format_only concurrently

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -85,6 +85,12 @@ def parse_args():
         help='custom options for evaluation, the key-value pair in xxx=yyy '
         'format will be kwargs for dataset.evaluate() function')
     parser.add_argument(
+        '--format-options',
+        nargs='+',
+        action=DictAction,
+        help='custom options for format_only, the key-value pair in xxx=yyy '
+        'format will be kwargs for dataset.format_results() function')
+    parser.add_argument(
         '--launcher',
         choices=['none', 'pytorch', 'slurm', 'mpi'],
         default='none',
@@ -112,9 +118,6 @@ def main():
         ('Please specify at least one operation (save/eval/format/show the '
          'results / save the results) with the argument "--out", "--eval"'
          ', "--format-only", "--show" or "--show-dir"')
-
-    if args.eval and args.format_only:
-        raise ValueError('--eval and --format_only cannot be both specified')
 
     if args.out is not None and not args.out.endswith(('.pkl', '.pickle')):
         raise ValueError('The output file must be a pkl file.')
@@ -215,10 +218,11 @@ def main():
         if args.out:
             print(f'\nwriting results to {args.out}')
             mmcv.dump(outputs, args.out)
-        kwargs = {} if args.eval_options is None else args.eval_options
         if args.format_only:
+            kwargs = {} if args.format_options is None else args.format_options
             dataset.format_results(outputs, **kwargs)
         if args.eval:
+            kwargs = {} if args.eval_options is None else args.eval_options
             eval_kwargs = cfg.get('evaluation', {}).copy()
             # hard-code way to remove EvalHook args
             for key in [


### PR DESCRIPTION
## Motivation

Currently, in `tools/test.py`, `--eval` and `--format_only` can not be used at the same time.

The cause is that these two modes (actually `dataset.format_results()` func and `dataset.evaluate()` func) both use `--eval_options` as their additional kwargs, while the args they allowed are not the same.

There is also an assertion to ensure that `--eval` and `--format_only` are not both given.

In my case, I need to obtain the evalution results and a '.json' output file at one run which requires `--eval` and `--format_only` concurrently. Otherwise I have to run test twice.

## Modification

1. A new arg `--format_options` is added to specify kwargs for `--format_only`. `--eval-options` is now only for `--eval`.
2. The assertion to ensure `--eval` and `--format_only` are not both given is removed.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
