### PR TITLE
[Enhance] Update YOLOX log for non square input

### DIFF
--- a/configs/yolox/yolox_s_8x8_300e_coco.py
+++ b/configs/yolox/yolox_s_8x8_300e_coco.py
@@ -1,6 +1,6 @@
 _base_ = ['../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py']
 
-img_scale = (640, 640)
+img_scale = (640, 640)  # height, width
 
 # model settings
 model = dict(

--- a/configs/yolox/yolox_tiny_8x8_300e_coco.py
+++ b/configs/yolox/yolox_tiny_8x8_300e_coco.py
@@ -7,7 +7,7 @@ model = dict(
     neck=dict(in_channels=[96, 192, 384], out_channels=96),
     bbox_head=dict(in_channels=96, feat_channels=96))
 
-img_scale = (640, 640)
+img_scale = (640, 640)  # height, width
 
 train_pipeline = [
     dict(type='Mosaic', img_scale=img_scale, pad_val=114.0),

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -11,6 +11,7 @@ from numpy import random
 
 from mmdet.core import PolygonMasks, find_inside_bboxes
 from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
+from mmdet.utils import log_img_scale
 from ..builder import PIPELINES
 
 try:
@@ -1979,9 +1980,10 @@ class Mosaic:
 
     Args:
         img_scale (Sequence[int]): Image size after mosaic pipeline of single
-           image. Default to (640, 640).
+            image. The shape order should be (height, width).
+            Default to (640, 640).
         center_ratio_range (Sequence[float]): Center ratio range of mosaic
-           output. Default to (0.5, 1.5).
+            output. Default to (0.5, 1.5).
         min_bbox_size (int | float): The minimum pixel for filtering
             invalid bboxes after the mosaic pipeline. Default to 0.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
@@ -2002,6 +2004,7 @@ class Mosaic:
                  skip_filter=True,
                  pad_val=114):
         assert isinstance(img_scale, tuple)
+        log_img_scale(img_scale, skip_square=True)
         self.img_scale = img_scale
         self.center_ratio_range = center_ratio_range
         self.min_bbox_size = min_bbox_size
@@ -2232,7 +2235,7 @@ class MixUp:
                 |             pad              |
                 +------------------------------+
 
-     The mixup transform steps are as follows::
+     The mixup transform steps are as follows:
 
         1. Another random image is picked by dataset and embedded in
            the top left patch(after padding and resizing)
@@ -2241,15 +2244,15 @@ class MixUp:
 
     Args:
         img_scale (Sequence[int]): Image output size after mixup pipeline.
-           Default: (640, 640).
+            The shape order should be (height, width). Default: (640, 640).
         ratio_range (Sequence[float]): Scale ratio of mixup image.
-           Default: (0.5, 1.5).
+            Default: (0.5, 1.5).
         flip_ratio (float): Horizontal flip ratio of mixup image.
-           Default: 0.5.
+            Default: 0.5.
         pad_val (int): Pad value. Default: 114.
         max_iters (int): The maximum number of iterations. If the number of
-           iterations is greater than `max_iters`, but gt_bbox is still
-           empty, then the iteration is terminated. Default: 15.
+            iterations is greater than `max_iters`, but gt_bbox is still
+            empty, then the iteration is terminated. Default: 15.
         min_bbox_size (float): Width and height threshold to filter bboxes.
             If the height or width of a box is smaller than this value, it
             will be removed. Default: 5.
@@ -2281,6 +2284,7 @@ class MixUp:
                  bbox_clip_border=True,
                  skip_filter=True):
         assert isinstance(img_scale, tuple)
+        log_img_scale(img_scale, skip_square=True)
         self.dynamic_scale = img_scale
         self.ratio_range = ratio_range
         self.flip_ratio = flip_ratio

--- a/mmdet/models/detectors/yolox.py
+++ b/mmdet/models/detectors/yolox.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from mmcv.runner import get_dist_info
 
+from ...utils import log_img_scale
 from ..builder import DETECTORS
 from .single_stage import SingleStageDetector
 
@@ -29,8 +30,8 @@ class YOLOX(SingleStageDetector):
             of YOLOX. Default: None.
         pretrained (str, optional): model pretrained path.
             Default: None.
-        input_size (tuple): The model default input image size.
-            Default: (640, 640).
+        input_size (tuple): The model default input image size. The shape
+            order should be (height, width). Default: (640, 640).
         size_multiplier (int): Image size multiplication factor.
             Default: 32.
         random_size_range (tuple): The multi-scale random range during
