### PR TITLE
update readme and pretrained related

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
       <td>
         <ul>
           <li><a href="configs/panoptic_fpn">Panoptic FPN (CVPR'2019)</a></li>
-          <li><a href="configs/maskformer">MaskFormer (NeurIPS'2019)</a></li>
+          <li><a href="configs/maskformer">MaskFormer (NeurIPS'2021)</a></li>
         </ul>
       </td>
       <td>

--- a/tools/test.py
+++ b/tools/test.py
@@ -143,7 +143,11 @@ def main():
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True
 
-    cfg.model.pretrained = None
+    if 'pretrained' in cfg.model:
+        cfg.model.pretrained = None
+    elif 'init_cfg' in cfg.model.backbone:
+        cfg.model.backbone.init_cfg = None
+
     if cfg.model.get('neck'):
         if isinstance(cfg.model.neck, list):
             for neck_cfg in cfg.model.neck:


### PR DESCRIPTION
1. maskformer NeurIPS'2019 -> NeurIPS'2021 in readme. 
2. modified to be compatible with models which does not support pretrained.