### PR TITLE
Clean unnecessary custom_imports in entrypoints

### DIFF
--- a/mmdet/core/export/pytorch2onnx.py
+++ b/mmdet/core/export/pytorch2onnx.py
@@ -78,10 +78,6 @@ def build_model_from_cfg(config_path, checkpoint_path, cfg_options=None):
     cfg = mmcv.Config.fromfile(config_path)
     if cfg_options is not None:
         cfg.merge_from_dict(cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -183,10 +183,6 @@ def main():
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
     cfg.data.test.test_mode = True
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
 
     cfg.data.test.pop('samples_per_gpu', 0)
     cfg.data.test.pipeline = get_loading_pipeline(cfg.data.train.pipeline)

--- a/tools/analysis_tools/eval_metric.py
+++ b/tools/analysis_tools/eval_metric.py
@@ -56,10 +56,6 @@ def main():
 
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     cfg.data.test.test_mode = True
 
     dataset = build_dataset(cfg.data.test)

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -63,10 +63,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
 
     model = build_detector(
         cfg.model,

--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -191,10 +191,6 @@ def main():
     cfg = mmcv.Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/misc/browse_dataset.py
+++ b/tools/misc/browse_dataset.py
@@ -56,10 +56,6 @@ def retrieve_data_cfg(config_path, skip_type, cfg_options):
     cfg = Config.fromfile(config_path)
     if cfg_options is not None:
         cfg.merge_from_dict(cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     train_data_cfg = cfg.data.train
     while 'dataset' in train_data_cfg and train_data_cfg[
             'type'] != 'MultiImageMixDataset':

--- a/tools/misc/print_config.py
+++ b/tools/misc/print_config.py
@@ -44,10 +44,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     print(f'Config:\n{cfg.pretty_text}')
 
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -122,10 +122,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/train.py
+++ b/tools/train.py
@@ -90,10 +90,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
## Motivation

According to #6543, MMCV already supports custom_imports since PR open-mmlab/mmcv#606. There is no need to manually handle custom_imports after calling `Config.fromfile`. So the code like below should be cleaned.

```python
if cfg.get('custom_imports', None): 
     from mmcv.utils import import_modules_from_strings 
     import_modules_from_strings(**cfg['custom_imports']) 
```

## Modification

1. Search all files with related code

List of files with related code:
- `mmdet/core/export/pytorch2onnx.py`
- `tools/analysis_tools/analyze_results.py`
- `tools/analysis_tools/eval_metric.py`
- `tools/analysis_tools/get_flops.py`
- `tools/analysis_tools/test_robustness.py`
- `tools/misc/browse_dataset.py`
- `tools/misc/print_config.py`
- `tools/test.py`
- `tools/train.py`

2. delete the code in the list.
