### PR TITLE
assign seed and deterministic from config if they are None in args

### DIFF
--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -217,7 +217,8 @@ def main():
     elif hasattr(cfg, "seed"):
         seed=cfg.seed
     else:
-        seed=None   
+        seed=None
+    seed = init_random_seed(seed)   
     set_random_seed(seed)
 
     if 'all' in args.corruptions:

--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -15,7 +15,8 @@ from pycocotools.cocoeval import COCOeval
 from tools.analysis_tools.robustness_eval import get_results
 
 from mmdet import datasets
-from mmdet.apis import multi_gpu_test, set_random_seed, single_gpu_test
+from mmdet.apis import (multi_gpu_test, init_random_seed, set_random_seed,
+                        single_gpu_test)
 from mmdet.core import eval_map
 from mmdet.datasets import build_dataloader, build_dataset
 from mmdet.models import build_detector
@@ -210,15 +211,15 @@ def main():
     if hasattr(cfg, "seed") and args.seed is not None:
         seed = args.seed
         print(f'Argument seed passed both in config file and as an argument. \
-            Please avoid setting the seed in the config file if also passing it as an argument. \
-            Using argument random seed {args.seed}')
+            Please avoid setting the seed in the config file if also passing \
+            it as an argument. Using argument random seed {args.seed}')
     elif args.seed is not None:
-        seed=args.seed
+        seed = args.seed
     elif hasattr(cfg, "seed"):
-        seed=cfg.seed
+        seed = cfg.seed
     else:
-        seed=None
-    seed = init_random_seed(seed)   
+        seed = None
+    seed = init_random_seed(seed)
     set_random_seed(seed)
 
     if 'all' in args.corruptions:

--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -209,6 +209,9 @@ def main():
     # set random seeds
     if args.seed is not None:
         set_random_seed(args.seed)
+    else:
+        if hasattr(cfg, "seed"):
+            set_random_seed(cfg.seed)
 
     if 'all' in args.corruptions:
         corruptions = [

--- a/tools/analysis_tools/test_robustness.py
+++ b/tools/analysis_tools/test_robustness.py
@@ -207,11 +207,18 @@ def main():
         init_dist(args.launcher, **cfg.dist_params)
 
     # set random seeds
-    if args.seed is not None:
-        set_random_seed(args.seed)
+    if hasattr(cfg, "seed") and args.seed is not None:
+        seed = args.seed
+        print(f'Argument seed passed both in config file and as an argument. \
+            Please avoid setting the seed in the config file if also passing it as an argument. \
+            Using argument random seed {args.seed}')
+    elif args.seed is not None:
+        seed=args.seed
+    elif hasattr(cfg, "seed"):
+        seed=cfg.seed
     else:
-        if hasattr(cfg, "seed"):
-            set_random_seed(cfg.seed)
+        seed=None   
+    set_random_seed(seed)
 
     if 'all' in args.corruptions:
         corruptions = [

--- a/tools/train.py
+++ b/tools/train.py
@@ -144,6 +144,11 @@ def main():
     logger.info(f'Config:\n{cfg.pretty_text}')
 
     # set random seeds
+    if hasattr(cfg, "seed") and args.seed is None:
+        args.seed = cfg.seed
+    if hasattr(cfg, "deterministic") and args.deterministic is None:
+        args.deterministic = cfg.deterministic
+
     seed = init_random_seed(args.seed)
     logger.info(f'Set random seed to {seed}, '
                 f'deterministic: {args.deterministic}')

--- a/tools/train.py
+++ b/tools/train.py
@@ -144,15 +144,34 @@ def main():
     logger.info(f'Config:\n{cfg.pretty_text}')
 
     # set random seeds
-    if hasattr(cfg, "seed") and args.seed is None:
-        args.seed = cfg.seed
-    if hasattr(cfg, "deterministic") and args.deterministic is None:
-        args.deterministic = cfg.deterministic
+    if hasattr(cfg, "seed") and args.seed is not None:
+        seed = args.seed
+        logger.info(f'Argument seed passed both in config file and as an argument. \
+            Please avoid setting the seed in the config file if also passing it as an argument. \
+            Using argument random seed {args.seed}')    
+    elif args.seed is not None:
+        seed=args.seed
+    elif hasattr(cfg, "seed"):
+        seed=cfg.seed
+    else:
+        seed=None                
 
-    seed = init_random_seed(args.seed)
+    if hasattr(cfg, "deterministic") and args.deterministic is not None:
+        deterministic = args.deterministic
+        logger.info(f'Option deterministic passed both in config file and as an argument. \
+            Please avoid setting the option in the config file if also passing it as an argument \
+            Using argument random seed {args.deterministic}')    
+    elif args.deterministic is not None:
+        deterministic=args.deterministic
+    elif hasattr(cfg, "deterministic"):
+        deterministic=cfg.deterministic
+    else:
+        deterministic=None      
+
+    seed = init_random_seed(seed)
     logger.info(f'Set random seed to {seed}, '
-                f'deterministic: {args.deterministic}')
-    set_random_seed(seed, deterministic=args.deterministic)
+                f'deterministic: {deterministic}')
+    set_random_seed(seed, deterministic=deterministic)
     cfg.seed = seed
     meta['seed'] = seed
     meta['exp_name'] = osp.basename(args.config)

--- a/tools/train.py
+++ b/tools/train.py
@@ -147,26 +147,27 @@ def main():
     if hasattr(cfg, "seed") and args.seed is not None:
         seed = args.seed
         logger.info(f'Argument seed passed both in config file and as an argument. \
-            Please avoid setting the seed in the config file if also passing it as an argument. \
-            Using argument random seed {args.seed}')    
+            Please avoid setting the seed in the config file if also passing \
+            it as an argument. Using argument random seed {args.seed}')
     elif args.seed is not None:
-        seed=args.seed
+        seed = args.seed
     elif hasattr(cfg, "seed"):
-        seed=cfg.seed
+        seed = cfg.seed
     else:
-        seed=None                
+        seed = None
 
     if hasattr(cfg, "deterministic") and args.deterministic is not None:
         deterministic = args.deterministic
         logger.info(f'Option deterministic passed both in config file and as an argument. \
-            Please avoid setting the option in the config file if also passing it as an argument \
-            Using argument random seed {args.deterministic}')    
+            Please avoid setting the option in the config file if also \
+            passing it as an argument. Using argument random seed \
+            {args.deterministic}')
     elif args.deterministic is not None:
-        deterministic=args.deterministic
+        deterministic = args.deterministic
     elif hasattr(cfg, "deterministic"):
-        deterministic=cfg.deterministic
+        deterministic = cfg.deterministic
     else:
-        deterministic=None      
+        deterministic = None
 
     seed = init_random_seed(seed)
     logger.info(f'Set random seed to {seed}, '


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Currently, as described in https://github.com/open-mmlab/mmdetection/issues/6553, it's not possible to set the random seed and the option Deterministic=True from the config file. This PR fixes that.

## Modification

Minor modifications to:

- `tools/train.py`
- `tools/analysis_tools/test_robustness.py`.

## BC-breaking (Optional)

None
