### PR TITLE
[Fix] set unmap_results=True in ssd_head

### DIFF
--- a/mmdet/models/dense_heads/ssd_head.py
+++ b/mmdet/models/dense_heads/ssd_head.py
@@ -316,7 +316,7 @@ class SSDHead(AnchorHead):
             gt_bboxes_ignore_list=gt_bboxes_ignore,
             gt_labels_list=gt_labels,
             label_channels=1,
-            unmap_outputs=False)
+            unmap_outputs=True)
         if cls_reg_targets is None:
             return None
         (labels_list, label_weights_list, bbox_targets_list, bbox_weights_list,


### PR DESCRIPTION
When use a input_size != 512, error will incur. Related issue #7264 
So we set `unmap_results = True` in ssd_head to be compalible with various input_size.

I ran a ssd_512 after set `unmap_results = True` for three times, results are 29.4,  29.3,  29.5 mAP.  And I ran two times for `unmap_results = False`, results are 29.5, 29.5 mAP. So I think it is reasonable to modify this. 