### PR TITLE
switch back to original pycocotools

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,5 @@
 matplotlib
 numpy
-pycocotools; platform_system == "Linux"
-pycocotools-windows; platform_system == "Windows"
+pycocotools
 six
 terminaltables


### PR DESCRIPTION
Windows installation (compilation settings) were missing on the original pycocotools package so we started to using pycocotools-windows package for windows.

Now Windows installation is fixed on the original pycocotools pypi package, so we can update the dependency.

Fixes https://github.com/open-mmlab/mmdetection/pull/4939#issuecomment-997632171