### PR TITLE
[Feature] Support automatically scaling LR according to GPU number and samples per GPU

### DIFF
--- a/configs/_base_/datasets/cityscapes_detection.py
+++ b/configs/_base_/datasets/cityscapes_detection.py
@@ -54,3 +54,6 @@ data = dict(
         img_prefix=data_root + 'leftImg8bit/test/',
         pipeline=test_pipeline))
 evaluation = dict(interval=1, metric='bbox')
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/_base_/datasets/cityscapes_instance.py
+++ b/configs/_base_/datasets/cityscapes_instance.py
@@ -54,3 +54,6 @@ data = dict(
         img_prefix=data_root + 'leftImg8bit/test/',
         pipeline=test_pipeline))
 evaluation = dict(metric=['bbox', 'segm'])
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/_base_/datasets/wider_face.py
+++ b/configs/_base_/datasets/wider_face.py
@@ -61,3 +61,6 @@ data = dict(
         ann_file=data_root + 'val.txt',
         img_prefix=data_root + 'WIDER_val/',
         pipeline=test_pipeline))
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 60

--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -19,3 +19,6 @@ workflow = [('train', 1)]
 opencv_num_threads = 0
 # set multi-process start method as `fork` to speed up the training
 mp_start_method = 'fork'
+
+# default number of GPU for mmdet, in order to support automatically scaling LR according to GPU number.
+default_gpu_number = 8

--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -20,5 +20,6 @@ opencv_num_threads = 0
 # set multi-process start method as `fork` to speed up the training
 mp_start_method = 'fork'
 
-# default number of GPU for mmdet, in order to support automatically scaling LR according to GPU number.
+# default number of GPU for mmdet,
+# in order to support automatically scaling LR according to GPU number.
 default_gpu_number = 8

--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -20,6 +20,6 @@ opencv_num_threads = 0
 # set multi-process start method as `fork` to speed up the training
 mp_start_method = 'fork'
 
-# default number of GPU for mmdet,
-# in order to support automatically scaling LR according to GPU number.
-default_gpu_number = 8
+# In order to support automatically scaling LR.
+default_gpu_number = 8  # default number of GPU for mmdet
+default_samples_per_gpu = 2  # default samples per GPU for mmdet

--- a/configs/centernet/centernet_resnet18_dcnv2_140e_coco.py
+++ b/configs/centernet/centernet_resnet18_dcnv2_140e_coco.py
@@ -120,3 +120,6 @@ lr_config = dict(
     warmup_ratio=1.0 / 1000,
     step=[18, 24])  # the real step is [18*5, 24*5]
 runner = dict(max_epochs=28)  # the real epoch is 28*5=140
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 16

--- a/configs/centripetalnet/centripetalnet_hourglass104_mstest_16x6_210e_coco.py
+++ b/configs/centripetalnet/centripetalnet_hourglass104_mstest_16x6_210e_coco.py
@@ -103,3 +103,7 @@ lr_config = dict(
     warmup_ratio=1.0 / 3,
     step=[190])
 runner = dict(type='EpochBasedRunner', max_epochs=210)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 16
+mmdet_official_special_samples_per_gpu = 6

--- a/configs/cornernet/cornernet_hourglass104_mstest_10x5_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_10x5_210e_coco.py
@@ -103,3 +103,6 @@ lr_config = dict(
     warmup_ratio=1.0 / 3,
     step=[180])
 runner = dict(type='EpochBasedRunner', max_epochs=210)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 5

--- a/configs/cornernet/cornernet_hourglass104_mstest_32x3_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_32x3_210e_coco.py
@@ -103,3 +103,6 @@ lr_config = dict(
     warmup_ratio=1.0 / 3,
     step=[180])
 runner = dict(type='EpochBasedRunner', max_epochs=210)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 3

