### PR TITLE
Fix dist runs

### DIFF
--- a/docs/1_exist_data_model.md
+++ b/docs/1_exist_data_model.md
@@ -549,8 +549,8 @@ CUDA_VISIBLE_DEVICES=4,5,6,7 PORT=29501 ./tools/dist_train.sh ${CONFIG_FILE} 4
 
 ### Training on multiple nodes
 
-MMDetection relies on `torch.distributed` package for distributed training.
-Thus, as a basic usage, one can launch distributed training via PyTorch's [launch utility](https://pytorch.org/docs/stable/distributed.html#launch-utility).
+MMDetection relies on `torchrun` package for distributed training.
+Thus, as a basic usage, one can launch distributed training via PyTorch's [torchrun](https://pytorch.org/docs/stable/elastic/run.html).
 
 ### Manage jobs with Slurm
 

--- a/docs/useful_tools.md
+++ b/docs/useful_tools.md
@@ -388,7 +388,7 @@ python tools/dataset_converters/pascal_voc.py ${DEVKIT_PATH} [-h] [-o ${OUT_DIR}
 `tools/analysis_tools/benchmark.py` helps users to calculate FPS. The FPS value includes model forward and post-processing. In order to get a more accurate value, currently only supports single GPU distributed startup mode.
 
 ```shell
-torchrun --nnodes=1 --nproc_per_node=1 --master_port=${PORT} tools/analysis_tools/benchmark.py \
+torchrun --standalone --nnodes=1 --nproc_per_node=1 --master_port=${PORT} tools/analysis_tools/benchmark.py \
     ${CONFIG} \
     ${CHECKPOINT} \
     [--repeat-num ${REPEAT_NUM}] \
@@ -399,7 +399,7 @@ torchrun --nnodes=1 --nproc_per_node=1 --master_port=${PORT} tools/analysis_tool
 Examples: Assuming that you have already downloaded the `Faster R-CNN` model checkpoint to the directory `checkpoints/`.
 
 ```shell
-torchrun --nnodes=1 --nproc_per_node=1 --master_port=29500 tools/analysis_tools/benchmark.py \
+torchrun --standalone --nnodes=1 --nproc_per_node=1 --master_port=29500 tools/analysis_tools/benchmark.py \
        configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py \
        checkpoints/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth
 ```

--- a/docs/useful_tools.md
+++ b/docs/useful_tools.md
@@ -388,22 +388,20 @@ python tools/dataset_converters/pascal_voc.py ${DEVKIT_PATH} [-h] [-o ${OUT_DIR}
 `tools/analysis_tools/benchmark.py` helps users to calculate FPS. The FPS value includes model forward and post-processing. In order to get a more accurate value, currently only supports single GPU distributed startup mode.
 
 ```shell
-python -m torch.distributed.launch --nproc_per_node=1 --master_port=${PORT} tools/analysis_tools/benchmark.py \
+torchrun --nnodes=1 --nproc_per_node=1 --master_port=${PORT} tools/analysis_tools/benchmark.py \
     ${CONFIG} \
     ${CHECKPOINT} \
     [--repeat-num ${REPEAT_NUM}] \
     [--max-iter ${MAX_ITER}] \
-    [--log-interval ${LOG_INTERVAL}] \
-    --launcher pytorch
+    [--log-interval ${LOG_INTERVAL}]
 ```
 
 Examples: Assuming that you have already downloaded the `Faster R-CNN` model checkpoint to the directory `checkpoints/`.
 
 ```shell
-python -m torch.distributed.launch --nproc_per_node=1 --master_port=29500 tools/analysis_tools/benchmark.py \
+torchrun --nnodes=1 --nproc_per_node=1 --master_port=29500 tools/analysis_tools/benchmark.py \
        configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py \
-       checkpoints/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth \
-       --launcher pytorch
+       checkpoints/faster_rcnn_r50_fpn_1x_coco_20200130-047c8118.pth
 ```
 
 ## Miscellaneous

--- a/tools/dist_test.sh
+++ b/tools/dist_test.sh
@@ -6,5 +6,5 @@ GPUS=$3
 PORT=${PORT:-29500}
 
 PYTHONPATH="$(dirname $0)/..":$PYTHONPATH \
-python -m torch.distributed.launch --nproc_per_node=$GPUS --master_port=$PORT \
-    $(dirname "$0")/test.py $CONFIG $CHECKPOINT --launcher pytorch ${@:4}
+torchrun --standalone --nnodes=1 --nproc_per_node=$GPUS --master_port=$PORT \
+    $(dirname "$0")/test.py $CONFIG $CHECKPOINT ${@:4}

--- a/tools/dist_train.sh
+++ b/tools/dist_train.sh
@@ -5,5 +5,5 @@ GPUS=$2
 PORT=${PORT:-29500}
 
 PYTHONPATH="$(dirname $0)/..":$PYTHONPATH \
-python -m torch.distributed.launch --nproc_per_node=$GPUS --master_port=$PORT \
-    $(dirname "$0")/train.py $CONFIG --launcher pytorch ${@:3}
+torchrun --standalone --nnodes=1 --nproc_per_node=$GPUS --master_port=$PORT \
+    $(dirname "$0")/train.py $CONFIG ${@:3}

--- a/tools/train.py
+++ b/tools/train.py
@@ -108,7 +108,10 @@ def main():
                                 osp.splitext(osp.basename(args.config))[0])
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
-    if args.gpu_ids is not None:
+
+    if os.environ.get("LOCAL_RANK"):
+        cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
+    elif args.gpu_ids is not None:
         cfg.gpu_ids = args.gpu_ids
     else:
         cfg.gpu_ids = range(1) if args.gpus is None else range(args.gpus)

--- a/tools/train.py
+++ b/tools/train.py
@@ -109,8 +109,8 @@ def main():
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
 
-    if os.environ.get("LOCAL_RANK"):
-        cfg.gpu_ids = [int(os.environ["LOCAL_RANK"])]
+    if os.environ.get('LOCAL_RANK'):
+        cfg.gpu_ids = [int(os.environ['LOCAL_RANK'])]
     elif args.gpu_ids is not None:
         cfg.gpu_ids = args.gpu_ids
     else:


### PR DESCRIPTION
## Motivation

Fixes #6534

## Modification

Use `torchrun` instead of the deprecated `torch.distributed.launch`.

## BC-breaking (Optional)

I'm not sure when `torchrun` was introduced, so if people are using older `pytorch` versions then it might cause issues.

## Checklist

1. [x] Pre-commit or other linting tools are used to fix the potential lint issues.
2. [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness. <- I don't think there's a test for this
3. [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls. <- I don't think it has a downstream effect (it might be worth changing this in the other repos though)
4. [x] The documentation has been modified accordingly, like docstring or example tutorials.
