### PR TITLE
[Enhance] add cpu_num in cocopanoptic for pq computing

### DIFF
--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -171,7 +171,7 @@ def pq_compute_multi_core(matched_annotations_list,
                           pred_folder,
                           categories,
                           file_client=None,
-                          cpu_num=-1):
+                          nproc=32):
     """Evaluate the metrics of Panoptic Segmentation with multithreading.
 
     Same as the function with the same name in `panopticapi`.
@@ -185,8 +185,8 @@ def pq_compute_multi_core(matched_annotations_list,
         categories (str): The categories of the dataset.
         file_client (object): The file client of the dataset. If None,
             the backend will be set to `disk`.
-        cpu_num (int): Number of cpus for panoptic quality computing.
-            Default to -1, which means use all cpus.
+        nproc (int): Number of processes for panoptic quality computing.
+            Default to 32.
     """
     if PQStat is None:
         raise RuntimeError(
@@ -198,10 +198,7 @@ def pq_compute_multi_core(matched_annotations_list,
         file_client_args = dict(backend='disk')
         file_client = mmcv.FileClient(**file_client_args)
 
-    if cpu_num == -1:
-        cpu_num = multiprocessing.cpu_count()
-    elif cpu_num <= 0:
-        raise ValueError('cpu_num = %d, which is invalided' % cpu_num)
+    cpu_num = min(nproc, multiprocessing.cpu_count())
 
     annotations_split = np.array_split(matched_annotations_list, cpu_num)
     print('Number of cores: {}, images per core: {}'.format(

--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -186,7 +186,8 @@ def pq_compute_multi_core(matched_annotations_list,
         file_client (object): The file client of the dataset. If None,
             the backend will be set to `disk`.
         nproc (int): Number of processes for panoptic quality computing.
-            Default to 32.
+            Defaults to 32. When `nproc` exceeds the number of cpu cores,
+            the number of cpu cores is used.
     """
     if PQStat is None:
         raise RuntimeError(

--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -170,7 +170,8 @@ def pq_compute_multi_core(matched_annotations_list,
                           gt_folder,
                           pred_folder,
                           categories,
-                          file_client=None):
+                          file_client=None,
+                          cpu_num=-1):
     """Evaluate the metrics of Panoptic Segmentation with multithreading.
 
     Same as the function with the same name in `panopticapi`.
@@ -184,6 +185,8 @@ def pq_compute_multi_core(matched_annotations_list,
         categories (str): The categories of the dataset.
         file_client (object): The file client of the dataset. If None,
             the backend will be set to `disk`.
+        cpu_num (int): Number of cpus for panoptic quality computing.
+            Default to -1, which means use all cpus.
     """
     if PQStat is None:
         raise RuntimeError(
@@ -195,7 +198,11 @@ def pq_compute_multi_core(matched_annotations_list,
         file_client_args = dict(backend='disk')
         file_client = mmcv.FileClient(**file_client_args)
 
-    cpu_num = multiprocessing.cpu_count()
+    if cpu_num == -1:
+        cpu_num = multiprocessing.cpu_count()
+    elif cpu_num <= 0:
+        raise ValueError('cpu_num = %d, which is invalided' % cpu_num)
+
     annotations_split = np.array_split(matched_annotations_list, cpu_num)
     print('Number of cores: {}, images per core: {}'.format(
         cpu_num, len(annotations_split[0])))

--- a/mmdet/datasets/coco_panoptic.py
+++ b/mmdet/datasets/coco_panoptic.py
@@ -160,8 +160,8 @@ class CocoPanopticDataset(CocoDataset):
         file_client_args (dict): Arguments to instantiate a FileClient.
             See :class:`mmcv.fileio.FileClient` for details.
             Defaults to ``dict(backend='disk')``.
-        cpu_num (int): Number of cpus for panoptic quality computing.
-            Defaults to -1, which means use all cpus.
+        nproc (int): Number of processes for panoptic quality computing.
+            Defaults to 32.
     """
     CLASSES = [
         'person', 'bicycle', 'car', 'motorcycle', 'airplane', 'bus', 'train',
@@ -266,12 +266,12 @@ class CocoPanopticDataset(CocoDataset):
                  test_mode=False,
                  filter_empty_gt=True,
                  file_client_args=dict(backend='disk'),
-                 cpu_num=-1):
+                 nproc=32):
         super(CocoDataset,
               self).__init__(ann_file, pipeline, classes, data_root,
                              img_prefix, seg_prefix, proposal_file, test_mode,
                              filter_empty_gt, file_client_args)
-        self.cpu_num = cpu_num
+        self.nproc = nproc
 
     def load_annotations(self, ann_file):
         """Load annotation from COCO Panoptic style annotation file.
@@ -493,7 +493,7 @@ class CocoPanopticDataset(CocoDataset):
 
         pq_stat = pq_compute_multi_core(matched_annotations_list, gt_folder,
                                         pred_folder, self.categories,
-                                        self.file_client, self.cpu_num)
+                                        self.file_client, self.nproc)
 
         metrics = [('All', None), ('Things', True), ('Stuff', False)]
         pq_results = {}


### PR DESCRIPTION
resolve #7309 
1. add arg `cpu_num` in  pq_compute_multi_core
2. add arg `cpu_num` and docstring for args in cocopanoptic