### PR TITLE
[Fix] Support setting pad_val in batch collating

### DIFF
--- a/mmdet/datasets/pipelines/formating.py
+++ b/mmdet/datasets/pipelines/formating.py
@@ -191,8 +191,10 @@ class DefaultFormatBundle:
     Args:
         img_to_float (bool): Whether to force the image to be converted to
             float type. Default: True.
-        pad_val (dict): A dict for padding value when collcate in parallel,
+        pad_val (dict): A dict for padding value in batch collating,
             the default value is `dict(img=0, masks=0, seg=255)`.
+            Without this argument, the padding value of "gt_semantic_seg"
+            will be set to 0 by default, which should be 255.
     """
 
     def __init__(self,


### PR DESCRIPTION
Now, the padding value is set to 0 by default, but in `gt_semantic_seg` it needs to be 255.

So I modified the `DefaultFormatBundle` and added `padding_value` in the `DataContainer`.
In batch collating, the `DataContainer` will fill the data with the `padding_value`.