### PR TITLE
[Fix] new params misplaced in loadannotation

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -442,9 +442,14 @@ class LoadPanopticAnnotations(LoadAnnotations):
                 'pip install git+https://github.com/cocodataset/'
                 'panopticapi.git.')
 
-        super(LoadPanopticAnnotations,
-              self).__init__(with_bbox, with_label, with_mask, with_seg, True,
-                             file_client_args)
+        super(LoadPanopticAnnotations, self).__init__(
+            with_bbox=with_bbox,
+            with_label=with_label,
+            with_mask=with_mask,
+            with_seg=with_seg,
+            poly2mask=True,
+            denorm_bbox=False,
+            file_client_args=file_client_args)
 
     def _load_masks_and_semantic_segs(self, results):
         """Private function to load mask and semantic segmentation annotations.


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

New params added in `LoadAnnotation` misplaced by https://github.com/open-mmlab/mmdetection/pull/6331 , which cause that the value `True` passed to `denorm_bbox` instead of `poly2mask` in `LoadPanopticAnnotations`, see  https://github.com/open-mmlab/mmdetection/blob/70f6d9cfade4a2f0b198e4f64776521d181b28be/mmdet/datasets/pipelines/loading.py#L442

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
