### PR TITLE
[feature]增加cpu可以支持的运行 add a **cpu version** of training-api

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -72,6 +72,7 @@ def train_detector(model,
                    dataset,
                    cfg,
                    distributed=False,
+                   device='cuda',
                    validate=False,
                    timestamp=None,
                    meta=None):
@@ -120,8 +121,12 @@ def train_detector(model,
             broadcast_buffers=False,
             find_unused_parameters=find_unused_parameters)
     else:
-        model = MMDataParallel(
-            model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+        if device == 'cuda':
+            model = MMDataParallel(model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+        elif device == 'cpu':
+            model = model.cpu()
+        else:
+            raise ValueError(F'unsupported device name {device}.')
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -72,7 +72,6 @@ def train_detector(model,
                    dataset,
                    cfg,
                    distributed=False,
-                   device='cuda',
                    validate=False,
                    timestamp=None,
                    meta=None):
@@ -121,12 +120,14 @@ def train_detector(model,
             broadcast_buffers=False,
             find_unused_parameters=find_unused_parameters)
     else:
-        if device == 'cuda':
+        if digit_version(mmcv.__version__) >= digit_version('1.4.4'):
             model = MMDataParallel(model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
-        elif device == 'cpu':
-            model = model.cpu()
+        elif torch.cuda.is_available():
+            model = MMDataParallel(model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
         else:
-            raise ValueError(F'unsupported device name {device}.')
+            print('Recommand to use MMCV >= 1.4.4 for CPU training!')
+            print('Now we are using an earlier version for CPU training!')
+            model = model.cpu()
 
     # build runner
     optimizer = build_optimizer(model, cfg.optimizer)


### PR DESCRIPTION
        if device == 'cuda':
            model = MMDataParallel(model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
        elif device == 'cpu':
            model = model.cpu()
        else:
            raise ValueError(F'unsupported device name {device}.')

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

在mmcls的api中可以使用cpu训练，但mmdet不行。就是因为少了这几行代码，故再此处添加。

## Modification

在train_detector函数添加传参device，并且加入判断，看是否是cpu。从而决定模型在何处训练。
这样，默认device为cuda，原有的工程不会受影响，而增加了对cpu训练的支持。


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
