### PR TITLE
Fix broken link in Colab tutorial

### DIFF
--- a/demo/MMDet_Tutorial.ipynb
+++ b/demo/MMDet_Tutorial.ipynb
@@ -363,7 +363,7 @@
     "\n",
     "Usually we recommend to use the first two methods which are usually easier than the third.\n",
     "\n",
-    "In this tutorial, we gives an example that converting the data into the format of existing datasets like COCO, VOC, etc. Other methods and more advanced usages can be found in the [doc](https://mmdetection.readthedocs.io/en/latest/tutorials/new_dataset.html#).\n",
+    "In this tutorial, we gives an example that converting the data into the format of existing datasets like COCO, VOC, etc. Other methods and more advanced usages can be found in the [doc](https://mmdetection.readthedocs.io/en/latest/tutorials/customize_dataset.html).\n",
     "\n",
     "Firstly, let's download a tiny dataset obtained from [KITTI](http://www.cvlibs.net/datasets/kitti/eval_object.php?obj_benchmark=3d). We select the first 75 images and their annotations from the 3D object detection dataset (it is the same dataset as the 2D object detection dataset but has 3D annotations). We convert the original images from PNG to JPEG format with 80% quality to reduce the size of dataset."
    ]


### PR DESCRIPTION
## Motivation

Fix a broken link in Colab tutorial.

## Modification

Change broken [doc](https://mmdetection.readthedocs.io/en/latest/tutorials/new_dataset.html) to a valid [link](https://mmdetection.readthedocs.io/en/latest/tutorials/customize_dataset.html).
