### PR TITLE
[Feature] utilize mmcv image backend

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -32,16 +32,20 @@ class LoadImageFromFile:
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmcv.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.
+        image_backend (str): The backend argument for :func:`mmcv.imfrombytes`.
+            Defaults to None.
     """
 
     def __init__(self,
                  to_float32=False,
                  color_type='color',
-                 file_client_args=dict(backend='disk')):
+                 file_client_args=dict(backend='disk'),
+                 image_backend=None):
         self.to_float32 = to_float32
         self.color_type = color_type
         self.file_client_args = file_client_args.copy()
         self.file_client = None
+        self.image_backend = image_backend
 
     def __call__(self, results):
         """Call functions to load image and get image meta information.
@@ -63,7 +67,8 @@ class LoadImageFromFile:
             filename = results['img_info']['filename']
 
         img_bytes = self.file_client.get(filename)
-        img = mmcv.imfrombytes(img_bytes, flag=self.color_type)
+        img = mmcv.imfrombytes(
+            img_bytes, flag=self.color_type, backend=self.image_backend)
         if self.to_float32:
             img = img.astype(np.float32)
 


### PR DESCRIPTION
Currently [LoadImageFromFile](https://github.com/fcakyon/mmdetection/blob/ff9bc39913cb3ff5dde79d3933add7dc2561bab7/mmdet/datasets/pipelines/loading.py#L66) pipeline doesnt support loading mmcv image backends as `pillow,tifffile...` but [mmcv](https://github.com/open-mmlab/mmcv/blob/b8d78336a791a2c1dda294890da35c8a5013cc77/mmcv/image/io.py#L165) supports it.

This PR adds the support of using other mmcv image backends.