### PR TITLE
remove self.training check for VFNet head

### DIFF
--- a/mmdet/models/dense_heads/vfnet_head.py
+++ b/mmdet/models/dense_heads/vfnet_head.py
@@ -301,10 +301,7 @@ class VFNetHead(ATSSHead, FCOSHead):
         cls_feat = self.relu(self.vfnet_cls_dconv(cls_feat, dcn_offset))
         cls_score = self.vfnet_cls(cls_feat)
 
-        if self.training:
-            return cls_score, bbox_pred, bbox_pred_refine
-        else:
-            return cls_score, bbox_pred_refine
+        return cls_score, bbox_pred, bbox_pred_refine
 
     def star_dcn_offset(self, bbox_pred, gradient_mul, stride):
         """Compute the star deformable conv offsets.


### PR DESCRIPTION
## Motivation

Self.training check causes error when model is validation mode because of inconsistent return values.

I find that the `forward_single` function returns three values `cls_score, bbox_pred, bbox_pred_refine` during training and returns only two values `cls_score, bbox_pred_refine` when it is not in training eg. validation.

## Modification

Remove the self.training check in the `forward_single` function.

Closes

https://github.com/open-mmlab/mmdetection/issues/6851

and 
https://github.com/open-mmlab/mmdetection/issues/7167