### PR TITLE
[fix] pycocotools can not build with py>3.8 and no VS14 for compilation in windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Build and install
         run: pip install -e .
       - name: Run unittests
-        run: coverage run --branch --source mmdet -m pytest tests -sv
+        run: coverage run --branch --source mmdet -m pytest tests
       - name: Generate coverage report
         run: |
           coverage xml

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Results and models are available in the [model zoo](docs/en/model_zoo.md).
       <td>
         <ul>
           <li><a href="configs/panoptic_fpn">Panoptic FPN (CVPR'2019)</a></li>
-          <li><a href="configs/maskformer">MaskFormer (NeurIPS'2019)</a></li>
+          <li><a href="configs/maskformer">MaskFormer (NeurIPS'2021)</a></li>
         </ul>
       </td>
       <td>
@@ -274,7 +274,7 @@ Please refer to [get_started.md](docs/en/get_started.md) for installation.
 ## Getting Started
 
 Please see [get_started.md](docs/en/get_started.md) for the basic usage of MMDetection.
-We provide [colab tutorial](demo/MMDet_Tutorial.ipynb), and full guidance for quick run [with existing dataset](docs/en/1_exist_data_model.md) and [with new dataset](docs/en/2_new_data_model.md) for beginners.
+We provide [detection colab tutorial](demo/MMDet_Tutorial.ipynb) and [instance segmentation colab tutorial](demo/MMDet_InstanceSeg_Tutorial.ipynb), and full guidance for quick run [with existing dataset](docs/en/1_exist_data_model.md) and [with new dataset](docs/en/2_new_data_model.md) for beginners.
 There are also tutorials for [finetuning models](docs/en/tutorials/finetune.md), [adding new dataset](docs/en/tutorials/customize_dataset.md), [designing data pipeline](docs/en/tutorials/data_pipeline.md), [customizing models](docs/en/tutorials/customize_models.md), [customizing runtime settings](docs/en/tutorials/customize_runtime.md) and [useful tools](docs/en/useful_tools.md).
 
 Please refer to [FAQ](docs/en/faq.md) for frequently asked questions.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -272,7 +272,7 @@ MMDetection 是一个基于 PyTorch 的目标检测开源工具箱。它是 [Ope
 ## 快速入门
 
 请参考[快速入门文档](docs/zh_cn/get_started.md)学习 MMDetection 的基本使用。
-我们提供了 [colab 教程](demo/MMDet_Tutorial.ipynb)，也为新手提供了完整的运行教程，分别针对[已有数据集](docs/zh_cn/1_exist_data_model.md)和[新数据集](docs/zh_cn/2_new_data_model.md) 完整的使用指南
+我们提供了 [检测的 colab 教程](demo/MMDet_Tutorial.ipynb) 和 [实例分割的 colab 教程](demo/MMDet_InstanceSeg_Tutorial.ipynb)，也为新手提供了完整的运行教程，分别针对[已有数据集](docs/zh_cn/1_exist_data_model.md)和[新数据集](docs/zh_cn/2_new_data_model.md) 完整的使用指南
 
 我们也提供了一些进阶教程，内容覆盖了 [finetune 模型](docs/zh_cn/tutorials/finetune.md)，[增加新数据集支持](docs/zh_cn/tutorials/customize_dataset.md)，[设计新的数据预处理流程](docs/zh_cn/tutorials/data_pipeline.md)，[增加自定义模型](docs/zh_cn/tutorials/customize_models.md)，[增加自定义的运行时配置](docs/zh_cn/tutorials/customize_runtime.md)，[常用工具和脚本](docs/zh_cn/useful_tools.md)。
 

--- a/configs/yolox/yolox_s_8x8_300e_coco.py
+++ b/configs/yolox/yolox_s_8x8_300e_coco.py
@@ -1,6 +1,6 @@
 _base_ = ['../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py']
 
-img_scale = (640, 640)
+img_scale = (640, 640)  # height, width
 
 # model settings
 model = dict(

--- a/configs/yolox/yolox_tiny_8x8_300e_coco.py
+++ b/configs/yolox/yolox_tiny_8x8_300e_coco.py
@@ -7,7 +7,7 @@ model = dict(
     neck=dict(in_channels=[96, 192, 384], out_channels=96),
     bbox_head=dict(in_channels=96, feat_channels=96))
 
-img_scale = (640, 640)
+img_scale = (640, 640)  # height, width
 
 train_pipeline = [
     dict(type='Mosaic', img_scale=img_scale, pad_val=114.0),

--- a/docs/en/useful_tools.md
+++ b/docs/en/useful_tools.md
@@ -10,7 +10,7 @@ Apart from training/testing scripts, We provide lots of useful tools under the
 python tools/analysis_tools/analyze_logs.py plot_curve [--keys ${KEYS}] [--title ${TITLE}] [--legend ${LEGEND}] [--backend ${BACKEND}] [--style ${STYLE}] [--out ${OUT_FILE}]
  ```
 
-![loss curve image](../resources/loss_curve.png)
+![loss curve image](../../resources/loss_curve.png)
 
 Examples:
 

--- a/docs/zh_cn/tutorials/finetune.md
+++ b/docs/zh_cn/tutorials/finetune.md
@@ -1,1 +1,84 @@
 # 教程 7: 模型微调
+
+在 COCO 数据集上预训练的检测器可以作为其他数据集（例如 CityScapes 和 KITTI 数据集）优质的预训练模型。
+本教程将指导用户如何把 [ModelZoo](../model_zoo.md) 中提供的模型用于其他数据集中并使得当前所训练的模型获得更好性能。
+
+以下是在新数据集中微调模型需要的两个步骤。
+
+- 按 [教程2：自定义数据集的方法](customize_dataset.md) 中的方法对新数据集添加支持中的方法对新数据集添加支持
+- 按照本教程中所讨论方法，修改配置信息
+
+接下来将会以 Cityscapes Dataset 上的微调过程作为例子，具体讲述用户需要在配置中修改的五个部分。
+
+## 继承基础配置
+
+为了减轻编写整个配置的负担并减少漏洞的数量， MMDetection V2.0 支持从多个现有配置中继承配置信息。微调 MaskRCNN 模型的时候，新的配置信息需要使用从 `_base_/models/mask_rcnn_r50_fpn.py`中继承的配置信息来构建模型的基本结构。当使用 Cityscapes 数据集时，新的配置信息可以简便地从`_base_/datasets/cityscapes_instance.py`中继承。对于训练过程的运行设置部分，新配置需要从 `_base_/default_runtime.py`中继承。这些配置文件`configs`的目录下，用户可以选择全部内容的重新编写而不是使用继承方法。
+
+```python
+_base_ = [
+    '../_base_/models/mask_rcnn_r50_fpn.py',
+    '../_base_/datasets/cityscapes_instance.py', '../_base_/default_runtime.py'
+]
+```
+
+
+##  Head 的修改
+接下来新的配置还需要根据新数据集的类别数量对 Head 进行修改。只需要对 roi_head 中的 `num_classes`进行修改。修改后除了最后的预测模型的 Head 之外，预训练模型的权重的大部分都会被重新使用。
+
+```python
+model = dict(
+    pretrained=None,
+    roi_head=dict(
+        bbox_head=dict(
+            type='Shared2FCBBoxHead',
+            in_channels=256,
+            fc_out_channels=1024,
+            roi_feat_size=7,
+            num_classes=8,
+            bbox_coder=dict(
+                type='DeltaXYWHBBoxCoder',
+                target_means=[0., 0., 0., 0.],
+                target_stds=[0.1, 0.1, 0.2, 0.2]),
+            reg_class_agnostic=False,
+            loss_cls=dict(
+                type='CrossEntropyLoss', use_sigmoid=False, loss_weight=1.0),
+            loss_bbox=dict(type='SmoothL1Loss', beta=1.0, loss_weight=1.0)),
+        mask_head=dict(
+            type='FCNMaskHead',
+            num_convs=4,
+            in_channels=256,
+            conv_out_channels=256,
+            num_classes=8,
+            loss_mask=dict(
+                type='CrossEntropyLoss', use_mask=True, loss_weight=1.0))))
+```
+
+## 数据集的修改
+用户可能还需要准备数据集并编写有关数据集的配置。目前 MMDetection V2.0 的配置文件已经支持 VOC、WIDER FACE、COCO 和 Cityscapes Dataset 的数据集信息。
+
+## 训练策略的修改
+微调超参数与默认的训练策略不同。它通常需要更小的学习率和更少的训练回合。
+
+```python
+# 优化器
+# batch size 为 8 时的 lr 配置
+optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
+optimizer_config = dict(grad_clip=None)
+# 学习策略
+lr_config = dict(
+    policy='step',
+    warmup='linear',
+    warmup_iters=500,
+    warmup_ratio=0.001,
+    step=[7])
+# lr_config 中的 max_epochs 和 step 需要针对自定义数据集进行专门调整
+runner = dict(max_epochs=8)
+log_config = dict(interval=100)
+```
+
+## 使用预训练模型
+
+如果要使用预训练模型时，可以在 `load_from` 中查阅新的配置信息，用户需要在训练开始之前下载好需要的模型权重，从而避免在训练过程中浪费了宝贵时间。
+```python
+load_from = 'https://download.openmmlab.com/mmdetection/v2.0/mask_rcnn/mask_rcnn_r50_caffe_fpn_mstrain-poly_3x_coco/mask_rcnn_r50_caffe_fpn_mstrain-poly_3x_coco_bbox_mAP-0.408__segm_mAP-0.37_20200504_163245-42aa3d00.pth'  # noqa
+```

--- a/docs/zh_cn/tutorials/onnx2tensorrt.md
+++ b/docs/zh_cn/tutorials/onnx2tensorrt.md
@@ -1,4 +1,107 @@
 # 教程 9: ONNX 到 TensorRT 的模型转换（实验性支持）
 
 
-> ## [尝试使用新的 MMDeploy 來部署你的模型](https://mmdeploy.readthedocs.io/)
+> ## [尝试使用新的 MMDeploy 来部署你的模型](https://mmdeploy.readthedocs.io/)
+
+<!-- TOC -->
+
+- [教程 9: ONNX 到 TensorRT 的模型转换（实验性支持）](#教程-9-onnx-到-tensorrt-的模型转换实验性支持)
+  - [如何将模型从 ONNX 转换为 TensorRT](#如何将模型从-onnx-转换为-tensorrt)
+    - [先决条件](#先决条件)
+    - [用法](#用法)
+  - [如何评估导出的模型](#如何评估导出的模型)
+  - [支持转换为 TensorRT 的模型列表](#支持转换为-tensorrt-的模型列表)
+  - [提醒](#提醒)
+  - [常见问题](#常见问题)
+
+<!-- TOC -->
+
+## 如何将模型从 ONNX 转换为 TensorRT
+
+### 先决条件
+
+1. 请参考 [get_started.md](https://mmdetection.readthedocs.io/en/latest/get_started.html) 从源码安装 MMCV 和 MMDetection。
+2. 请参考 [ONNXRuntime in mmcv](https://mmcv.readthedocs.io/en/latest/deployment/onnxruntime_op.html) 和 [TensorRT plugin in mmcv](https://github.com/open-mmlab/mmcv/blob/master/docs/en/deployment/tensorrt_plugin.md/) 安装支持 ONNXRuntime 自定义操作和 TensorRT 插件的 `mmcv-full`。
+3. 使用工具 [pytorch2onnx](https://mmdetection.readthedocs.io/en/latest/tutorials/pytorch2onnx.html) 将模型从 PyTorch 转换为 ONNX。
+
+### 用法
+
+```bash
+python tools/deployment/onnx2tensorrt.py \
+    ${CONFIG} \
+    ${MODEL} \
+    --trt-file ${TRT_FILE} \
+    --input-img ${INPUT_IMAGE_PATH} \
+    --shape ${INPUT_IMAGE_SHAPE} \
+    --min-shape ${MIN_IMAGE_SHAPE} \
+    --max-shape ${MAX_IMAGE_SHAPE} \
+    --workspace-size {WORKSPACE_SIZE} \
+    --show \
+    --verify \
+```
+
+所有参数的说明：
+
+- `config`: 模型配置文件的路径。
+- `model`: ONNX 模型文件的路径。
+- `--trt-file`: 输出 TensorRT 引擎文件的路径。如果未指定，它将被设置为 `tmp.trt`。
+- `--input-img`: 用于追踪和转换的输入图像的路径。默认情况下，它将设置为 `demo/demo.jpg`。
+- `--shape`: 模型输入的高度和宽度。如果未指定，它将设置为 `400 600`。
+- `--min-shape`: 模型输入的最小高度和宽度。如果未指定，它将被设置为与 `--shape` 相同。
+- `--max-shape`: 模型输入的最大高度和宽度。如果未指定，它将被设置为与 `--shape` 相同。
+- `--workspace-size`: 构建 TensorRT 引擎所需的 GPU 工作空间大小（以 GiB 为单位）。如果未指定，它将设置为 `1` GiB。
+- `--show`: 确定是否显示模型的输出。如果未指定，它将设置为 `False`。
+- `--verify`: 确定是否在 ONNXRuntime 和 TensorRT 之间验证模型的正确性。如果未指定，它将设置为 `False`。
+- `--verbose`: 确定是否打印日志消息。它对调试很有用。如果未指定，它将设置为 `False`。
+
+例子:
+
+```bash
+python tools/deployment/onnx2tensorrt.py \
+    configs/retinanet/retinanet_r50_fpn_1x_coco.py \
+    checkpoints/retinanet_r50_fpn_1x_coco.onnx \
+    --trt-file checkpoints/retinanet_r50_fpn_1x_coco.trt \
+    --input-img demo/demo.jpg \
+    --shape 400 600 \
+    --show \
+    --verify \
+```
+
+## 如何评估导出的模型
+
+我们准备了一个工具 `tools/deplopyment/test.py` 来评估 TensorRT 模型。
+
+请参阅以下链接以获取更多信息。
+
+- [如何评估导出的模型](pytorch2onnx.md#how-to-evaluate-the-exported-models)
+- [结果和模型](pytorch2onnx.md#results-and-models)
+
+## 支持转换为 TensorRT 的模型列表
+
+下表列出了确定可转换为 TensorRT 的模型。
+
+|    Model     |                        Config                        | Dynamic Shape | Batch Inference | Note  |
+| :----------: | :--------------------------------------------------: | :-----------: | :-------------: | :---: |
+|     SSD      |             `configs/ssd/ssd300_coco.py`             |       Y       |        Y        |       |
+|     FSAF     |        `configs/fsaf/fsaf_r50_fpn_1x_coco.py`        |       Y       |        Y        |       |
+|     FCOS     |   `configs/fcos/fcos_r50_caffe_fpn_4x4_1x_coco.py`   |       Y       |        Y        |       |
+|    YOLOv3    |  `configs/yolo/yolov3_d53_mstrain-608_273e_coco.py`  |       Y       |        Y        |       |
+|  RetinaNet   |   `configs/retinanet/retinanet_r50_fpn_1x_coco.py`   |       Y       |        Y        |       |
+| Faster R-CNN | `configs/faster_rcnn/faster_rcnn_r50_fpn_1x_coco.py` |       Y       |        Y        |       |
+| Cascade R-CNN| `configs/cascade_rcnn/cascade_rcnn_r50_fpn_1x_coco.py` |   Y    |   Y        |       |
+|  Mask R-CNN  |   `configs/mask_rcnn/mask_rcnn_r50_fpn_1x_coco.py`   |       Y       |        Y        |       |
+| Cascade Mask R-CNN  |   `configs/cascade_rcnn/cascade_mask_rcnn_r50_fpn_1x_coco.py`   |       Y       |        Y        |       |
+|  PointRend   | `configs/point_rend/point_rend_r50_caffe_fpn_mstrain_1x_coco.py` |   Y    |   Y        |       |
+
+注意:
+
+- *以上所有模型通过 Pytorch==1.6.0, onnx==1.7.0 与 TensorRT-7.2.1.6.Ubuntu-16.04.x86_64-gnu.cuda-10.2.cudnn8.0 测试*
+
+## 提醒
+
+- 如果您在上面列出的模型中遇到任何问题，请创建 issue，我们会尽快处理。对于未包含在列表中的模型，由于资源有限，我们可能无法在此提供太多帮助。请尝试深入挖掘并自行调试。
+- 由于此功能是实验性的，并且可能会快速更改，因此请始终尝试使用最新的 `mmcv` 和 `mmdetecion`。
+
+## 常见问题
+
+- 空

--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -170,7 +170,8 @@ def pq_compute_multi_core(matched_annotations_list,
                           gt_folder,
                           pred_folder,
                           categories,
-                          file_client=None):
+                          file_client=None,
+                          nproc=32):
     """Evaluate the metrics of Panoptic Segmentation with multithreading.
 
     Same as the function with the same name in `panopticapi`.
@@ -184,6 +185,9 @@ def pq_compute_multi_core(matched_annotations_list,
         categories (str): The categories of the dataset.
         file_client (object): The file client of the dataset. If None,
             the backend will be set to `disk`.
+        nproc (int): Number of processes for panoptic quality computing.
+            Defaults to 32. When `nproc` exceeds the number of cpu cores,
+            the number of cpu cores is used.
     """
     if PQStat is None:
         raise RuntimeError(
@@ -195,7 +199,8 @@ def pq_compute_multi_core(matched_annotations_list,
         file_client_args = dict(backend='disk')
         file_client = mmcv.FileClient(**file_client_args)
 
-    cpu_num = multiprocessing.cpu_count()
+    cpu_num = min(nproc, multiprocessing.cpu_count())
+
     annotations_split = np.array_split(matched_annotations_list, cpu_num)
     print('Number of cores: {}, images per core: {}'.format(
         cpu_num, len(annotations_split[0])))

--- a/mmdet/datasets/custom.py
+++ b/mmdet/datasets/custom.py
@@ -74,8 +74,8 @@ class CustomDataset(Dataset):
         self.proposal_file = proposal_file
         self.test_mode = test_mode
         self.filter_empty_gt = filter_empty_gt
-        self.CLASSES = self.get_classes(classes)
         self.file_client = mmcv.FileClient(**file_client_args)
+        self.CLASSES = self.get_classes(classes)
 
         # join paths if data_root is specified
         if self.data_root is not None:

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -37,9 +37,11 @@ class LoadImageFromFile:
     def __init__(self,
                  to_float32=False,
                  color_type='color',
+                 channel_order='bgr',
                  file_client_args=dict(backend='disk')):
         self.to_float32 = to_float32
         self.color_type = color_type
+        self.channel_order = channel_order
         self.file_client_args = file_client_args.copy()
         self.file_client = None
 
@@ -63,7 +65,8 @@ class LoadImageFromFile:
             filename = results['img_info']['filename']
 
         img_bytes = self.file_client.get(filename)
-        img = mmcv.imfrombytes(img_bytes, flag=self.color_type)
+        img = mmcv.imfrombytes(
+            img_bytes, flag=self.color_type, channel_order=self.channel_order)
         if self.to_float32:
             img = img.astype(np.float32)
 
@@ -79,6 +82,7 @@ class LoadImageFromFile:
         repr_str = (f'{self.__class__.__name__}('
                     f'to_float32={self.to_float32}, '
                     f"color_type='{self.color_type}', "
+                    f"channel_order='{self.channel_order}', "
                     f'file_client_args={self.file_client_args})')
         return repr_str
 

--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -11,6 +11,7 @@ from numpy import random
 
 from mmdet.core import PolygonMasks, find_inside_bboxes
 from mmdet.core.evaluation.bbox_overlaps import bbox_overlaps
+from mmdet.utils import log_img_scale
 from ..builder import PIPELINES
 
 try:
@@ -1979,9 +1980,10 @@ class Mosaic:
 
     Args:
         img_scale (Sequence[int]): Image size after mosaic pipeline of single
-           image. Default to (640, 640).
+            image. The shape order should be (height, width).
+            Default to (640, 640).
         center_ratio_range (Sequence[float]): Center ratio range of mosaic
-           output. Default to (0.5, 1.5).
+            output. Default to (0.5, 1.5).
         min_bbox_size (int | float): The minimum pixel for filtering
             invalid bboxes after the mosaic pipeline. Default to 0.
         bbox_clip_border (bool, optional): Whether to clip the objects outside
@@ -2002,6 +2004,7 @@ class Mosaic:
                  skip_filter=True,
                  pad_val=114):
         assert isinstance(img_scale, tuple)
+        log_img_scale(img_scale, skip_square=True)
         self.img_scale = img_scale
         self.center_ratio_range = center_ratio_range
         self.min_bbox_size = min_bbox_size
@@ -2232,7 +2235,7 @@ class MixUp:
                 |             pad              |
                 +------------------------------+
 
-     The mixup transform steps are as follows::
+     The mixup transform steps are as follows:
 
         1. Another random image is picked by dataset and embedded in
            the top left patch(after padding and resizing)
@@ -2241,15 +2244,15 @@ class MixUp:
 
     Args:
         img_scale (Sequence[int]): Image output size after mixup pipeline.
-           Default: (640, 640).
+            The shape order should be (height, width). Default: (640, 640).
         ratio_range (Sequence[float]): Scale ratio of mixup image.
-           Default: (0.5, 1.5).
+            Default: (0.5, 1.5).
         flip_ratio (float): Horizontal flip ratio of mixup image.
-           Default: 0.5.
+            Default: 0.5.
         pad_val (int): Pad value. Default: 114.
         max_iters (int): The maximum number of iterations. If the number of
-           iterations is greater than `max_iters`, but gt_bbox is still
-           empty, then the iteration is terminated. Default: 15.
+            iterations is greater than `max_iters`, but gt_bbox is still
+            empty, then the iteration is terminated. Default: 15.
         min_bbox_size (float): Width and height threshold to filter bboxes.
             If the height or width of a box is smaller than this value, it
             will be removed. Default: 5.
@@ -2281,6 +2284,7 @@ class MixUp:
                  bbox_clip_border=True,
                  skip_filter=True):
         assert isinstance(img_scale, tuple)
+        log_img_scale(img_scale, skip_square=True)
         self.dynamic_scale = img_scale
         self.ratio_range = ratio_range
         self.flip_ratio = flip_ratio

--- a/mmdet/models/dense_heads/centripetal_head.py
+++ b/mmdet/models/dense_heads/centripetal_head.py
@@ -2,6 +2,7 @@
 import torch.nn as nn
 from mmcv.cnn import ConvModule, normal_init
 from mmcv.ops import DeformConv2d
+from mmcv.runner import force_fp32
 
 from mmdet.core import multi_apply
 from ..builder import HEADS, build_loss
@@ -203,6 +204,7 @@ class CentripetalHead(CornerHead):
         ]
         return result_list
 
+    @force_fp32()
     def loss(self,
              tl_heats,
              br_heats,
@@ -361,6 +363,7 @@ class CentripetalHead(CornerHead):
 
         return det_loss, off_loss, guiding_loss, centripetal_loss
 
+    @force_fp32()
     def get_bboxes(self,
                    tl_heats,
                    br_heats,

--- a/mmdet/models/dense_heads/corner_head.py
+++ b/mmdet/models/dense_heads/corner_head.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 from mmcv.cnn import ConvModule, bias_init_with_prob
 from mmcv.ops import CornerPool, batched_nms
-from mmcv.runner import BaseModule
+from mmcv.runner import BaseModule, force_fp32
 
 from mmdet.core import multi_apply
 from ..builder import HEADS, build_loss
@@ -152,6 +152,7 @@ class CornerHead(BaseDenseHead, BBoxTestMixin):
         self.train_cfg = train_cfg
         self.test_cfg = test_cfg
 
+        self.fp16_enabled = False
         self._init_layers()
 
     def _make_layers(self, out_channels, in_channels=256, feat_channels=256):
@@ -509,6 +510,7 @@ class CornerHead(BaseDenseHead, BBoxTestMixin):
 
         return target_result
 
+    @force_fp32()
     def loss(self,
              tl_heats,
              br_heats,
@@ -649,6 +651,7 @@ class CornerHead(BaseDenseHead, BBoxTestMixin):
 
         return det_loss, pull_loss, push_loss, off_loss
 
+    @force_fp32()
     def get_bboxes(self,
                    tl_heats,
                    br_heats,

--- a/mmdet/models/dense_heads/ssd_head.py
+++ b/mmdet/models/dense_heads/ssd_head.py
@@ -316,7 +316,7 @@ class SSDHead(AnchorHead):
             gt_bboxes_ignore_list=gt_bboxes_ignore,
             gt_labels_list=gt_labels,
             label_channels=1,
-            unmap_outputs=False)
+            unmap_outputs=True)
         if cls_reg_targets is None:
             return None
         (labels_list, label_weights_list, bbox_targets_list, bbox_weights_list,

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -212,6 +212,7 @@ class YOLOXHead(BaseDenseHead, BBoxTestMixin):
                            self.multi_level_conv_reg,
                            self.multi_level_conv_obj)
 
+    @force_fp32(apply_to=('cls_scores', 'bbox_preds', 'objectnesses'))
     def get_bboxes(self,
                    cls_scores,
                    bbox_preds,

--- a/mmdet/models/detectors/yolox.py
+++ b/mmdet/models/detectors/yolox.py
@@ -6,6 +6,7 @@ import torch.distributed as dist
 import torch.nn.functional as F
 from mmcv.runner import get_dist_info
 
+from ...utils import log_img_scale
 from ..builder import DETECTORS
 from .single_stage import SingleStageDetector
 
@@ -29,8 +30,8 @@ class YOLOX(SingleStageDetector):
             of YOLOX. Default: None.
         pretrained (str, optional): model pretrained path.
             Default: None.
-        input_size (tuple): The model default input image size.
-            Default: (640, 640).
+        input_size (tuple): The model default input image size. The shape
+            order should be (height, width). Default: (640, 640).
         size_multiplier (int): Image size multiplication factor.
             Default: 32.
         random_size_range (tuple): The multi-scale random range during
@@ -56,6 +57,7 @@ class YOLOX(SingleStageDetector):
                  init_cfg=None):
         super(YOLOX, self).__init__(backbone, neck, bbox_head, train_cfg,
                                     test_cfg, pretrained, init_cfg)
+        log_img_scale(input_size, skip_square=True)
         self.rank, self.world_size = get_dist_info()
         self._default_input_size = input_size
         self._input_size = input_size

--- a/mmdet/models/necks/fpn.py
+++ b/mmdet/models/necks/fpn.py
@@ -15,8 +15,8 @@ class FPN(BaseModule):
     Detection <https://arxiv.org/abs/1612.03144>`_.
 
     Args:
-        in_channels (List[int]): Number of input channels per scale.
-        out_channels (int): Number of output channels (used at each scale)
+        in_channels (list[int]): Number of input channels per scale.
+        out_channels (int): Number of output channels (used at each scale).
         num_outs (int): Number of output scales.
         start_level (int): Index of the start input backbone level used to
             build the feature pyramid. Default: 0.
@@ -29,7 +29,7 @@ class FPN(BaseModule):
             Only the following options are allowed
 
             - 'on_input': Last feat map of neck inputs (i.e. backbone feature).
-            - 'on_lateral':  Last feature map after lateral convs.
+            - 'on_lateral': Last feature map after lateral convs.
             - 'on_output': The last output feature map after fpn convs.
         relu_before_extra_convs (bool): Whether to apply relu before the extra
             conv. Default: False.
@@ -37,10 +37,10 @@ class FPN(BaseModule):
             Default: False.
         conv_cfg (dict): Config dict for convolution layer. Default: None.
         norm_cfg (dict): Config dict for normalization layer. Default: None.
-        act_cfg (str): Config dict for activation layer in ConvModule.
+        act_cfg (dict): Config dict for activation layer in ConvModule.
             Default: None.
         upsample_cfg (dict): Config dict for interpolate layer.
-            Default: `dict(mode='nearest')`
+            Default: dict(mode='nearest').
         init_cfg (dict or list[dict], optional): Initialization config dict.
 
     Example:

--- a/mmdet/utils/__init__.py
+++ b/mmdet/utils/__init__.py
@@ -1,10 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .collect_env import collect_env
-from .logger import get_root_logger
+from .logger import get_caller_name, get_root_logger, log_img_scale
 from .misc import find_latest_checkpoint
 from .setup_env import setup_multi_processes
 
 __all__ = [
     'get_root_logger', 'collect_env', 'find_latest_checkpoint',
-    'setup_multi_processes'
+    'setup_multi_processes', 'get_caller_name', 'log_img_scale'
 ]

--- a/mmdet/utils/logger.py
+++ b/mmdet/utils/logger.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import inspect
 import logging
 
 from mmcv.utils import get_logger
@@ -18,3 +19,47 @@ def get_root_logger(log_file=None, log_level=logging.INFO):
     logger = get_logger(name='mmdet', log_file=log_file, log_level=log_level)
 
     return logger
+
+
+def get_caller_name():
+    """Get name of caller method."""
+    # this_func_frame = inspect.stack()[0][0]  # i.e., get_caller_name
+    # callee_frame = inspect.stack()[1][0]  # e.g., log_img_scale
+    caller_frame = inspect.stack()[2][0]  # e.g., caller of log_img_scale
+    caller_method = caller_frame.f_code.co_name
+    try:
+        caller_class = caller_frame.f_locals['self'].__class__.__name__
+        return f'{caller_class}.{caller_method}'
+    except KeyError:  # caller is a function
+        return caller_method
+
+
+def log_img_scale(img_scale, shape_order='hw', skip_square=False):
+    """Log image size.
+
+    Args:
+        img_scale (tuple): Image size to be logged.
+        shape_order (str, optional): The order of image shape.
+            'hw' for (height, width) and 'wh' for (width, height).
+            Defaults to 'hw'.
+        skip_square (bool, optional): Whether to skip logging for square
+            img_scale. Defaults to False.
+
+    Returns:
+        bool: Whether to have done logging.
+    """
+    if shape_order == 'hw':
+        height, width = img_scale
+    elif shape_order == 'wh':
+        width, height = img_scale
+    else:
+        raise ValueError(f'Invalid shape_order {shape_order}.')
+
+    if skip_square and (height == width):
+        return False
+
+    logger = get_root_logger()
+    caller = get_caller_name()
+    logger.info(f'image shape: height={height}, width={width} in {caller}')
+
+    return True

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,8 +1,9 @@
 matplotlib
 numpy
-# python<=3.8 can easily use this platform choise to define which pycocotools to use.
-# however, I can not fix it with python3.9
 pycocotools; platform_system == "Linux"
-pycocotools-windows; platform_system == "Windows"
+# we have a easy way to deal with python<=3.8
+pycocotools-windows; platform_system == "Windows" and python_version <= '3.8'
+# if python>3.8, you have to install Visual C++ 14.0 or greater from "https://visualstudio.microsoft.com/visual-cpp-build-tools" first. Then you can build pycocotools in your computer.
+pycocotools; platform_system == "Windows" and python_version > '3.8'
 six
 terminaltables

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,8 @@
 matplotlib
 numpy
-pycocotools; platform=="Linux"
-pycocotools-windows; platform=="Windows"
+# python<=3.8 can easily use this platform choise to define which pycocotools to use.
+# however, I can not fix it with python3.9
+pycocotools; platform_system == "Linux"
+pycocotools-windows; platform_system == "Windows"
 six
 terminaltables

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 matplotlib
 numpy
-pycocotools
+pycocotools; platform=="Linux"
+pycocotools-windows; platform=="Windows"
 six
 terminaltables

--- a/tests/test_data/test_pipelines/test_loading.py
+++ b/tests/test_data/test_pipelines/test_loading.py
@@ -27,7 +27,7 @@ class TestLoading:
         assert results['img_shape'] == (288, 512, 3)
         assert results['ori_shape'] == (288, 512, 3)
         assert repr(transform) == transform.__class__.__name__ + \
-            "(to_float32=False, color_type='color', " + \
+            "(to_float32=False, color_type='color', channel_order='bgr', " + \
             "file_client_args={'backend': 'disk'})"
 
         # no img_prefix

--- a/tests/test_utils/test_logger.py
+++ b/tests/test_utils/test_logger.py
@@ -1,0 +1,47 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+
+from mmdet.utils import get_caller_name, log_img_scale
+
+
+def callee_func():
+    caller_name = get_caller_name()
+    return caller_name
+
+
+class CallerClassForTest:
+
+    def __init__(self):
+        self.caller_name = callee_func()
+
+
+def test_get_caller_name():
+    # test the case that caller is a function
+    caller_name = callee_func()
+    assert caller_name == 'test_get_caller_name'
+
+    # test the case that caller is a method in a class
+    caller_class = CallerClassForTest()
+    assert caller_class.caller_name == 'CallerClassForTest.__init__'
+
+
+def test_log_img_scale():
+    img_scale = (800, 1333)
+    done_logging = log_img_scale(img_scale)
+    assert done_logging
+
+    img_scale = (1333, 800)
+    done_logging = log_img_scale(img_scale, shape_order='wh')
+    assert done_logging
+
+    with pytest.raises(ValueError):
+        img_scale = (1333, 800)
+        done_logging = log_img_scale(img_scale, shape_order='xywh')
+
+    img_scale = (640, 640)
+    done_logging = log_img_scale(img_scale, skip_square=False)
+    assert done_logging
+
+    img_scale = (640, 640)
+    done_logging = log_img_scale(img_scale, skip_square=True)
+    assert not done_logging

--- a/tools/test.py
+++ b/tools/test.py
@@ -143,7 +143,11 @@ def main():
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True
 
-    cfg.model.pretrained = None
+    if 'pretrained' in cfg.model:
+        cfg.model.pretrained = None
+    elif 'init_cfg' in cfg.model.backbone:
+        cfg.model.backbone.init_cfg = None
+
     if cfg.model.get('neck'):
         if isinstance(cfg.model.neck, list):
             for neck_cfg in cfg.model.neck:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Using python 3.8 in Windows and pycocotools cannot be installed. So change to this one.

## Modification

add platform check.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
no

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
pip install mdmet

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.


## error like this 
```
(py38) PS C:\Users\Administrator> pip install mmdet==2.22.0 -i https://pypi.tuna.tsinghua.edu.cn/simple
Looking in indexes: https://pypi.tuna.tsinghua.edu.cn/simple
Collecting mmdet==2.22.0
  Downloading https://pypi.tuna.tsinghua.edu.cn/packages/66/61/0e03c564c04d3d84a2d4f6e218c1fa287e61955322dcaa943f66ec4fbae9/mmdet-2.22.0-py3-none-any.whl (1.3 MB)
     |████████████████████████████████| 1.3 MB 544 kB/s
Requirement already satisfied: six in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from mmdet==2.22.0) (1.16.0)
Collecting pycocotools
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/75/5c/ac61ea715d7a89ecc31c090753bde28810238225ca8b71778dfe3e6a68bc/pycocotools-2.0.4.tar.gz (106 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: matplotlib in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from mmdet==2.22.0) (3.5.1)
Requirement already satisfied: numpy in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from mmdet==2.22.0) (1.22.3)
Requirement already satisfied: terminaltables in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from mmdet==2.22.0) (3.1.10)
Requirement already satisfied: kiwisolver>=1.0.1 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (1.3.2)
Requirement already satisfied: pyparsing>=2.2.1 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (3.0.7)
Requirement already satisfied: fonttools>=4.22.0 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (4.30.0)
Requirement already satisfied: packaging>=20.0 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (21.3)
Requirement already satisfied: cycler>=0.10 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (0.11.0)
Requirement already satisfied: python-dateutil>=2.7 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (2.8.2)
Requirement already satisfied: pillow>=6.2.0 in c:\users\administrator\miniconda3\envs\py38\lib\site-packages (from matplotlib->mmdet==2.22.0) (9.0.1)
Building wheels for collected packages: pycocotools
  Building wheel for pycocotools (PEP 517) ... error
  ERROR: Command errored out with exit status 1:
   command: 'C:\Users\Administrator\miniconda3\envs\py38\python.exe' 'C:\Users\Administrator\miniconda3\envs\py38\lib\site-packages\pip\_vendor\pep517\in_process\_in_process.py' build_wheel 'C:\Users\ADMINI~1\AppData\Local\Temp\tmprgehj4jg'
       cwd: C:\Users\Administrator\AppData\Local\Temp\pip-install-skr_hg80\pycocotools_9e584a053ba44d929b7530e67949486d
  Complete output (14 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build\lib.win-amd64-3.8
  creating build\lib.win-amd64-3.8\pycocotools
  copying pycocotools\coco.py -> build\lib.win-amd64-3.8\pycocotools
  copying pycocotools\cocoeval.py -> build\lib.win-amd64-3.8\pycocotools
  copying pycocotools\mask.py -> build\lib.win-amd64-3.8\pycocotools
  copying pycocotools\__init__.py -> build\lib.win-amd64-3.8\pycocotools
  running build_ext
  skipping 'pycocotools\_mask.c' Cython extension (up-to-date)
  building 'pycocotools._mask' extension
  error: Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft C++ Build Tools": https://visualstudio.microsoft.com/visual-cpp-build-tools/
  ----------------------------------------
  ERROR: Failed building wheel for pycocotools
Failed to build pycocotools
ERROR: Could not build wheels for pycocotools which use PEP 517 and cannot be installed directly
```

