### PR TITLE
[Fix] Keep the same weights before reassign in the PAA head

### DIFF
--- a/mmdet/models/dense_heads/paa_head.py
+++ b/mmdet/models/dense_heads/paa_head.py
@@ -241,14 +241,14 @@ class PAAHead(ATSSHead):
             pos_scores,
             pos_label,
             pos_label_weight,
-            avg_factor=self.loss_cls.loss_weight,
+            avg_factor=1.0,
             reduction_override='none')
 
         loss_bbox = self.loss_bbox(
             pos_bbox_pred,
             pos_bbox_target,
             pos_bbox_weight,
-            avg_factor=self.loss_bbox.loss_weight,
+            avg_factor=1.0,  # keep same loss weight before reassign
             reduction_override='none')
 
         loss_cls = loss_cls.sum(-1)


### PR DESCRIPTION
## Motivation

Worried about "Fix wrong bbox loss_weight of the PAA head (#6744)" in MMDetection V2.20.0.

According to the PAA's source code, it seems that the authors calculated the cls_loss and reg_loss with the same weight (always equal to 1.0) before reassignment, and calculated the final loss with different loss_weight

https://github.com/kkhoot/PAA/blob/master/paa_core/modeling/rpn/paa/loss.py#L306
https://github.com/kkhoot/PAA/blob/master/paa_core/modeling/rpn/paa/loss.py#L356

## Modification

Before reassignment, always set loss_weight as 1.0 (maybe it will lead to some confusion for setting all losses as self.loss_cls.loss_weight)
