### PR TITLE
[Fix] Fix wrong img name in onnx2tensorrt.py

### DIFF
--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -201,7 +201,7 @@ if __name__ == '__main__':
         parsed directly from config file and are deprecated and will be \
         removed in future releases.')
     if not args.input_img:
-        args.input_img = osp.join(osp.dirname(__file__), '../demo/demo.jpg')
+        args.input_img = osp.join(osp.dirname(__file__), '../../demo/demo.jpg')
 
     cfg = Config.fromfile(args.config)
 


### PR DESCRIPTION
Fix #7156

the original path of demo.jpg in onnx2tensorrt.py is different with that in pytorch2onnx.py
https://github.com/open-mmlab/mmdetection/blob/5e246d5e3bc3310b5c625fb57bc03d2338ca39bc/tools/deployment/pytorch2onnx.py#L328