### PR TITLE
check error when the "image" field of json file of dataset is empty, which may lead to an empty dataloader

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -110,7 +110,9 @@ def train_detector(model,
     ]
     # assert an error due to the empty train dataloader
     for i_dataloader in data_loaders:
-        assert len(i_dataloader) != 0, "empty train dataloader, which may be due to the \"image\" field of json file"
+        assert len(i_dataloader) != 0, \
+            'empty train dataloader, ' \
+            'which may be due to the \"image\" field of json file'
 
     # put model on gpus
     if distributed:
@@ -191,7 +193,9 @@ def train_detector(model,
             dist=distributed,
             shuffle=False)
         # assert an error due to the empty validation dataloader
-        assert len(val_dataloader) != 0, "empty validation dataloader, which may be due to the \"image\" field of json file"
+        assert len(val_dataloader) != 0, \
+            'empty validation dataloader, ' \
+            'which may be due to the \"image\" field of json file'
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -108,6 +108,9 @@ def train_detector(model,
             persistent_workers=cfg.data.get('persistent_workers', False))
         for ds in dataset
     ]
+    # assert an error due to the empty train dataloader
+    for i_dataloader in data_loaders:
+        assert len(i_dataloader) != 0, "empty train dataloader, which may be due to the \"image\" field of json file"
 
     # put model on gpus
     if distributed:
@@ -187,6 +190,8 @@ def train_detector(model,
             workers_per_gpu=cfg.data.workers_per_gpu,
             dist=distributed,
             shuffle=False)
+        # assert an error due to the empty validation dataloader
+        assert len(val_dataloader) != 0, "empty validation dataloader, which may be due to the \"image\" field of json file"
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -108,11 +108,6 @@ def train_detector(model,
             persistent_workers=cfg.data.get('persistent_workers', False))
         for ds in dataset
     ]
-    # assert an error due to the empty train dataloader
-    for i_dataloader in data_loaders:
-        assert len(i_dataloader) != 0, \
-            'empty train dataloader, ' \
-            'which may be due to the \"image\" field of json file'
 
     # put model on gpus
     if distributed:
@@ -192,10 +187,6 @@ def train_detector(model,
             workers_per_gpu=cfg.data.workers_per_gpu,
             dist=distributed,
             shuffle=False)
-        # assert an error due to the empty validation dataloader
-        assert len(val_dataloader) != 0, \
-            'empty validation dataloader, ' \
-            'which may be due to the \"image\" field of json file'
         eval_cfg = cfg.get('evaluation', {})
         eval_cfg['by_epoch'] = cfg.runner['type'] != 'IterBasedRunner'
         eval_hook = DistEvalHook if distributed else EvalHook

--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -100,6 +100,10 @@ class CustomDataset(Dataset):
                 'might cause errors if the path is not a local path. '
                 'Please use MMCV>= 1.3.16 if you meet errors.')
             self.data_infos = self.load_annotations(self.ann_file)
+        # assert an error when the data info is empty
+        assert len(self.data_infos) != 0, \
+            'empty data_infos, ' \
+            'which may be due to the \"image\" field of annotation json file'
 
         if self.proposal_file is not None:
             if hasattr(self.file_client, 'get_local_path'):

--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -103,7 +103,7 @@ class CustomDataset(Dataset):
         # assert an error when the data info is empty
         assert len(self.data_infos) != 0, \
             'empty data_infos, ' \
-            'which may be due to the \"image\" field of annotation json file'
+            'Please check your dataset files'
 
         if self.proposal_file is not None:
             if hasattr(self.file_client, 'get_local_path'):


### PR DESCRIPTION
Check error when the "image" field of json file of dataset is empty, which may lead to an empty dataloader.
It could be an empty train dataloader or an empty validation dataloader.
This PR is related to the previous PR  #7123  and the previous issue  #7105
