### PR TITLE
[Fix] confusion_matrix.py analysis tool NaN errors

### DIFF
--- a/tools/analysis_tools/confusion_matrix.py
+++ b/tools/analysis_tools/confusion_matrix.py
@@ -207,7 +207,10 @@ def plot_confusion_matrix(confusion_matrix,
             ax.text(
                 j,
                 i,
-                '{}%'.format(int(confusion_matrix[i, j])),
+                '{}%'.format(
+                    int(confusion_matrix[
+                        i,
+                        j]) if not np.isnan(confusion_matrix[i, j]) else -1),
                 ha='center',
                 va='center',
                 color='w',


### PR DESCRIPTION
## Motivation

Fixes #6965 

A ValueError is raised on confusion_matrix.py tool when the confusion matrix contains NaN values.
Commonly happens when you generate results.pkl with a validation/test dataset where some categories do not have a single datapoint.

Reproduced the error using a very small subset of COCO val2017 where most categories are missing images/annotations.

## Modification

Substituting NaN values for -1.
Assigning -1 makes the confusion matrix figure look like this (showing subregion):

![confusion_martix_handling_nans](https://user-images.githubusercontent.com/13849741/153717562-4ed2aae0-28d6-45e4-89ec-411842de5154.png)

The categories that don't have any datapoints are simply rendered as white empty cells.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. 
