### PR TITLE
[Fix] change torch.mm to torch.einsum to avoid OOM

### DIFF
--- a/mmdet/core/post_processing/matrix_nms.py
+++ b/mmdet/core/post_processing/matrix_nms.py
@@ -64,7 +64,10 @@ def mask_matrix_nms(masks,
     num_masks = len(labels)
     flatten_masks = masks.reshape(num_masks, -1).float()
     # inter.
-    inter_matrix = torch.mm(flatten_masks, flatten_masks.transpose(1, 0))
+    # inter_matrix1 = torch.mm(flatten_masks, flatten_masks.transpose(1, 0))
+    # torch.mm() may cause GPU out of memory error
+    inter_matrix = torch.einsum('ik, kj -> ij', flatten_masks,
+                                flatten_masks.transpose(1, 0))
     expanded_mask_area = mask_area.expand(num_masks, num_masks)
     # Upper triangle iou matrix.
     iou_matrix = (inter_matrix /


### PR DESCRIPTION
Fix `torch.mm` to `torch.einsum` to avoid OOM:
before change, mAP: 0.331
```python
inter_matrix = torch.mm(flatten_masks, flatten_masks.transpose(1, 0))
```

after change, mAP: 0.331
```python
inter_matrix = torch.einsum('ik, kj -> ij', flatten_masks,  flatten_masks.transpose(1, 0))
```
