### PR TITLE
[Docs] fix the format of default value in SwinTransformer class doc

### DIFF
--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -515,7 +515,7 @@ class SwinTransformer(BaseModule):
             to convert some keys to make it compatible.
             Default: False.
         frozen_stages (int): Stages to be frozen (stop grad and set eval mode).
-            -1 means not freezing any parameters.
+            Default: -1 (-1 means not freezing any parameters).
         init_cfg (dict, optional): The Config for initialization.
             Defaults to None.
     """


### PR DESCRIPTION
## Motivation

the format of the  frozen_stages default value is different from others in the SwinTransformer class doc

## Modification

-1 means not freezing any parameters. ---> Default: -1 (-1 means not freezing any parameters).