### PR TITLE
[Fix] update albumentations installed way

### DIFF
--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -134,7 +134,7 @@ Or you can still install MMDetection manually:
     # for LVIS dataset
     pip install git+https://github.com/lvis-dataset/lvis-api.git
     # for albumentations
-    pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
+    pip install -r requirements/albu.txt
     ```
 
 **Note:**
@@ -148,9 +148,12 @@ you can install it before installing MMCV.
 c. Some dependencies are optional. Simply running `pip install -v -e .` will
  only install the minimum runtime requirements. To use optional dependencies like `albumentations` and `imagecorruptions` either install them manually with `pip install -r requirements/optional.txt` or specify desired extras when calling `pip` (e.g. `pip install -v -e .[optional]`). Valid keys for the extras field are: `all`, `tests`, `build`, and `optional`.
 
-d. If you would like to use `albumentations`, we suggest using
-`pip install albumentations>=0.3.2 --no-binary imgaug,albumentations`. If you simply use
-`pip install albumentations>=0.3.2`, it will install `opencv-python-headless` simultaneously (even though you have already installed `opencv-python`). We should not allow `opencv-python` and `opencv-python-headless` installed at the same time, because it might cause unexpected issues. Please refer to [official documentation](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies) for more details.
+d. If you would like to use `albumentations`, we suggest using `pip install -r requirements/albu.txt` or
+`pip install -U albumentations --no-binary qudida,albumentations`. If you simply use `pip install albumentations>=0.3.2`,
+it will install `opencv-python-headless` simultaneously (even though you have already
+installed `opencv-python`). We recommended checking the environment after installing `albumentation` to
+ensure that `opencv-python` and `opencv-python-headless` are not installed at the same time, because it might cause unexpected issues if they both installed. Please refer
+to [official documentation](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies) for more details.
 
 ### Install without GPU support
 

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -142,7 +142,7 @@ MIM 能够自动地安装 OpenMMLab 的项目以及对应的依赖包。
     # 安装 LVIS 数据集依赖
     pip install git+https://github.com/lvis-dataset/lvis-api.git
     # 安装 albumentations 依赖
-    pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
+    pip install -r requirements/albu.txt
     ```
 
 **注意：**
@@ -153,7 +153,7 @@ MIM 能够自动地安装 OpenMMLab 的项目以及对应的依赖包。
 
 (3) 一些安装依赖是可以选择的。例如只需要安装最低运行要求的版本，则可以使用 `pip install -v -e .` 命令。如果希望使用可选择的像 `albumentations` 和 `imagecorruptions` 这种依赖项，可以使用 `pip install -r requirements/optional.txt` 进行手动安装，或者在使用 `pip` 时指定所需的附加功能（例如 `pip install -v -e .[optional]`），支持附加功能的有效键值包括  `all`、`tests`、`build` 以及 `optional` 。
 
-(4) 如果希望使用 `albumentations`，我们建议使用 `pip install albumentations>=0.3.2 --no-binary imgaug,albumentations` 进行安装。 如果简单地使用 `pip install albumentations>=0.3.2` 进行安装，则会同时安装 `opencv-python-headless`（即便已经安装了 `opencv-python` 也会再次安装）。我们不允许同时安装 `opencv-python` 和 `opencv-python-headless`，因为这样可能会导致一些问题。更多细节请参考[官方文档](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies)。
+(4) 如果希望使用 `albumentations`，我们建议使用 `pip install -r requirements/albu.txt` 或者 `pip install -U albumentations --no-binary qudida,albumentations` 进行安装。 如果简单地使用 `pip install albumentations>=0.3.2` 进行安装，则会同时安装 `opencv-python-headless`（即便已经安装了 `opencv-python` 也会再次安装）。我们建议在安装 `albumentations` 后检查环境，以确保没有同时安装 `opencv-python` 和 `opencv-python-headless`，因为同时安装可能会导致一些问题。更多细节请参考[官方文档](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies)。
 
 ### 只在 CPU 安装
 

--- a/requirements/albu.txt
+++ b/requirements/albu.txt
@@ -1,0 +1,1 @@
+albumentations>=0.3.2 --no-binary qudida,albumentations


### PR DESCRIPTION
Continue to follow https://github.com/open-mmlab/mmdetection/pull/5868.

By default, installing `albumentations` by pip has `opencv-python-headless` dependency even if `opencv-python` has already been installed. This could cause different opencv versions installed in the environment and lead to unexpected errors. https://github.com/open-mmlab/mmdetection/pull/5868 has fixed this potential issue, but albumentations has updated their installing way, which changes `pip install albumentations --no-binary imgaug,albumentations` to `pip install -U albumentations --no-binary qudida,albumentations`. See its [docs](https://albumentations.ai/docs/getting_started/installation/#note-on-opencv-dependencies) for details.

If simply use `pip install albumentations>=0.3.2 --no-binary qudida,albumentations` may cause some error or installed opencv-python-headless simultaneously. so it is suggested to use `pip install -r requirements/albu.txt` or `pip install -U albumentations --no-binary qudida,albumentations` to install albu.