### PR TITLE
fix end_level in FPN when end_level==len(input)

### DIFF
--- a/mmdet/models/necks/fpn.py
+++ b/mmdet/models/necks/fpn.py
@@ -85,13 +85,14 @@ class FPN(BaseModule):
         self.fp16_enabled = False
         self.upsample_cfg = upsample_cfg.copy()
 
-        if end_level == -1:
+        if end_level == -1 or end_level == self.num_ins:
+            # if end_level == len(inputs) or end_level == -1, extra level is allowed
             self.backbone_end_level = self.num_ins
             assert num_outs >= self.num_ins - start_level
         else:
             # if end_level < inputs, no extra level is allowed
             self.backbone_end_level = end_level
-            assert end_level <= len(in_channels)
+            assert end_level < len(in_channels)
             assert num_outs == end_level - start_level
         self.start_level = start_level
         self.end_level = end_level


### PR DESCRIPTION
Motivation
```
from mmdet.models.necks import FPN
fpn = FPN(in_channels=[256,512,1024,2048],
          out_channels=256,
          start_level=0,  
          end_level=4,  # when end_level == len(in_channels)
          add_extra_convs='on_input',
          num_outs=5)
```
but get AssertionError：assert num_outs == end_level - start_level.
when change the end_level=-1, run successfully.
However, ```end_level=-1``` is equal to ```end_level=len(inputs)```, the assertionerror shouldn't happen.

Modification
To fix the bug, just change the if condition
```
if end_level == -1 or end_level == self.num_ins:
```
