### PR TITLE
Fix VOC unit test not to remove data directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
             mmcv: 1.9
           - torch: 1.10.1
             torchvision: 0.11.2
-            mmcv: 1.10
+            mmcv: "1.10"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -172,7 +172,7 @@ jobs:
           - torch: 1.10.1+cu102
             torch_version: torch1.10.1
             torchvision: 0.11.2+cu102
-            mmcv: 1.10
+            mmcv: "1.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/tests/test_data/test_datasets/test_common.py
+++ b/tests/test_data/test_datasets/test_common.py
@@ -1,10 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
 import logging
-import os
 import os.path as osp
-import platform
-import shutil
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -106,26 +103,17 @@ def _create_dummy_results():
 
 @pytest.mark.parametrize('config_path',
                          ['./configs/_base_/datasets/voc0712.py'])
-def test_dataset_init(config_path):
-    use_symlink = False
-    if not os.path.exists('./data'):
-        if platform.system() != 'Windows':
-            os.symlink('./tests/data', './data')
-            use_symlink = True
-        else:
-            shutil.copytree('./tests/data', './data')
+def test_dataset_init(config_path, monkeypatch):
     data_config = mmcv.Config.fromfile(config_path)
     if 'data' not in data_config:
         return
+
+    monkeypatch.chdir('./tests/')  # to use ./tests/data
     stage_names = ['train', 'val', 'test']
     for stage_name in stage_names:
         dataset_config = copy.deepcopy(data_config.data.get(stage_name))
         dataset = build_dataset(dataset_config)
         dataset[0]
-    if use_symlink:
-        os.unlink('./data')
-    else:
-        shutil.rmtree('./data')
 
 
 def test_dataset_evaluation():


### PR DESCRIPTION
## Motivation

Fix https://github.com/open-mmlab/mmdetection/issues/7269

## Modification

- Fix and simplify `test_dataset_init`
- Fix CI: `mmcv: 1.10` == `mmcv: 1.1` causes a wrong URL https://download.openmmlab.com/mmcv/dist/cpu/torch1.1/index.html