### PR TITLE
Add deprecation message for deploy tools

### DIFF
--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -252,3 +252,15 @@ if __name__ == '__main__':
         show=args.show,
         workspace_size=args.workspace_size,
         verbose=args.verbose)
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -343,3 +343,15 @@ if __name__ == '__main__':
         do_simplify=args.simplify,
         dynamic_export=args.dynamic_export,
         skip_postprocess=args.skip_postprocess)
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)

--- a/tools/deployment/test.py
+++ b/tools/deployment/test.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+import warnings
 
 import mmcv
 from mmcv import Config, DictAction
@@ -140,4 +141,16 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    # main()
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)


### PR DESCRIPTION
Related PR https://github.com/open-mmlab/mmclassification/pull/697

Motivation
Since [MMDeploy](https://github.com/open-mmlab/mmdeploy) has been released, the deployment tools scattered in each OpenMMLab codebase will be deprecated in future.

Modification
Add deprecation message in deployment tools.
Used package [colorama](https://github.com/tartley/colorama#colored-output)[](https://user-images.githubusercontent.com/28671653/154436568-9b36c248-812a-402f-bef8-5631ed8abd7a.png) to print cross-platform colored text.

BC-breaking (Optional)
None

Use cases (Optional)
And the message would look like it in Ubuntu18.04 terminal:
![image](https://user-images.githubusercontent.com/26483343/155464046-61e88a00-5c6f-4c00-93fe-d5d83caca3fe.png)