### PR TITLE
 [Refactor] Remove some code in mmdet/apis/train.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,4 @@ If you use this toolbox or benchmark in your research, please cite this project.
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab image and video editing toolbox.
 - [MMOCR](https://github.com/open-mmlab/mmocr): A Comprehensive Toolbox for Text Detection, Recognition and Understanding.
 - [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab image and video generative models toolbox.
+- [MMFlow](https://github.com/open-mmlab/mmflow): OpenMMLab optical flow toolbox and benchmark.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -203,6 +203,7 @@ MMDetection 是一款由来自不同高校和企业的研发人员共同参与�
 - [MMEditing](https://github.com/open-mmlab/mmediting): OpenMMLab 图像视频编辑工具箱
 - [MMOCR](https://github.com/open-mmlab/mmocr): OpenMMLab 全流程文字检测识别理解工具包
 - [MMGeneration](https://github.com/open-mmlab/mmgeneration): OpenMMLab 图片视频生成模型工具箱
+- [MMFlow](https://github.com/open-mmlab/mmflow): OpenMMLab 光流估计工具箱与测试基准
 
 ## 欢迎加入 OpenMMLab 社区
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -131,6 +131,10 @@ html_theme_options = {
                     'name': 'MMTracking',
                     'url': 'https://github.com/open-mmlab/mmtracking',
                 },
+                {
+                    'name': 'MMFlow',
+                    'url': 'https://github.com/open-mmlab/mmflow',
+                },
             ]
         },
         {

--- a/docs_zh-CN/conf.py
+++ b/docs_zh-CN/conf.py
@@ -131,6 +131,10 @@ html_theme_options = {
                     'name': 'MMTracking',
                     'url': 'https://github.com/open-mmlab/mmtracking',
                 },
+                {
+                    'name': 'MMFlow',
+                    'url': 'https://github.com/open-mmlab/mmflow',
+                },
             ]
         },
         {

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -162,7 +162,8 @@ def train_detector(model,
     # register hooks
     runner.register_training_hooks(cfg.lr_config, optimizer_config,
                                    cfg.checkpoint_config, cfg.log_config,
-                                   cfg.get('momentum_config', None))
+                                   cfg.get('momentum_config', None),
+                                   custom_hooks_config=cfg.get('custom_imports', None))
     if distributed:
         if isinstance(runner, EpochBasedRunner):
             runner.register_hook(DistSamplerSeedHook())

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -163,7 +163,7 @@ def train_detector(model,
     runner.register_training_hooks(cfg.lr_config, optimizer_config,
                                    cfg.checkpoint_config, cfg.log_config,
                                    cfg.get('momentum_config', None),
-                                   custom_hooks_config=cfg.get('custom_imports', None))
+                                   custom_hooks_config=cfg.get('custom_hooks', None))
     if distributed:
         if isinstance(runner, EpochBasedRunner):
             runner.register_hook(DistSamplerSeedHook())

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -160,10 +160,13 @@ def train_detector(model,
         optimizer_config = cfg.optimizer_config
 
     # register hooks
-    runner.register_training_hooks(cfg.lr_config, optimizer_config,
-                                   cfg.checkpoint_config, cfg.log_config,
-                                   cfg.get('momentum_config', None),
-                                   custom_hooks_config=cfg.get('custom_hooks', None))
+    runner.register_training_hooks(
+        cfg.lr_config,
+        optimizer_config,
+        cfg.checkpoint_config,
+        cfg.log_config,
+        cfg.get('momentum_config', None),
+        custom_hooks_config=cfg.get('custom_hooks', None))
     if distributed:
         if isinstance(runner, EpochBasedRunner):
             runner.register_hook(DistSamplerSeedHook())

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -6,10 +6,9 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
-from mmcv.runner import (HOOKS, DistSamplerSeedHook, EpochBasedRunner,
+from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner,
                          Fp16OptimizerHook, OptimizerHook, build_optimizer,
                          build_runner, get_dist_info)
-from mmcv.utils import build_from_cfg
 
 from mmdet.core import DistEvalHook, EvalHook
 from mmdet.datasets import (build_dataloader, build_dataset,

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -194,20 +194,6 @@ def train_detector(model,
         runner.register_hook(
             eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 
-    # user-defined hooks
-    if cfg.get('custom_hooks', None):
-        custom_hooks = cfg.custom_hooks
-        assert isinstance(custom_hooks, list), \
-            f'custom_hooks expect list type, but got {type(custom_hooks)}'
-        for hook_cfg in cfg.custom_hooks:
-            assert isinstance(hook_cfg, dict), \
-                'Each item in custom_hooks expects dict type, but got ' \
-                f'{type(hook_cfg)}'
-            hook_cfg = hook_cfg.copy()
-            priority = hook_cfg.pop('priority', 'NORMAL')
-            hook = build_from_cfg(hook_cfg, HOOKS)
-            runner.register_hook(hook, priority=priority)
-
     if cfg.resume_from:
         runner.resume(cfg.resume_from)
     elif cfg.load_from:

--- a/tools/train.py
+++ b/tools/train.py
@@ -90,10 +90,6 @@ def main():
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
-    # import modules from string list.
-    if cfg.get('custom_imports', None):
-        from mmcv.utils import import_modules_from_strings
-        import_modules_from_strings(**cfg['custom_imports'])
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
Remove some code in mmdet/apis/train.py, because  the function runner.register_training_hooks()  (https://github.com/open-mmlab/mmcv/blob/58e32423f04048980946693772fb059d554eacd0/mmcv/runner/base_runner.py#L503) adds a new argument custom_hooks_config. Therefore, some functions have been  implemented in mmcv.