### PR TITLE
Fix BadZipFile Error when build docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,12 +13,13 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
     && rm -rf /var/lib/apt/lists/*
 
 # Install MMCV
-RUN pip install mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
+RUN pip install --no-cache-dir -U pip wheel setuptools 
+RUN pip install --no-cache-dir mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
 
 # Install MMDetection
 RUN conda clean --all
 RUN git clone https://github.com/open-mmlab/mmdetection.git /mmdetection
 WORKDIR /mmdetection
 ENV FORCE_CUDA="1"
-RUN pip install -r requirements/build.txt
+RUN pip install --no-cache-dir -r requirements/build.txt
 RUN pip install --no-cache-dir -e .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
     && rm -rf /var/lib/apt/lists/*
 
 # Install MMCV
-RUN pip install --no-cache-dir -U pip wheel setuptools
+RUN pip install --no-cache-dir --upgrade pip wheel setuptools
 RUN pip install --no-cache-dir mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
 
 # Install MMDetection

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
     && rm -rf /var/lib/apt/lists/*
 
 # Install MMCV
-RUN pip install --no-cache-dir -U pip wheel setuptools 
+RUN pip install --no-cache-dir -U pip wheel setuptools
 RUN pip install --no-cache-dir mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
 
 # Install MMDetection


### PR DESCRIPTION
Fix "BadZipFile Error" when build docker. "BadZipFile Error" is same as [mmcv #1352](https://github.com/open-mmlab/mmcv/issues/1352)

```
(base) ➜  mmdetection git:(master) docker build -t mmdet docker/
Sending build context to Docker daemon  7.168kB
Step 1/15 : ARG PYTORCH="1.6.0"
Step 2/15 : ARG CUDA="10.1"
Step 3/15 : ARG CUDNN="7"
Step 4/15 : FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 ---> bb833e4d631f
Step 5/15 : ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ---> Using cache
 ---> db65124ef61d
Step 6/15 : ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ---> Using cache
 ---> d83a99117aa2
Step 7/15 : ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
 ---> Using cache
 ---> 7bfd23a73348
Step 8/15 : RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 lib
xrender-dev libxext6     && apt-get clean     && rm -rf /var/lib/apt/lists/*
 ---> Using cache
 ---> 97e88db9944a
Step 9/15 : RUN pip install mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.ht
ml
 ---> Running in c298acc26563
Looking in links: https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
Collecting mmcv-full==1.3.17
  Downloading https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/mmcv_full-1.3.17-cp37-cp37m-manylinux1_x86_
64.whl (41.7 MB)
ERROR: Exception:
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 186, in _main
    status = self.run(options, args)
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 331, in run
    resolver.resolve(requirement_set)
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/legacy_resolve.py", line 177, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/legacy_resolve.py", line 333, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/legacy_resolve.py", line 282, in _get_abstract_dist_fo
r
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 482, in prepare_linked_re
quirement
    hashes=hashes,
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 287, in unpack_url
    hashes=hashes,
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 164, in unpack_http_url
    unpack_file(from_path, location, content_type)
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/utils/unpacking.py", line 252, in unpack_file
    flatten=not filename.endswith('.whl')
  File "/opt/conda/lib/python3.7/site-packages/pip/_internal/utils/unpacking.py", line 114, in unzip_file
    zip = zipfile.ZipFile(zipfp, allowZip64=True)
  File "/opt/conda/lib/python3.7/zipfile.py", line 1258, in __init__
    self._RealGetContents()
  File "/opt/conda/lib/python3.7/zipfile.py", line 1325, in _RealGetContents
    raise BadZipFile("File is not a zip file")
zipfile.BadZipFile: File is not a zip file
The command '/bin/sh -c pip install mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/
index.html' returned a non-zero code: 2
```
