### PR TITLE
[Fix] Fix num_last_epochs logic for the hooks in YOLOX training

### DIFF
--- a/mmdet/core/hook/sync_norm_hook.py
+++ b/mmdet/core/hook/sync_norm_hook.py
@@ -33,7 +33,7 @@ class SyncNormHook(Hook):
 
     def before_train_epoch(self, runner):
         epoch = runner.epoch
-        if (epoch + 1) == runner.max_epochs - self.num_last_epochs:
+        if epoch == runner.max_epochs - self.num_last_epochs:
             # Synchronize norm every epoch.
             self.interval = 1
 

--- a/mmdet/core/hook/yolox_mode_switch_hook.py
+++ b/mmdet/core/hook/yolox_mode_switch_hook.py
@@ -32,7 +32,7 @@ class YOLOXModeSwitchHook(Hook):
         model = runner.model
         if is_module_wrapper(model):
             model = model.module
-        if (epoch + 1) == runner.max_epochs - self.num_last_epochs:
+        if epoch == runner.max_epochs - self.num_last_epochs:
             runner.logger.info('No mosaic and mixup aug now!')
             # The dataset pipeline cannot be updated when persistent_workers
             # is True, so we need to force the dataloader's multi-process


### PR DESCRIPTION
## Motivation

Based on #7284 , I ran a few more experiments with ``` num_last_epochs```. 
I could still see that the ``` before_train_epoch``` hooks didn't come in at the proper epoch. 
They came in one epoch earlier than I expected them to, so I made a PR to fix it. 

On the other hand, the learning rate schedule, which is the learning rate is fixed during the ``` num_last_epochs```, works fine. 
This means that the ``` number of epochs``` for fixed learning rate and the ``` number of epochs``` for non-mixup-mosaic augmentation didn't match as well. 

## Modification

I modified two files, ``` sync_norm_hook.py``` and  ``` yolox_mode_switch_hook.py``` that implement ``` before_train_epoch``` hook using ``` num_last_epochs```. 
In both of the files, the if logic was modified from
```python
        if (epoch + 1) == runner.max_epochs - self.num_last_epochs:
```
to
```python
        if epoch == runner.max_epochs - self.num_last_epochs:
```

## BC-breaking (Optional)

Yes

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
