### PR TITLE
[Enhance] Continue to speed up training.

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -14,3 +14,8 @@ log_level = 'INFO'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+
+# disable opencv multithreading to avoid system being overloaded
+opencv_num_threads = 0
+# set multi-process start method as `fork` to speed up the training
+mp_start_method = 'fork'

--- a/tools/train.py
+++ b/tools/train.py
@@ -1,8 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 import copy
+import multiprocessing as mp
 import os
 import os.path as osp
+import platform
 import time
 import warnings
 
@@ -18,8 +20,6 @@ from mmdet.apis import init_random_seed, set_random_seed, train_detector
 from mmdet.datasets import build_dataset
 from mmdet.models import build_detector
 from mmdet.utils import collect_env, get_root_logger
-
-cv2.setNumThreads(0)
 
 
 def parse_args():
@@ -91,12 +91,50 @@ def parse_args():
     return args
 
 
+def setup_multi_processes(cfg):
+    # set multi-process start method as `fork` to speed up the training
+    if platform.system() != 'Windows':
+        mp.set_start_method('fork')
+
+    # disable opencv multithreading to avoid overwheleming
+    cv2.setNumThreads(0)
+
+    # setup OMP threads
+    # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
+    if ('OMP_NUM_THREADS' not in os.environ and cfg.data.workers_per_gpu > 1):
+        omp_num_threads = 1
+        warnings.warn(
+            f'\n*****************************************\n'
+            f'Setting OMP_NUM_THREADS environment variable for each process '
+            f'to be {omp_num_threads} in default, to avoid your system being '
+            f'overloaded, please further tune the variable for optimal '
+            f'performance in your application as needed. \n'
+            f'*****************************************')
+        os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
+
+    # setup MKL threads
+    if 'MKL_NUM_THREADS' not in os.environ and cfg.data.workers_per_gpu > 1:
+        mkl_num_threads = 1
+        warnings.warn(
+            f'\n*****************************************\n'
+            f'Setting MKL_NUM_THREADS environment variable for each process '
+            f'to be {mkl_num_threads} in default, to avoid your system being '
+            f'overloaded, please further tune the variable for optimal '
+            f'performance in your application as needed. \n'
+            f'*****************************************')
+        os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)
+
+
 def main():
     args = parse_args()
 
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
+
+    # set multi-process settings
+    setup_multi_processes(cfg)
+
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True

--- a/tools/train.py
+++ b/tools/train.py
@@ -94,34 +94,32 @@ def parse_args():
 def setup_multi_processes(cfg):
     # set multi-process start method as `fork` to speed up the training
     if platform.system() != 'Windows':
-        mp.set_start_method('fork')
+        mp_start_method = cfg.get('mp_start_method', 'fork')
+        mp.set_start_method(mp_start_method)
 
-    # disable opencv multithreading to avoid overwheleming
-    cv2.setNumThreads(0)
+    # disable opencv multithreading to avoid system being overloaded
+    opencv_num_threads = cfg.get('opencv_num_threads', 0)
+    cv2.setNumThreads(opencv_num_threads)
 
     # setup OMP threads
     # This code is referred from https://github.com/pytorch/pytorch/blob/master/torch/distributed/run.py  # noqa
     if ('OMP_NUM_THREADS' not in os.environ and cfg.data.workers_per_gpu > 1):
         omp_num_threads = 1
         warnings.warn(
-            f'\n*****************************************\n'
             f'Setting OMP_NUM_THREADS environment variable for each process '
             f'to be {omp_num_threads} in default, to avoid your system being '
             f'overloaded, please further tune the variable for optimal '
-            f'performance in your application as needed. \n'
-            f'*****************************************')
+            f'performance in your application as needed.')
         os.environ['OMP_NUM_THREADS'] = str(omp_num_threads)
 
     # setup MKL threads
     if 'MKL_NUM_THREADS' not in os.environ and cfg.data.workers_per_gpu > 1:
         mkl_num_threads = 1
         warnings.warn(
-            f'\n*****************************************\n'
             f'Setting MKL_NUM_THREADS environment variable for each process '
             f'to be {mkl_num_threads} in default, to avoid your system being '
             f'overloaded, please further tune the variable for optimal '
-            f'performance in your application as needed. \n'
-            f'*****************************************')
+            f'performance in your application as needed.')
         os.environ['MKL_NUM_THREADS'] = str(mkl_num_threads)
 
 


