### PR TITLE
[Fix] Fix PALETTE AttributeError in single_gpu_test

### DIFF
--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -22,7 +22,7 @@ def single_gpu_test(model,
     model.eval()
     results = []
     dataset = data_loader.dataset
-    PALETTE = dataset.PALETTE
+    PALETTE = getattr(dataset, 'PALETTE', None)
     prog_bar = mmcv.ProgressBar(len(dataset))
     for i, data in enumerate(data_loader):
         with torch.no_grad():


### PR DESCRIPTION
This PR aims to fix https://github.com/open-mmlab/mmdetection/issues/7224 and https://github.com/open-mmlab/mmdetection3d/issues/1259

https://github.com/open-mmlab/mmdetection/pull/7085 has fixed the same errors in `dataset_wrappers.py`, but the error in `single_gpu_test` remains.