### PR TITLE
Fix get_indexes method of pipelines

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2032,7 +2032,7 @@ class Mosaic:
             list: indexes.
         """
 
-        indexes = [random.randint(0, len(dataset)) for _ in range(3)]
+        indexes = [random.randint(0, len(dataset) - 1) for _ in range(3)]
         return indexes
 
     def _mosaic_transform(self, results):
@@ -2316,7 +2316,7 @@ class MixUp:
         """
 
         for i in range(self.max_iters):
-            index = random.randint(0, len(dataset))
+            index = random.randint(0, len(dataset) - 1)
             gt_bboxes_i = dataset.get_ann_info(index)['bboxes']
             if len(gt_bboxes_i) != 0:
                 break


### PR DESCRIPTION
## Motivation

get_indexes method in the pipelines has a potential problem if it draws len(dataset).

https://github.com/open-mmlab/mmdetection/blob/98949809b7179fab9391663ee5a4ab5978425f90/mmdet/datasets/dataset_wrappers.py#L408

## Modification
Fix it to len(dataset) -1.