@@ -56,6 +57,7 @@ class YOLOX(SingleStageDetector):
                  init_cfg=None):
         super(YOLOX, self).__init__(backbone, neck, bbox_head, train_cfg,
                                     test_cfg, pretrained, init_cfg)
+        log_img_scale(input_size, skip_square=True)
         self.rank, self.world_size = get_dist_info()
         self._default_input_size = input_size
         self._input_size = input_size

--- a/mmdet/utils/__init__.py
+++ b/mmdet/utils/__init__.py
@@ -1,10 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .collect_env import collect_env
-from .logger import get_root_logger
+from .logger import get_caller_name, get_root_logger, log_img_scale
 from .misc import find_latest_checkpoint
 from .setup_env import setup_multi_processes
 
 __all__ = [
     'get_root_logger', 'collect_env', 'find_latest_checkpoint',
-    'setup_multi_processes'
+    'setup_multi_processes', 'get_caller_name', 'log_img_scale'
 ]

--- a/mmdet/utils/logger.py
+++ b/mmdet/utils/logger.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 import logging
 
 from mmcv.utils import get_logger
@@ -18,3 +19,47 @@ def get_root_logger(log_file=None, log_level=logging.INFO):
     logger = get_logger(name='mmdet', log_file=log_file, log_level=log_level)
 
     return logger
+
+
+def get_caller_name():
+    """Get name of caller method."""
+    # this_func_frame = inspect.stack()[0][0]  # i.e., get_caller_name
+    # callee_frame = inspect.stack()[1][0]  # e.g., log_img_scale
+    caller_frame = inspect.stack()[2][0]  # e.g., caller of log_img_scale
+    caller_method = caller_frame.f_code.co_name
+    try:
+        caller_class = caller_frame.f_locals['self'].__class__.__name__
+        return f'{caller_class}.{caller_method}'
+    except KeyError:  # caller is a function
+        return caller_method
+
+
+def log_img_scale(img_scale, shape_order='hw', skip_square=False):
+    """Log image size.
+
+    Args:
+        img_scale (tuple): Image size to be logged.
+        shape_order (str, optional): The order of image shape.
+            'hw' for (height, width) and 'wh' for (width, height).
+            Defaults to 'hw'.
+        skip_square (bool, optional): Whether to skip logging for square
+            img_scale. Defaults to False.
+
+    Returns:
+        bool: Whether to have done logging.
+    """
+    if shape_order == 'hw':
+        height, width = img_scale
+    elif shape_order == 'wh':
+        width, height = img_scale
+    else:
+        raise ValueError(f'Invalid shape_order {shape_order}.')
+
+    if skip_square and (height == width):
+        return False
+
+    logger = get_root_logger()
+    caller = get_caller_name()
+    logger.info(f'image shape: height={height}, width={width} in {caller}')
+
+    return True

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -1,0 +1,47 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+
+from mmdet.utils import get_caller_name, log_img_scale
+
+
+def callee_func():
+    caller_name = get_caller_name()
+    return caller_name
+
+
+class CallerClassForTest:
+
+    def __init__(self):
+        self.caller_name = callee_func()
+
+
+def test_get_caller_name():
+    # test the case that caller is a function
+    caller_name = callee_func()
+    assert caller_name == 'test_get_caller_name'
+
+    # test the case that caller is a method in a class
+    caller_class = CallerClassForTest()
+    assert caller_class.caller_name == 'CallerClassForTest.__init__'
+
+
+def test_log_img_scale():
+    img_scale = (800, 1333)
+    done_logging = log_img_scale(img_scale)
+    assert done_logging
+
+    img_scale = (1333, 800)
+    done_logging = log_img_scale(img_scale, shape_order='wh')
+    assert done_logging
+
+    with pytest.raises(ValueError):
+        img_scale = (1333, 800)
+        done_logging = log_img_scale(img_scale, shape_order='xywh')
+
+    img_scale = (640, 640)
+    done_logging = log_img_scale(img_scale, skip_square=False)
+    assert done_logging
+
+    img_scale = (640, 640)
+    done_logging = log_img_scale(img_scale, skip_square=True)
+    assert not done_logging


### PR DESCRIPTION
## Motivation

This PR updates the log messages and docstrings of YOLOX and its data augmentation to avoid wrong order of image shape.
Related issue: https://github.com/open-mmlab/mmdetection/issues/7149

## Modification

- Add `log_img_scale` function to log image's height and width
- Call `log_img_scale` from `YOLOX`, `Mosaic`, and `MixUp` 
- Add a utility function `get_caller_name` to show the name of caller method without explicit passing of class name
- Update docstrings