### PR TITLE
[Fix] Put the `mAP` at the front of OrderedDict in VOCDataset

### DIFF
--- a/mmdet/datasets/voc.py
+++ b/mmdet/datasets/voc.py
@@ -92,6 +92,7 @@ class VOCDataset(XMLDataset):
                 mean_aps.append(mean_ap)
                 eval_results[f'AP{int(iou_thr * 100):02d}'] = round(mean_ap, 3)
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
+            eval_results.move_to_end('mAP', last=False)
         elif metric == 'recall':
             gt_bboxes = [ann['bboxes'] for ann in annotations]
             recalls = eval_recalls(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In VOCDdataset, the first item of output is `AP50`. When setting `save_best` as `auto` in evaluation, the `EvalHook` can not match a rule for `AP50` and will raise an error #7061. Thus, I put the `mAP` at the front of OrderedDict in VOCDataset. 

## Modification

Add `eval_results.move_to_end('mAP', last=False)` in VOCDataset.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
