### PR TITLE
[Fix] Fix bbox clamp in pt1.10

### DIFF
--- a/mmdet/models/dense_heads/autoassign_head.py
+++ b/mmdet/models/dense_heads/autoassign_head.py
@@ -197,7 +197,7 @@ class AutoAssignHead(FCOSHead):
         # scale the bbox_pred of different level
         # float to avoid overflow when enabling FP16
         bbox_pred = scale(bbox_pred).float()
-        bbox_pred = F.relu(bbox_pred)
+        bbox_pred = bbox_pred.clamp(min=0)
         bbox_pred *= stride
         return cls_score, bbox_pred, centerness
 

--- a/mmdet/models/dense_heads/fcos_head.py
+++ b/mmdet/models/dense_heads/fcos_head.py
@@ -3,7 +3,6 @@ import warnings
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 from mmcv.cnn import Scale
 from mmcv.runner import force_fp32
 
@@ -155,7 +154,7 @@ class FCOSHead(AnchorFreeHead):
         # float to avoid overflow when enabling FP16
         bbox_pred = scale(bbox_pred).float()
         if self.norm_on_bbox:
-            bbox_pred = F.relu(bbox_pred)
+            bbox_pred = bbox_pred.clamp(min=0)
             if not self.training:
                 bbox_pred *= stride
         else:


### PR DESCRIPTION
## Motivation
FCOS and AutoAssign cannot run with PyTorch 1.10. 
Error message:
```
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [2, 4, 20, 20]], which is output 0 of ReluBackward0, is at version 1; expected version 0 instead.
```

After using  `with torch.autograd.set_detect_anomaly(True):` to debug and find out that it was caused by the ReLU in bbox branch.

## Modification

Replace `F.relu(bbox_pred)` with `bbox_pred.clamp(min=0)`
