### PR TITLE
[Fix] Fix init weights in Swin and PVT.

### DIFF
--- a/mmdet/models/backbones/pvt.py
+++ b/mmdet/models/backbones/pvt.py
@@ -529,15 +529,12 @@ class PyramidVisionTransformer(BaseModule):
                 if isinstance(m, nn.Linear):
                     trunc_normal_init(m, std=.02, bias=0.)
                 elif isinstance(m, nn.LayerNorm):
-                    constant_init(m.bias, 0)
-                    constant_init(m.weight, 1.0)
+                    constant_init(m, 1.0)
                 elif isinstance(m, nn.Conv2d):
                     fan_out = m.kernel_size[0] * m.kernel_size[
                         1] * m.out_channels
                     fan_out //= m.groups
-                    normal_init(m.weight, 0, math.sqrt(2.0 / fan_out))
-                    if m.bias is not None:
-                        constant_init(m.bias, 0)
+                    normal_init(m, 0, math.sqrt(2.0 / fan_out))
                 elif isinstance(m, AbsolutePositionEmbedding):
                     m.init_weights()
         else:

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -678,8 +678,7 @@ class SwinTransformer(BaseModule):
                 if isinstance(m, nn.Linear):
                     trunc_normal_init(m, std=.02, bias=0.)
                 elif isinstance(m, nn.LayerNorm):
-                    constant_init(m.bias, 0)
-                    constant_init(m.weight, 1.0)
+                    constant_init(m, 1.0)
         else:
             assert 'checkpoint' in self.init_cfg, f'Only support ' \
                                                   f'specify `Pretrained` in ' \


### PR DESCRIPTION
## Motivation

`constant_init` and `normal_init` in mmcv can only initialize nn.Module with weight and bias.

## Modification

Fix `init_weights` in both Swin and PVT

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
