### PR TITLE
Fix None grad problem during training TOOD by adding SigmoidGeometricMean

### DIFF
--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -9,6 +9,7 @@ from mmcv.runner import force_fp32
 from mmdet.core import (anchor_inside_flags, build_assigner, distance2bbox,
                         images_to_levels, multi_apply, reduce_mean, unmap)
 from mmdet.core.utils import filter_scores_and_topk
+from mmdet.models.utils import SigmoidGeometricMean
 from ..builder import HEADS, build_loss
 from .atss_head import ATSSHead
 
@@ -245,7 +246,7 @@ class TOODHead(ATSSHead):
             # cls prediction and alignment
             cls_logits = self.tood_cls(cls_feat)
             cls_prob = self.cls_prob_module(feat)
-            cls_score = (cls_logits.sigmoid() * cls_prob.sigmoid()).sqrt()
+            cls_score = SigmoidGeometricMean.apply(cls_logits, cls_prob)
 
             # reg prediction and alignment
             if self.anchor_type == 'anchor_free':

--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -9,7 +9,7 @@ from mmcv.runner import force_fp32
 from mmdet.core import (anchor_inside_flags, build_assigner, distance2bbox,
                         images_to_levels, multi_apply, reduce_mean, unmap)
 from mmdet.core.utils import filter_scores_and_topk
-from mmdet.models.utils import SigmoidGeometricMean
+from mmdet.models.utils import sigmoid_geometric_mean
 from ..builder import HEADS, build_loss
 from .atss_head import ATSSHead
 
@@ -246,7 +246,7 @@ class TOODHead(ATSSHead):
             # cls prediction and alignment
             cls_logits = self.tood_cls(cls_feat)
             cls_prob = self.cls_prob_module(feat)
-            cls_score = SigmoidGeometricMean.apply(cls_logits, cls_prob)
+            cls_score = sigmoid_geometric_mean(cls_logits, cls_prob)
 
             # reg prediction and alignment
             if self.anchor_type == 'anchor_free':

--- a/mmdet/models/utils/__init__.py
+++ b/mmdet/models/utils/__init__.py
@@ -7,7 +7,7 @@ from .csp_layer import CSPLayer
 from .gaussian_target import gaussian_radius, gen_gaussian_target
 from .inverted_residual import InvertedResidual
 from .make_divisible import make_divisible
-from .misc import interpolate_as
+from .misc import SigmoidGeometricMean, interpolate_as
 from .normed_predictor import NormedConv2d, NormedLinear
 from .positional_encoding import (LearnedPositionalEncoding,
                                   SinePositionalEncoding)
@@ -25,5 +25,5 @@ __all__ = [
     'NormedLinear', 'NormedConv2d', 'make_divisible', 'InvertedResidual',
     'SELayer', 'interpolate_as', 'ConvUpsample', 'CSPLayer',
     'adaptive_avg_pool2d', 'AdaptiveAvgPool2d', 'PatchEmbed', 'nchw_to_nlc',
-    'nlc_to_nchw', 'pvt_convert'
+    'nlc_to_nchw', 'pvt_convert', 'SigmoidGeometricMean'
 ]

--- a/mmdet/models/utils/__init__.py
+++ b/mmdet/models/utils/__init__.py
@@ -7,7 +7,7 @@ from .csp_layer import CSPLayer
 from .gaussian_target import gaussian_radius, gen_gaussian_target
 from .inverted_residual import InvertedResidual
 from .make_divisible import make_divisible
-from .misc import SigmoidGeometricMean, interpolate_as
+from .misc import interpolate_as, sigmoid_geometric_mean
 from .normed_predictor import NormedConv2d, NormedLinear
 from .positional_encoding import (LearnedPositionalEncoding,
                                   SinePositionalEncoding)
@@ -25,5 +25,5 @@ __all__ = [
     'NormedLinear', 'NormedConv2d', 'make_divisible', 'InvertedResidual',
     'SELayer', 'interpolate_as', 'ConvUpsample', 'CSPLayer',
     'adaptive_avg_pool2d', 'AdaptiveAvgPool2d', 'PatchEmbed', 'nchw_to_nlc',
-    'nlc_to_nchw', 'pvt_convert', 'SigmoidGeometricMean'
+    'nlc_to_nchw', 'pvt_convert', 'sigmoid_geometric_mean'
 ]

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -29,6 +29,9 @@ class SigmoidGeometricMean(Function):
         return grad_x, grad_y
 
 
