### PR TITLE
Bump to version v2.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <img src="https://user-images.githubusercontent.com/12907710/137271636-56ba1cd2-b110-4812-8221-b4c120320aa9.png"/>
 
 
-[📘Documentation](https://mmdetection.readthedocs.io/en/v2.19.1/) |
-[🛠️Installation](https://mmdetection.readthedocs.io/en/v2.19.1/get_started.html) |
-[👀Model Zoo](https://mmdetection.readthedocs.io/en/v2.19.1/model_zoo.html) |
-[🆕Update News](https://mmdetection.readthedocs.io/en/v2.19.1/changelog.html) |
+[📘Documentation](https://mmdetection.readthedocs.io/en/v2.20.0/) |
+[🛠️Installation](https://mmdetection.readthedocs.io/en/v2.20.0/get_started.html) |
+[👀Model Zoo](https://mmdetection.readthedocs.io/en/v2.20.0/model_zoo.html) |
+[🆕Update News](https://mmdetection.readthedocs.io/en/v2.20.0/changelog.html) |
 [🚀Ongoing Projects](https://github.com/open-mmlab/mmdetection/projects) |
 [🤔Reporting Issues](https://github.com/open-mmlab/mmdetection/issues/new/choose)
 
@@ -60,11 +60,12 @@ This project is released under the [Apache 2.0 license](LICENSE).
 
 ## Changelog
 
-**2.19.1** was released in 14/12/2021:
+**2.20.0** was released in 27/12/2021:
 
-- Release [YOLOX](configs/yolox/README.md) COCO pretrained models
-- Add abstract and sketch of the papers in readmes
-- Fix some weight initialization bugs
+- Support [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection (ICCV 2021 Oral)
+- Support selecting GPU-ids in non-distributed testing time
+- Support resuming from the latest checkpoint automatically
+- Fix some bugs in documentation, links and codes
 
 Please refer to [changelog.md](docs/en/changelog.md) for details and release history.
 

--- a/README.md
+++ b/README.md
@@ -63,9 +63,7 @@ This project is released under the [Apache 2.0 license](LICENSE).
 **2.20.0** was released in 27/12/2021:
 
 - Support [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection (ICCV 2021 Oral)
-- Support selecting GPU-ids in non-distributed testing time
 - Support resuming from the latest checkpoint automatically
-- Fix some bugs in documentation, links and codes
 
 Please refer to [changelog.md](docs/en/changelog.md) for details and release history.
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -13,10 +13,10 @@
   <img src="https://user-images.githubusercontent.com/12907710/137271636-56ba1cd2-b110-4812-8221-b4c120320aa9.png"/>
 
 
-[📘使用文档](https://mmdetection.readthedocs.io/zh_CN/v2.19.1/) |
-[🛠️安装教程](https://mmdetection.readthedocs.io/zh_CN/v2.19.1/get_started.html) |
-[👀模型库](https://mmdetection.readthedocs.io/zh_CN/v2.19.1/model_zoo.html) |
-[🆕更新日志](https://mmdetection.readthedocs.io/en/v2.19.1/changelog.html) |
+[📘使用文档](https://mmdetection.readthedocs.io/zh_CN/v2.20.0/) |
+[🛠️安装教程](https://mmdetection.readthedocs.io/zh_CN/v2.20.0/get_started.html) |
+[👀模型库](https://mmdetection.readthedocs.io/zh_CN/v2.20.0/model_zoo.html) |
+[🆕更新日志](https://mmdetection.readthedocs.io/en/v2.20.0/changelog.html) |
 [🚀进行中的项目](https://github.com/open-mmlab/mmdetection/projects) |
 [🤔报告问题](https://github.com/open-mmlab/mmdetection/issues/new/choose)
 
@@ -59,10 +59,11 @@ MMDetection 是一个基于 PyTorch 的目标检测开源工具箱。它是 [Ope
 
 ## 更新日志
 
-最新的 **2.19.1** 版本已经在 2021.12.14 发布:
-- 发布 [YOLOX](configs/yolox/README.md) COCO 预训练模型
-- 在自述文件中添加论文的摘要和草图
-- 修复一些权重初始化错误
+最新的 **2.20.0** 版本已经在 2021.12.27 发布:
+- 支持了 ICCV 2021 Oral 方法 [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection
+- 支持了在非分布式测试时选择 GPU
+- 支持了自动从最新的存储参数节点恢复训练
+- 修复了一些文档、代码和链接上的问题
 
 如果想了解更多版本更新细节和历史信息，请阅读[更新日志](docs/changelog.md)。
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -61,9 +61,7 @@ MMDetection 是一个基于 PyTorch 的目标检测开源工具箱。它是 [Ope
 
 最新的 **2.20.0** 版本已经在 2021.12.27 发布:
 - 支持了 ICCV 2021 Oral 方法 [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection
-- 支持了在非分布式测试时选择 GPU
 - 支持了自动从最新的存储参数节点恢复训练
-- 修复了一些文档、代码和链接上的问题
 
 如果想了解更多版本更新细节和历史信息，请阅读[更新日志](docs/changelog.md)。
 

--- a/docker/serve/Dockerfile
+++ b/docker/serve/Dockerfile
@@ -4,7 +4,7 @@ ARG CUDNN="7"
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
 ARG MMCV="1.3.17"
-ARG MMDET="2.19.1"
+ARG MMDET="2.20.0"
 
 ENV PYTHONUNBUFFERED TRUE
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -8,32 +8,25 @@
 - Support resuming from the latest checkpoint automatically (#6727)
 
 #### Bug Fixes
+
 - Fix yolox ci failed (#6864)
 - Fix wrong bbox loss_weight of the PAA head (#6744)
 - Fix the padding value of `gt_semantic_seg` in batch collating (#6837)
 - Fix test error of lvis when using `classwise` (#6845)
-- Avoid get_local_path bc-breaking (#6719)
-- Fix norm sync bug (#6852)
-- Cancel previous runs that are not completed in workflow (#6772)
+- Avoid BC-breaking of `get_local_path`  (#6719)
+- Fix bug in `sync_norm_hook` when the BN layer does not exist (#6852)
 - Use pycocotools directly no matter what platform it is (#6838)
 
 #### Improvements
+
 - Add unit test for SimOTA with no valid bbox (#6770)
 - Use precommit to check readme (#6802)
 - Support selecting GPU-ids in non-distributed testing time (#6781)
-
-#### Documents
-- Update docs/conf.py and docs_zh-CN/conf.py to use shared items (#6801)
-- Add MMRazor and MMSelfSup in readme (#6874)
-- Update comments in base detector (#6795)
-- Fix link (#6796)
-- Fix typo (#6865)
 
 #### Contributors
 
 A total of 12 developers contributed to this release.
 Thanks @ZwwWayne, @Czm369, @jshilong, @RangiLyu, @BIGWangYuDong, @hhaAndroid, @jamiechoi1995, @AronLin, @Keiku, @gkagkos, @fcakyon, @www516717402
-
 
 ### v2.19.1 (14/12/2021)
 

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -12,6 +12,10 @@
 - Fix wrong bbox loss_weight of the PAA head (#6744)
 - Fix the padding value of `gt_semantic_seg` in batch collating (#6837)
 - Fix test error of lvis when using `classwise` (#6845)
+- Avoid get_local_path bc-breaking (#6719)
+- Fix norm sync bug (#6852)
+- Cancel previous runs that are not completed in workflow (#6772)
+- Use pycocotools directly no matter what platform it is (#6838)
 
 #### Improvements
 - Add unit test for SimOTA with no valid bbox (#6770)
@@ -27,8 +31,8 @@
 
 #### Contributors
 
-A total of 10 developers contributed to this release.
-Thanks @ZwwWayne, @Czm369, @jshilong, @RangiLyu, @BIGWangYuDong, @hhaAndroid, @jamiechoi1995, @AronLin, @Keiku, @gkagkos
+A total of 12 developers contributed to this release.
+Thanks @ZwwWayne, @Czm369, @jshilong, @RangiLyu, @BIGWangYuDong, @hhaAndroid, @jamiechoi1995, @AronLin, @Keiku, @gkagkos, @fcakyon, @www516717402
 
 
 ### v2.19.1 (14/12/2021)

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -9,8 +9,7 @@
 
 #### Bug Fixes
 
-- Fix yolox ci failed (#6864)
-- Fix wrong bbox loss_weight of the PAA head (#6744)
+- Fix wrong bbox `loss_weight` of the PAA head (#6744)
 - Fix the padding value of `gt_semantic_seg` in batch collating (#6837)
 - Fix test error of lvis when using `classwise` (#6845)
 - Avoid BC-breaking of `get_local_path`  (#6719)

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,5 +1,36 @@
 ## Changelog
 
+### v2.20.0 (27/12/2021)
+
+#### New Features
+
+- Support [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection (ICCV 2021 Oral) (#6746)
+- Support resuming from the latest checkpoint automatically (#6727)
+
+#### Bug Fixes
+- Fix yolox ci failed (#6864)
+- Fix wrong bbox loss_weight of the PAA head (#6744)
+- Fix the padding value of `gt_semantic_seg` in batch collating (#6837)
+- Fix test error of lvis when using `classwise` (#6845)
+
+#### Improvements
+- Add unit test for SimOTA with no valid bbox (#6770)
+- Use precommit to check readme (#6802)
+- Support selecting GPU-ids in non-distributed testing time (#6781)
+
+#### Documents
+- Update docs/conf.py and docs_zh-CN/conf.py to use shared items (#6801)
+- Add MMRazor and MMSelfSup in readme (#6874)
+- Update comments in base detector (#6795)
+- Fix link (#6796)
+- Fix typo (#6865)
+
+#### Contributors
+
+A total of 10 developers contributed to this release.
+Thanks @ZwwWayne, @Czm369, @jshilong, @RangiLyu, @BIGWangYuDong, @hhaAndroid, @jamiechoi1995, @AronLin, @Keiku, @gkagkos
+
+
 ### v2.19.1 (14/12/2021)
 
 #### New Features

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -12,6 +12,7 @@ Compatible MMDetection and MMCV versions are shown as below. Please install the 
 | MMDetection version |    MMCV version     |
 |:-------------------:|:-------------------:|
 | master              | mmcv-full>=1.3.17, <1.5.0 |
+| 2.20.0              | mmcv-full>=1.3.17, <1.5.0 |
 | 2.19.1              | mmcv-full>=1.3.17, <1.5.0 |
 | 2.19.0              | mmcv-full>=1.3.17, <1.5.0 |
 | 2.18.0              | mmcv-full>=1.3.17, <1.4.0 |

--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -16,7 +16,7 @@ def digit_version(version_str):
     return digit_version
 
 
-mmcv_minimum_version = '1.3.8'
+mmcv_minimum_version = '1.3.17'
 mmcv_maximum_version = '1.5.0'
 mmcv_version = digit_version(mmcv.__version__)
 

--- a/mmdet/version.py
+++ b/mmdet/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-__version__ = '2.19.1'
+__version__ = '2.20.0'
 short_version = __version__
 
 


### PR DESCRIPTION
## Motivation
Bump to version v2.20.0.

## Changelog

### v2.20.0 (27/12/2021)

#### New Features

- Support [TOOD](configs/tood/README.md): Task-aligned One-stage Object Detection (ICCV 2021 Oral) (#6746)
- Support resuming from the latest checkpoint automatically (#6727)

#### Bug Fixes
- Fix yolox ci failed (#6864)
- Fix wrong bbox loss_weight of the PAA head (#6744)
- Fix the padding value of `gt_semantic_seg` in batch collating (#6837)
- Fix test error of lvis when using `classwise` (#6845)
- Avoid get_local_path bc-breaking (#6719)
- Fix norm sync bug (#6852)
- Cancel previous runs that are not completed in the workflow (#6772)
- Use pycocotools directly no matter what platform it is (#6838)

#### Improvements
- Add unit test for SimOTA with no valid bbox (#6770)
- Use precommit to check readme (#6802)
- Support selecting GPU-ids in non-distributed testing time (#6781)

#### Documents
- Update docs/conf.py and docs_zh-CN/conf.py to use shared items (#6801)
- Add MMRazor and MMSelfSup in readme (#6874)
- Update comments in base detector (#6795)
- Fix link (#6796)
- Fix typo (#6865)

#### Contributors

A total of 12 developers contributed to this release.
Thanks @ZwwWayne, @Czm369, @jshilong, @RangiLyu, @BIGWangYuDong, @hhaAndroid, @jamiechoi1995, @AronLin, @Keiku, @gkagkos, @fcakyon, @www516717402