### PR DESCRIPTION
# Motivation

This PR continues on #6867.

Not only limit the opencv multi-processing but also set OMP and MKL threads to 1 if not set in the environment.
Also, switch the start method from spawn to fork to speed up the start time.

# Comparison

## V100 x8

system info:
```
sys.platform: linux                                                                                                                                                                                                                                    
Python: 3.8.11 (default, Aug  3 2021, 15:09:35) [GCC 7.5.0]                                                                                                                                                                                            
CUDA available: True                                                                                                                                                                                                                                   
GPU 0,1,2,3,4,5,6,7: Tesla V100-SXM2-32GB                                                                                                                                                                                                              
CUDA_HOME: /mnt/lustre/share/cuda-11.2
NVCC: Build cuda_11.2.r11.2/compiler.29618528_0
GCC: gcc (GCC) 5.4.0
PyTorch: 1.9.0
TorchVision: 0.10.0
OpenCV: 4.5.3
MMCV: 1.4.0
MMCV Compiler: GCC 5.4
MMCV CUDA Compiler: 11.2
MMDetection: 2.20.0+ff9bc39
```

### YOLOX-s

launcher: slurm
workers per GPU: 8
file client: s3

OMP&MKL Thread | OpenCV thread | MP start method | Start time | datatime | time | Eta @ 3 epoch 1400 iter
-- | -- | -- | -- | -- | -- | --
default | default | spawn | 10min | 0.030 | 0.334 | 2 days, 11:10:22
default | 0 | spawn | 10min | 0.034 | 0.275 | 2 days, 3:03:15
1 | default | spawn | 9min | 0.027 | 0.297 | 2 days, 5:27:36
default | default | fork | 36s | 0.027 | 0.327 | 2 days, 1:39:53
1 | 0 | fork | 24s | 0.025 | 0.268 | 1 day, 18:31:02

### Faster RCNN

launcher: slurm
workers per GPU: 2
file client: s3

OMP&MKL Thread | OpenCV thread | MP start method | Start time | datatime | time | Eta @ 1 epoch 4000 iter
-- | -- | -- | -- | -- | -- | --
default | default | spawn | 1min19s | 0.011 | 0.483 | 11:40:39
1 | 0 | fork | 12s | 0.010 | 0.232 | 5:32:23


## A100 x8

```
sys.platform: linux
Python: 3.7.11 (default, Jul 27 2021, 14:32:16) [GCC 7.5.0]
CUDA available: True
GPU 0,1,2,3,4,5,6,7: A100-SXM-80GB
CUDA_HOME: /usr/local/cuda
NVCC: Build cuda_11.2.r11.2/compiler.29618528_0
GCC: gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)
PyTorch: 1.10.1
TorchVision: 0.11.2
OpenCV: 4.5.5
MMCV: 1.4.2
MMCV Compiler: GCC 7.3
MMCV CUDA Compiler: 11.1
MMDetection: 2.20.0+ff9bc39
```

### YOLOX-s

launcher: torch
workers per GPU: 8
file client: hard disk

OMP&MKL Thread | OpenCV thread | MP start method | Start time | datatime | time | Eta @ 3 epoch 1400 iter
-- | -- | -- | -- | -- | -- | --
num CPU core | default | spawn | 7min | 0.039 | 0.317 | 2 days, 5:46:18
1 | default | spawn | 5min | 0.036 | 0.308 | 2 days, 3:07:02
1 | default | fork | 10s | 0.035 | 0.298 | 2 days, 1:57:50
1 | 0 | fork | 10s | 0.016 | 0.189 | 1 day, 5:08:11