+sigmoid_geometric_mean = SigmoidGeometricMean.apply
+
+
 def interpolate_as(source, target, mode='bilinear', align_corners=False):
     """Interpolate the `source` to the shape of the `target`.
 

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -1,5 +1,32 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from torch.autograd import Function
 from torch.nn import functional as F
+
+
+class SigmoidGeometricMean(Function):
+    """Forward and backward function of geometric mean of two sigmoid
+    functions.
+
+    This implementation with analytical gradient function substitutes
+    the autograd function of (x.sigmoid() * y.sigmoid()).sqrt(). The
+    original implementation incurs none during gradient backprapagation
+    if both x and y are very small values.
+    """
+
+    @staticmethod
+    def forward(ctx, x, y):
+        x_sigmoid = x.sigmoid()
+        y_sigmoid = y.sigmoid()
+        z = (x_sigmoid * y_sigmoid).sqrt()
+        ctx.save_for_backward(x_sigmoid, y_sigmoid, z)
+        return z
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x_sigmoid, y_sigmoid, z = ctx.saved_tensors
+        grad_x = grad_output * z * (1 - x_sigmoid) / 2
+        grad_y = grad_output * z * (1 - y_sigmoid) / 2
+        return grad_x, grad_y
 
 
 def interpolate_as(source, target, mode='bilinear', align_corners=False):

--- a/tests/test_models/test_dense_heads/test_tood_head.py
+++ b/tests/test_models/test_dense_heads/test_tood_head.py
@@ -5,7 +5,7 @@ import torch
 from mmdet.models.dense_heads import TOODHead
 
 
-def test_paa_head_loss():
+def test_tood_head_loss():
     """Tests paa head loss when truth is empty and non-empty."""
 
     s = 256

--- a/tests/test_models/test_utils/test_model_misc.py
+++ b/tests/test_models/test_utils/test_model_misc.py
@@ -1,8 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
 import torch
+from torch.autograd import gradcheck
 
-from mmdet.models.utils import interpolate_as
+from mmdet.models.utils import SigmoidGeometricMean, interpolate_as
 
 
 def test_interpolate_as():
@@ -25,3 +26,11 @@ def test_interpolate_as():
     target = np.random.rand(16, 16)
     result = interpolate_as(source.squeeze(0), target)
     assert result.shape == torch.Size((5, 16, 16))
+
+
+def test_sigmoid_geometric_mean():
+    x = torch.randn(20, 20, dtype=torch.double, requires_grad=True)
+    y = torch.randn(20, 20, dtype=torch.double, requires_grad=True)
+    inputs = (x, y)
+    test = gradcheck(SigmoidGeometricMean.apply, inputs, eps=1e-6, atol=1e-4)
+    assert test

--- a/tests/test_models/test_utils/test_model_misc.py
+++ b/tests/test_models/test_utils/test_model_misc.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 from torch.autograd import gradcheck
 
-from mmdet.models.utils import SigmoidGeometricMean, interpolate_as
+from mmdet.models.utils import interpolate_as, sigmoid_geometric_mean
 
 
 def test_interpolate_as():
@@ -32,5 +32,5 @@ def test_sigmoid_geometric_mean():
     x = torch.randn(20, 20, dtype=torch.double, requires_grad=True)
     y = torch.randn(20, 20, dtype=torch.double, requires_grad=True)
     inputs = (x, y)
-    test = gradcheck(SigmoidGeometricMean.apply, inputs, eps=1e-6, atol=1e-4)
+    test = gradcheck(sigmoid_geometric_mean, inputs, eps=1e-6, atol=1e-4)
     assert test


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The training of TOOD often encounters None gradient during backpropagation, which would further cause None tensors in the next training step. Some issues in the original repo (https://github.com/fcjian/TOOD/issues/11) might be also due to this error. The problem is caused by the naive implementation of sigmoid geometric mean function ``cls_score = (cls_logits.sigmoid() * cls_prob.sigmoid()).sqrt()``. This output might be 0 if  ``cls_logits`` or ``cls_prob`` is a low negative value, which causes either inf grad of none grad during backpropagation. 

## Modification

A reimplementation of ``SigmoidGeometricMean`` class as an inheritance of ``torch.autograd.Function`` is proposed. The backward function is derived analytically and would avoid and inf or none grad during bp. 
- This modification has little influence on the final results (42.3 mAP after modification vs. 42.4 mAP as reported).
- This modification enables users to train TOOD without ATSS warmup, yet with some performance drop (~41.8 mAP)

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] This PR does not involve any function interface change.
- [x] Docstring has been added.
