### PR TITLE
[Fix] Adjust the order of get_classes and FileClient.

### DIFF
--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -74,8 +74,8 @@ class CustomDataset(Dataset):
         self.proposal_file = proposal_file
         self.test_mode = test_mode
         self.filter_empty_gt = filter_empty_gt
-        self.CLASSES = self.get_classes(classes)
         self.file_client = mmcv.FileClient(**file_client_args)
+        self.CLASSES = self.get_classes(classes)
 
         # join paths if data_root is specified
         if self.data_root is not None:


### PR DESCRIPTION
## Motivation

The motivation of this PR is to be able to use `self.file_client` in `self.get_classes` function instead of repeatedly creating `file_client` in `self.get_classes`.

## Modification

1. CustomDataset
    - Adjust the order of `self.get_classes` and `mmcv.FileClient`. Get `self.file_client` before `self.get_classes`.

## BC-breaking (Optional)

No.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
5. The documentation has been modified accordingly, like docstring or example tutorials.