--- a/configs/cornernet/cornernet_hourglass104_mstest_8x6_210e_coco.py
+++ b/configs/cornernet/cornernet_hourglass104_mstest_8x6_210e_coco.py
@@ -103,3 +103,6 @@ lr_config = dict(
     warmup_ratio=1.0 / 3,
     step=[180])
 runner = dict(type='EpochBasedRunner', max_epochs=210)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 6

--- a/configs/dyhead/atss_r50_caffe_fpn_dyhead_1x_coco.py
+++ b/configs/dyhead/atss_r50_caffe_fpn_dyhead_1x_coco.py
@@ -110,3 +110,6 @@ data = dict(
     train=dict(pipeline=train_pipeline),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 4

--- a/configs/dyhead/atss_r50_fpn_dyhead_1x_coco.py
+++ b/configs/dyhead/atss_r50_fpn_dyhead_1x_coco.py
@@ -63,3 +63,6 @@ model = dict(
         max_per_img=100))
 # optimizer
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 4

--- a/configs/fcos/fcos_r50_caffe_fpn_gn-head_4x4_1x_coco.py
+++ b/configs/fcos/fcos_r50_caffe_fpn_gn-head_4x4_1x_coco.py
@@ -2,3 +2,6 @@
 _base_ = 'fcos_r50_caffe_fpn_gn-head_1x_coco.py'
 
 data = dict(samples_per_gpu=4, workers_per_gpu=4)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 4

