### PR TITLE
[Fix] Fix description for args in CSPDarknet

### DIFF
--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -128,9 +128,9 @@ class CSPDarknet(BaseModule):
         arch (str): Architecture of CSP-Darknet, from {P5, P6}.
             Default: P5.
         deepen_factor (float): Depth multiplier, multiply number of
-            channels in each layer by this amount. Default: 1.0.
-        widen_factor (float): Width multiplier, multiply number of
             blocks in CSP layer by this amount. Default: 1.0.
+        widen_factor (float): Width multiplier, multiply number of
+            channels in each layer by this amount. Default: 1.0.
         out_indices (Sequence[int]): Output from which stages.
             Default: (2, 3, 4).
         frozen_stages (int): Stages to be frozen (stop grad and set eval


### PR DESCRIPTION
Hi, Thanks for your great repo. It's been very helpful for my project. I deeply appreciate it!

## Motivation
In mmdet/models/backbones/csp_darknet.py, I found that the description for deepen_factor and widen_factor were interchanged like below. 
```python
        """
        deepen_factor (float): Depth multiplier, multiply number of
            channels in each layer by this amount. Default: 1.0.
        widen_factor (float): Width multiplier, multiply number of
            blocks in CSP layer by this amount. Default: 1.0.
        """
```
while they were being used as 
```python
            in_channels = int(in_channels * widen_factor)
            out_channels = int(out_channels * widen_factor)
```
```python
            num_blocks = max(round(num_blocks * deepen_factor), 1)
```

## Modification

The description should be fixed like below
```python
       """
        deepen_factor (float): Depth multiplier, multiply number of
            blocks in CSP layer by this amount. Default: 1.0.
        widen_factor (float): Width multiplier, multiply number of
            channels in each layer by this amount. Default: 1.0.
        """
```
## BC-breaking (Optional)

No.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.

