### PR TITLE
Support `bbox_clip_border` for the augmentations of YOLOX

### DIFF
--- a/mmdet/core/bbox/__init__.py
+++ b/mmdet/core/bbox/__init__.py
@@ -12,7 +12,7 @@ from .samplers import (BaseSampler, CombinedSampler,
 from .transforms import (bbox2distance, bbox2result, bbox2roi,
                          bbox_cxcywh_to_xyxy, bbox_flip, bbox_mapping,
                          bbox_mapping_back, bbox_rescale, bbox_xyxy_to_cxcywh,
-                         distance2bbox, remove_outside_bboxes, roi2bbox)
+                         distance2bbox, find_inside_bboxes, roi2bbox)
 
 __all__ = [
     'bbox_overlaps', 'BboxOverlaps2D', 'BaseAssigner', 'MaxIoUAssigner',
@@ -24,5 +24,5 @@ __all__ = [
     'build_bbox_coder', 'BaseBBoxCoder', 'PseudoBBoxCoder',
     'DeltaXYWHBBoxCoder', 'TBLRBBoxCoder', 'DistancePointBBoxCoder',
     'CenterRegionAssigner', 'bbox_rescale', 'bbox_cxcywh_to_xyxy',
-    'bbox_xyxy_to_cxcywh', 'RegionAssigner', 'remove_outside_bboxes'
+    'bbox_xyxy_to_cxcywh', 'RegionAssigner', 'find_inside_bboxes'
 ]

--- a/mmdet/core/bbox/__init__.py
+++ b/mmdet/core/bbox/__init__.py
@@ -12,7 +12,7 @@ from .samplers import (BaseSampler, CombinedSampler,
 from .transforms import (bbox2distance, bbox2result, bbox2roi,
                          bbox_cxcywh_to_xyxy, bbox_flip, bbox_mapping,
                          bbox_mapping_back, bbox_rescale, bbox_xyxy_to_cxcywh,
-                         distance2bbox, roi2bbox)
+                         distance2bbox, remove_outside_bboxes, roi2bbox)
 
 __all__ = [
     'bbox_overlaps', 'BboxOverlaps2D', 'BaseAssigner', 'MaxIoUAssigner',
@@ -24,5 +24,5 @@ __all__ = [
     'build_bbox_coder', 'BaseBBoxCoder', 'PseudoBBoxCoder',
     'DeltaXYWHBBoxCoder', 'TBLRBBoxCoder', 'DistancePointBBoxCoder',
     'CenterRegionAssigner', 'bbox_rescale', 'bbox_cxcywh_to_xyxy',
-    'bbox_xyxy_to_cxcywh', 'RegionAssigner'
+    'bbox_xyxy_to_cxcywh', 'RegionAssigner', 'remove_outside_bboxes'
 ]

--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -3,6 +3,24 @@ import numpy as np
 import torch
 
 
+def remove_outside_bboxes(bboxes, img_h, img_w):
+    """Remove bboxes that are out of the image boundary.
+
+    Args:
+        bboxes (Tensor): Shape (N, 4).
+        img_h (int): Image height.
+        img_w (int): Image width.
+
+    Returns:
+        Tensor: Index of the remaining bboxes.
+    """
+    inside_inds = bboxes[:, 0] < img_w
+    inside_inds = inside_inds & (bboxes[:, 2] > 0)
+    inside_inds = inside_inds & (bboxes[:, 1] < img_h)
+    inside_inds = inside_inds & (bboxes[:, 3] > 0)
+    return inside_inds
+
+
 def bbox_flip(bboxes, img_shape, direction='horizontal'):
     """Flip bboxes horizontally or vertically.
 

--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -4,7 +4,7 @@ import torch
 
 
 def remove_outside_bboxes(bboxes, img_h, img_w):
-    """Remove bboxes that are out of the image boundary.
+    """Remove bboxes that are completely out of the image boundary.
 
     Args:
         bboxes (Tensor): Shape (N, 4).
@@ -14,10 +14,8 @@ def remove_outside_bboxes(bboxes, img_h, img_w):
     Returns:
         Tensor: Index of the remaining bboxes.
     """
-    inside_inds = bboxes[:, 0] < img_w
-    inside_inds = inside_inds & (bboxes[:, 2] > 0)
-    inside_inds = inside_inds & (bboxes[:, 1] < img_h)
-    inside_inds = inside_inds & (bboxes[:, 3] > 0)
+    inside_inds = (bboxes[:, 0] < img_w) & (bboxes[:, 2] > 0) \
+        & (bboxes[:, 1] < img_h) & (bboxes[:, 3] > 0)
     return inside_inds
 
 

--- a/mmdet/core/bbox/transforms.py
+++ b/mmdet/core/bbox/transforms.py
@@ -3,8 +3,8 @@ import numpy as np
 import torch
 
 
-def remove_outside_bboxes(bboxes, img_h, img_w):
-    """Remove bboxes that are completely out of the image boundary.
+def find_inside_bboxes(bboxes, img_h, img_w):
+    """Find bboxes as long as a part of bboxes is inside the image.
 
     Args:
         bboxes (Tensor): Shape (N, 4).

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -239,6 +239,9 @@ class Resize:
         """Resize bounding boxes with ``results['scale_factor']``."""
         for key in results.get('bbox_fields', []):
             bboxes = results[key] * results['scale_factor']
+            # In some dataset like MOT17, the gt bboxes are allowed to cross
+            # the border of images. Therefore, we don't need to clip the gt
+            # bboxes in these cases.
             if self.bbox_clip_border:
                 img_shape = results['img_shape']
                 bboxes[:, 0::2] = np.clip(bboxes[:, 0::2], 0, img_shape[1])
@@ -2105,6 +2108,9 @@ class Mosaic:
             mosaic_bboxes = np.concatenate(mosaic_bboxes, 0)
             mosaic_labels = np.concatenate(mosaic_labels, 0)
 
+            # In some dataset like MOT17, the gt bboxes are allowed to cross
+            # the border of images. Therefore, we don't need to clip the gt
+            # bboxes in these cases.
             if self.bbox_clip_border:
                 mosaic_bboxes[:, 0::2] = np.clip(mosaic_bboxes[:, 0::2], 0,
                                                  2 * self.img_scale[1])
@@ -2389,6 +2395,9 @@ class MixUp:
         retrieve_gt_bboxes = retrieve_results['gt_bboxes']
         retrieve_gt_bboxes[:, 0::2] = retrieve_gt_bboxes[:, 0::2] * scale_ratio
         retrieve_gt_bboxes[:, 1::2] = retrieve_gt_bboxes[:, 1::2] * scale_ratio
+        # In some dataset like MOT17, the gt bboxes are allowed to cross
+        # the border of images. Therefore, we don't need to clip the gt
+        # bboxes in these cases.
         if self.bbox_clip_border:
             retrieve_gt_bboxes[:, 0::2] = np.clip(retrieve_gt_bboxes[:, 0::2],
                                                   0, origin_w)
@@ -2405,6 +2414,9 @@ class MixUp:
             cp_retrieve_gt_bboxes[:, 0::2] - x_offset
         cp_retrieve_gt_bboxes[:, 1::2] = \
             cp_retrieve_gt_bboxes[:, 1::2] - y_offset
+        # In some dataset like MOT17, the gt bboxes are allowed to cross
+        # the border of images. Therefore, we don't need to clip the gt
+        # bboxes in these cases.
         if self.bbox_clip_border:
             cp_retrieve_gt_bboxes[:, 0::2] = np.clip(
                 cp_retrieve_gt_bboxes[:, 0::2], 0, target_w)
@@ -2594,6 +2606,9 @@ class RandomAffine:
                 warp_bboxes = np.vstack(
                     (xs.min(1), ys.min(1), xs.max(1), ys.max(1))).T
 
+                # In some dataset like MOT17, the gt bboxes are allowed to
+                # cross the border of images. Therefore, we don't need to clip
+                # the gt bboxes in these cases.
                 if self.bbox_clip_border:
                     warp_bboxes[:, [0, 2]] = \
                         warp_bboxes[:, [0, 2]].clip(0, width)

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -54,7 +54,7 @@ class Resize:
         ratio_range (tuple[float]): (min_ratio, max_ratio)
         keep_ratio (bool): Whether to keep the aspect ratio when resizing the
             image.
-        bbox_clip_border (bool, optional): Whether clip the objects outside
+        bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. Defaults to True.
         backend (str): Image resize backend, choices are 'cv2' and 'pillow'.
             These two backends generates slightly different results. Defaults
@@ -1985,7 +1985,7 @@ class Mosaic:
            output. Default to (0.5, 1.5).
         min_bbox_size (int | float): The minimum pixel for filtering
             invalid bboxes after the mosaic pipeline. Default to 0.
-        bbox_clip_border (bool, optional): Whether clip the objects outside
+        bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the
@@ -2261,7 +2261,7 @@ class MixUp:
         max_aspect_ratio (float): Aspect ratio of width and height
             threshold to filter bboxes. If max(h/w, w/h) larger than this
             value, the box will be removed. Default: 20.
-        bbox_clip_border (bool, optional): Whether clip the objects outside
+        bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the
@@ -2513,7 +2513,7 @@ class RandomAffine:
         max_aspect_ratio (float): Aspect ratio of width and height
             threshold to filter bboxes. If max(h/w, w/h) larger than this
             value, the box will be removed.
-        bbox_clip_border (bool, optional): Whether clip the objects outside
+        bbox_clip_border (bool, optional): Whether to clip the objects outside
             the border of the image. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -55,7 +55,9 @@ class Resize:
         keep_ratio (bool): Whether to keep the aspect ratio when resizing the
             image.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
-            the border of the image. Defaults to True.
+            the border of the image. In some dataset like MOT17, the gt bboxes
+            are allowed to cross the border of images. Therefore, we don't
+            need to clip the gt bboxes in these cases. Defaults to True.
         backend (str): Image resize backend, choices are 'cv2' and 'pillow'.
             These two backends generates slightly different results. Defaults
             to 'cv2'.
@@ -239,9 +241,6 @@ class Resize:
         """Resize bounding boxes with ``results['scale_factor']``."""
         for key in results.get('bbox_fields', []):
             bboxes = results[key] * results['scale_factor']
-            # In some dataset like MOT17, the gt bboxes are allowed to cross
-            # the border of images. Therefore, we don't need to clip the gt
-            # bboxes in these cases.
             if self.bbox_clip_border:
                 img_shape = results['img_shape']
                 bboxes[:, 0::2] = np.clip(bboxes[:, 0::2], 0, img_shape[1])
@@ -1986,7 +1985,9 @@ class Mosaic:
         min_bbox_size (int | float): The minimum pixel for filtering
             invalid bboxes after the mosaic pipeline. Default to 0.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
-            the border of the image. Defaults to True.
+            the border of the image. In some dataset like MOT17, the gt bboxes
+            are allowed to cross the border of images. Therefore, we don't
+            need to clip the gt bboxes in these cases. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the
             `min_bbox_size` is invalid. Default to True.
@@ -2108,9 +2109,6 @@ class Mosaic:
             mosaic_bboxes = np.concatenate(mosaic_bboxes, 0)
             mosaic_labels = np.concatenate(mosaic_labels, 0)
 
-            # In some dataset like MOT17, the gt bboxes are allowed to cross
-            # the border of images. Therefore, we don't need to clip the gt
-            # bboxes in these cases.
             if self.bbox_clip_border:
                 mosaic_bboxes[:, 0::2] = np.clip(mosaic_bboxes[:, 0::2], 0,
                                                  2 * self.img_scale[1])
@@ -2261,7 +2259,9 @@ class MixUp:
             threshold to filter bboxes. If max(h/w, w/h) larger than this
             value, the box will be removed. Default: 20.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
-            the border of the image. Defaults to True.
+            the border of the image. In some dataset like MOT17, the gt bboxes
+            are allowed to cross the border of images. Therefore, we don't
+            need to clip the gt bboxes in these cases. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the
             `min_bbox_size` and `min_area_ratio` and `max_aspect_ratio`
@@ -2394,9 +2394,6 @@ class MixUp:
         retrieve_gt_bboxes = retrieve_results['gt_bboxes']
         retrieve_gt_bboxes[:, 0::2] = retrieve_gt_bboxes[:, 0::2] * scale_ratio
         retrieve_gt_bboxes[:, 1::2] = retrieve_gt_bboxes[:, 1::2] * scale_ratio
-        # In some dataset like MOT17, the gt bboxes are allowed to cross
-        # the border of images. Therefore, we don't need to clip the gt
-        # bboxes in these cases.
         if self.bbox_clip_border:
             retrieve_gt_bboxes[:, 0::2] = np.clip(retrieve_gt_bboxes[:, 0::2],
                                                   0, origin_w)
@@ -2413,9 +2410,6 @@ class MixUp:
             cp_retrieve_gt_bboxes[:, 0::2] - x_offset
         cp_retrieve_gt_bboxes[:, 1::2] = \
             cp_retrieve_gt_bboxes[:, 1::2] - y_offset
-        # In some dataset like MOT17, the gt bboxes are allowed to cross
-        # the border of images. Therefore, we don't need to clip the gt
-        # bboxes in these cases.
         if self.bbox_clip_border:
             cp_retrieve_gt_bboxes[:, 0::2] = np.clip(
                 cp_retrieve_gt_bboxes[:, 0::2], 0, target_w)
@@ -2512,7 +2506,9 @@ class RandomAffine:
             threshold to filter bboxes. If max(h/w, w/h) larger than this
             value, the box will be removed.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
-            the border of the image. Defaults to True.
+            the border of the image. In some dataset like MOT17, the gt bboxes
+            are allowed to cross the border of images. Therefore, we don't
+            need to clip the gt bboxes in these cases. Defaults to True.
         skip_filter (bool): Whether to skip filtering rules. If it
             is True, the filter rule will not be applied, and the
             `min_bbox_size` and `min_area_ratio` and `max_aspect_ratio`
@@ -2604,9 +2600,6 @@ class RandomAffine:
                 warp_bboxes = np.vstack(
                     (xs.min(1), ys.min(1), xs.max(1), ys.max(1))).T
 
-                # In some dataset like MOT17, the gt bboxes are allowed to
-                # cross the border of images. Therefore, we don't need to clip
-                # the gt bboxes in these cases.
                 if self.bbox_clip_border:
                     warp_bboxes[:, [0, 2]] = \
                         warp_bboxes[:, [0, 2]].clip(0, width)

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -9,7 +9,7 @@ import mmcv
 import numpy as np
 from numpy import random
 
-from mmdet.core import PolygonMasks, remove_outside_bboxes
+from mmdet.core import PolygonMasks, find_inside_bboxes
 from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
 from ..builder import PIPELINES
 
@@ -2122,9 +2122,8 @@ class Mosaic:
                     self._filter_box_candidates(mosaic_bboxes, mosaic_labels)
 
         # remove outside bboxes
-        inside_inds = remove_outside_bboxes(mosaic_bboxes,
-                                            2 * self.img_scale[0],
-                                            2 * self.img_scale[1])
+        inside_inds = find_inside_bboxes(mosaic_bboxes, 2 * self.img_scale[0],
+                                         2 * self.img_scale[1])
         mosaic_bboxes = mosaic_bboxes[inside_inds]
         mosaic_labels = mosaic_labels[inside_inds]
 
@@ -2442,8 +2441,7 @@ class MixUp:
             (results['gt_labels'], retrieve_gt_labels), axis=0)
 
         # remove outside bbox
-        inside_inds = remove_outside_bboxes(mixup_gt_bboxes, target_h,
-                                            target_w)
+        inside_inds = find_inside_bboxes(mixup_gt_bboxes, target_h, target_w)
         mixup_gt_bboxes = mixup_gt_bboxes[inside_inds]
         mixup_gt_labels = mixup_gt_labels[inside_inds]
 
@@ -2616,7 +2614,7 @@ class RandomAffine:
                         warp_bboxes[:, [1, 3]].clip(0, height)
 
                 # remove outside bbox
-                valid_index = remove_outside_bboxes(warp_bboxes, height, width)
+                valid_index = find_inside_bboxes(warp_bboxes, height, width)
                 if not self.skip_filter:
                     # filter bboxes
                     filter_index = self.filter_gt_bboxes(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support `bbox_clip_border` argument for the data augmentations of YOLOX.

## Modification

Add `bbox_clip_border` argument for `Mosaic`, `MixUp` and `RandomAffine` augmentations. The argument allow the augmentations not to clip the bboxes based on the image border, just like [`Resize`](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/pipelines/transforms.py#L57).

## BC-breaking (Optional)

No BC-breaking

## Use cases (Optional)

Just set `bbox_clip_border=False` in these augmentations to not clip the bboxes.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