--- a/configs/foveabox/fovea_r50_fpn_4x4_1x_coco.py
+++ b/configs/foveabox/fovea_r50_fpn_4x4_1x_coco.py
@@ -50,3 +50,7 @@ model = dict(
 data = dict(samples_per_gpu=4, workers_per_gpu=4)
 # optimizer
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 4
+mmdet_official_special_samples_per_gpu = 4

--- a/configs/fpg/faster_rcnn_r50_fpn_crop640_50e_coco.py
+++ b/configs/fpg/faster_rcnn_r50_fpn_crop640_50e_coco.py
@@ -66,3 +66,6 @@ lr_config = dict(
 # runtime settings
 runner = dict(max_epochs=50)
 evaluation = dict(interval=2)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/fpg/mask_rcnn_r50_fpn_crop640_50e_coco.py
+++ b/configs/fpg/mask_rcnn_r50_fpn_crop640_50e_coco.py
@@ -72,3 +72,6 @@ lr_config = dict(
 # runtime settings
 runner = dict(max_epochs=50)
 evaluation = dict(interval=2)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/htc/htc_x101_32x4d_fpn_16x1_20e_coco.py
+++ b/configs/htc/htc_x101_32x4d_fpn_16x1_20e_coco.py
@@ -17,3 +17,6 @@ data = dict(samples_per_gpu=1, workers_per_gpu=1)
 # learning policy
 lr_config = dict(step=[16, 19])
 runner = dict(type='EpochBasedRunner', max_epochs=20)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/htc/htc_x101_64x4d_fpn_16x1_20e_coco.py
+++ b/configs/htc/htc_x101_64x4d_fpn_16x1_20e_coco.py
@@ -17,3 +17,6 @@ data = dict(samples_per_gpu=1, workers_per_gpu=1)
 # learning policy
 lr_config = dict(step=[16, 19])
 runner = dict(type='EpochBasedRunner', max_epochs=20)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/htc/htc_x101_64x4d_fpn_dconv_c3-c5_mstrain_400_1400_16x1_20e_coco.py
+++ b/configs/htc/htc_x101_64x4d_fpn_dconv_c3-c5_mstrain_400_1400_16x1_20e_coco.py
@@ -41,3 +41,6 @@ data = dict(
 # learning policy
 lr_config = dict(step=[16, 19])
 runner = dict(type='EpochBasedRunner', max_epochs=20)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/lad/lad_r101_paa_r50_fpn_coco_1x.py
+++ b/configs/lad/lad_r101_paa_r50_fpn_coco_1x.py
@@ -119,3 +119,6 @@ model = dict(
 data = dict(samples_per_gpu=8, workers_per_gpu=4)
 optimizer = dict(lr=0.01)
 fp16 = dict(loss_scale=512.)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/lad/lad_r50_paa_r101_fpn_coco_1x.py
+++ b/configs/lad/lad_r50_paa_r101_fpn_coco_1x.py
@@ -118,3 +118,6 @@ model = dict(
 data = dict(samples_per_gpu=8, workers_per_gpu=4)
 optimizer = dict(lr=0.01)
 fp16 = dict(loss_scale=512.)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/legacy_1.x/ssd300_coco_v1.py
+++ b/configs/legacy_1.x/ssd300_coco_v1.py
@@ -77,3 +77,6 @@ data = dict(
 optimizer = dict(type='SGD', lr=2e-3, momentum=0.9, weight_decay=5e-4)
 optimizer_config = dict(_delete_=True)
 dist_params = dict(backend='nccl', port=29555)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/maskformer/maskformer_r50_mstrain_16x1_75e_coco.py
+++ b/configs/maskformer/maskformer_r50_mstrain_16x1_75e_coco.py
@@ -218,3 +218,7 @@ lr_config = dict(
     warmup_ratio=1.0,  # no warmup
     warmup_iters=10)
 runner = dict(type='EpochBasedRunner', max_epochs=75)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 16
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/nas_fcos/nas_fcos_fcoshead_r50_caffe_fpn_gn-head_4x4_1x_coco.py
+++ b/configs/nas_fcos/nas_fcos_fcoshead_r50_caffe_fpn_gn-head_4x4_1x_coco.py
@@ -98,3 +98,7 @@ data = dict(
 
 optimizer = dict(
     lr=0.01, paramwise_cfg=dict(bias_lr_mult=2., bias_decay_mult=0.))
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 4
+mmdet_official_special_samples_per_gpu = 4

--- a/configs/nas_fcos/nas_fcos_nashead_r50_caffe_fpn_gn-head_4x4_1x_coco.py
+++ b/configs/nas_fcos/nas_fcos_nashead_r50_caffe_fpn_gn-head_4x4_1x_coco.py
@@ -97,3 +97,7 @@ data = dict(
 
 optimizer = dict(
     lr=0.01, paramwise_cfg=dict(bias_lr_mult=2., bias_decay_mult=0.))
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 4
+mmdet_official_special_samples_per_gpu = 4

--- a/configs/nas_fpn/retinanet_r50_fpn_crop640_50e_coco.py
+++ b/configs/nas_fpn/retinanet_r50_fpn_crop640_50e_coco.py
@@ -78,3 +78,6 @@ lr_config = dict(
     step=[30, 40])
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=50)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/nas_fpn/retinanet_r50_nasfpn_crop640_50e_coco.py
+++ b/configs/nas_fpn/retinanet_r50_nasfpn_crop640_50e_coco.py
@@ -77,3 +77,6 @@ lr_config = dict(
     step=[30, 40])
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=50)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/openimages/ssd300_32x8_36e_openimages.py
+++ b/configs/openimages/ssd300_32x8_36e_openimages.py
@@ -76,3 +76,7 @@ lr_config = dict(
     warmup_iters=20000,
     warmup_ratio=0.001,
     step=[8, 11])
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_gpu_number = 32
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/pascal_voc/ssd300_voc0712.py
+++ b/configs/pascal_voc/ssd300_voc0712.py
@@ -67,3 +67,6 @@ lr_config = dict(
 checkpoint_config = dict(interval=1)
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=24)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/pvt/retinanet_pvtv2-b4_fpn_1x_coco.py
+++ b/configs/pvt/retinanet_pvtv2-b4_fpn_1x_coco.py
@@ -11,3 +11,6 @@ optimizer = dict(
     _delete_=True, type='AdamW', lr=0.0001 / 1.4, weight_decay=0.0001)
 # dataset settings
 data = dict(samples_per_gpu=1, workers_per_gpu=1)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/pvt/retinanet_pvtv2-b5_fpn_1x_coco.py
+++ b/configs/pvt/retinanet_pvtv2-b5_fpn_1x_coco.py
@@ -5,10 +5,13 @@ model = dict(
         num_layers=[3, 6, 40, 3],
         mlp_ratios=(4, 4, 4, 4),
         init_cfg=dict(checkpoint='https://github.com/whai362/PVT/'
-                      'releases/download/v2/pvt_v2_b5.pth')),
+                                 'releases/download/v2/pvt_v2_b5.pth')),
     neck=dict(in_channels=[64, 128, 320, 512]))
 # optimizer
 optimizer = dict(
     _delete_=True, type='AdamW', lr=0.0001 / 1.4, weight_decay=0.0001)
 # dataset settings
 data = dict(samples_per_gpu=1, workers_per_gpu=1)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/scnet/scnet_x101_64x4d_fpn_8x1_20e_coco.py
+++ b/configs/scnet/scnet_x101_64x4d_fpn_8x1_20e_coco.py
@@ -1,3 +1,6 @@
 _base_ = './scnet_x101_64x4d_fpn_20e_coco.py'
 data = dict(samples_per_gpu=1, workers_per_gpu=1)
 optimizer = dict(type='SGD', lr=0.01, momentum=0.9, weight_decay=0.0001)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 1

--- a/configs/ssd/ssd300_coco.py
+++ b/configs/ssd/ssd300_coco.py
@@ -64,3 +64,6 @@ custom_hooks = [
     dict(type='NumClassCheckHook'),
     dict(type='CheckInvalidLossHook', interval=50, priority='VERY_LOW')
 ]
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/ssd/ssd512_coco.py
+++ b/configs/ssd/ssd512_coco.py
@@ -77,3 +77,6 @@ custom_hooks = [
     dict(type='NumClassCheckHook'),
     dict(type='CheckInvalidLossHook', interval=50, priority='VERY_LOW')
 ]
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
+++ b/configs/ssd/ssdlite_mobilenetv2_scratch_600e_coco.py
@@ -143,3 +143,6 @@ custom_hooks = [
     dict(type='NumClassCheckHook'),
     dict(type='CheckInvalidLossHook', interval=50, priority='VERY_LOW')
 ]
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 24

--- a/configs/yolact/yolact_r50_1x8_coco.py
+++ b/configs/yolact/yolact_r50_1x8_coco.py
@@ -158,3 +158,6 @@ lr_config = dict(
 runner = dict(type='EpochBasedRunner', max_epochs=55)
 cudnn_benchmark = True
 evaluation = dict(metric=['bbox', 'segm'])
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py
+++ b/configs/yolo/yolov3_d53_mstrain-608_273e_coco.py
@@ -125,3 +125,6 @@ lr_config = dict(
 # runtime settings
 runner = dict(type='EpochBasedRunner', max_epochs=273)
 evaluation = dict(interval=1, metric=['bbox'])
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py
+++ b/configs/yolo/yolov3_mobilenetv2_mstrain-416_300e_coco.py
@@ -135,3 +135,6 @@ lr_config = dict(
 runner = dict(type='EpochBasedRunner', max_epochs=30)
 evaluation = dict(interval=1, metric=['bbox'])
 find_unused_parameters = True
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 24

--- a/configs/yolof/yolof_r50_c5_8x8_1x_coco.py
+++ b/configs/yolof/yolof_r50_c5_8x8_1x_coco.py
@@ -103,3 +103,7 @@ data = dict(
     train=dict(pipeline=train_pipeline),
     val=dict(pipeline=test_pipeline),
     test=dict(pipeline=test_pipeline))
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8
+

--- a/configs/yolox/yolox_s_8x8_300e_coco.py
+++ b/configs/yolox/yolox_s_8x8_300e_coco.py
@@ -158,3 +158,6 @@ evaluation = dict(
     dynamic_intervals=[(max_epochs - num_last_epochs, 1)],
     metric='bbox')
 log_config = dict(interval=50)
+
+# NOTE: This is for automatically scaling LR, USER CAN'T CHANGE THIS VALUE
+mmdet_official_special_samples_per_gpu = 8

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -125,15 +125,15 @@ def train_detector(model,
     # Automatically scaling LR according to GPU number
     if len(cfg.gpu_ids) != cfg.default_gpu_number:
         # Get original LR from config
-        optimizer_original = cfg.optimizer.get("lr", 0)
-        assert optimizer_original != 0
+        original_lr = cfg.optimizer.get("lr", 0)
+        assert original_lr != 0
 
         # scale LR according to paper [linear scaling rule](https://arxiv.org/abs/1706.02677)
-        scaled_lr = (len(cfg.gpu_ids) * cfg.data.samples_per_gpu) / optimizer_original
+        scaled_lr = (len(cfg.gpu_ids) * cfg.data.samples_per_gpu) / original_lr
         cfg.optimizer.update({"lr": scaled_lr})
 
         logger.info(f'You are using {len(cfg.gpu_ids)} GPU(s), '
-                    f'automatically scaling LR from {optimizer_original} to {scaled_lr}')
+                    f'automatically scaling LR from {original_lr} to {scaled_lr}')
 
     # build optimizer
     optimizer = build_optimizer(model, cfg.optimizer)

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -135,7 +135,7 @@ def train_detector(model,
         logger.info(f'You are using {len(cfg.gpu_ids)} GPU(s), '
                     f'automatically scaling LR from {optimizer_original} to {scaled_lr}')
 
-    # build runner optimizer
+    # build optimizer
     optimizer = build_optimizer(model, cfg.optimizer)
 
     # build runner

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -132,7 +132,8 @@ def train_detector(model,
         scaled_lr = (len(cfg.gpu_ids) * cfg.data.samples_per_gpu) / original_lr
         cfg.optimizer.update({"lr": scaled_lr})
 
-        logger.info(f'You are using {len(cfg.gpu_ids)} GPU(s), '
+        logger.info(f'You are using {len(cfg.gpu_ids)} GPU(s) '
+                    f'and {cfg.data.samples_per_gpu} samples per gpu, '
                     f'automatically scaling LR from {original_lr} to {scaled_lr}')
 
     # build optimizer

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -129,7 +129,9 @@ def train_detector(model,
         assert original_lr != 0
 
         # scale LR according to paper [linear scaling rule](https://arxiv.org/abs/1706.02677)
-        scaled_lr = (len(cfg.gpu_ids) * cfg.data.samples_per_gpu) / original_lr
+        batch_size = len(cfg.gpu_ids) * cfg.data.samples_per_gpu
+        original_batch_size = cfg.default_gpu_number * cfg.data.samples_per_gpu
+        scaled_lr = (batch_size / original_batch_size) * original_lr
         cfg.optimizer.update({"lr": scaled_lr})
 
         logger.info(f'You are using {len(cfg.gpu_ids)} GPU(s) '


### PR DESCRIPTION
## Motivation

Support automatically scaling LR according to GPU number and samples per GPU
 
## Modification

- Add `scale_lr` before build_optimizer in function `train_detector`.
- Add `default_gpu_number = 8` and `default_samples_per_gpu = 2` in `configs/_base_/default_runtime.py`.
- Add `mmdet_official_special_gpu_number` or `mmdet_official_special_samples_per_gpu` in the config file which is not using the default setting.

![image](https://user-images.githubusercontent.com/25873202/157913377-7c6f240b-3ba3-4004-8f8e-c94dc02e7dc3.png)


- print `original LR` and `scaled LR` to the terminal log when the training start.

![4027845ee62c82a23fb1439edc6f7fc](https://user-images.githubusercontent.com/25873202/157913236-a355ccdd-6144-4169-86db-e9c31fe9c8a9.png)

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

## Need Help:
I don't konw hwo to do the scale LR when using distributed mode. 

pls review, thx 😁   @jbwang1997 
