### PR TITLE
Dedicated WandbLogger for MMDetection

### DIFF
--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -18,8 +18,7 @@ def single_gpu_test(model,
                     data_loader,
                     show=False,
                     out_dir=None,
-                    show_score_thr=0.3,
-                    rescale=True):
+                    show_score_thr=0.3):
     model.eval()
     results = []
     dataset = data_loader.dataset
@@ -27,7 +26,7 @@ def single_gpu_test(model,
     prog_bar = mmcv.ProgressBar(len(dataset))
     for i, data in enumerate(data_loader):
         with torch.no_grad():
-            result = model(return_loss=False, rescale=rescale, **data)
+            result = model(return_loss=False, rescale=True, **data)
 
         batch_size = len(result)
         if show or out_dir:

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -18,7 +18,8 @@ def single_gpu_test(model,
                     data_loader,
                     show=False,
                     out_dir=None,
-                    show_score_thr=0.3):
+                    show_score_thr=0.3,
+                    rescale=True):
     model.eval()
     results = []
     dataset = data_loader.dataset
@@ -26,7 +27,7 @@ def single_gpu_test(model,
     prog_bar = mmcv.ProgressBar(len(dataset))
     for i, data in enumerate(data_loader):
         with torch.no_grad():
-            result = model(return_loss=False, rescale=True, **data)
+            result = model(return_loss=False, rescale=rescale, **data)
 
         batch_size = len(result)
         if show or out_dir:

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -77,7 +77,7 @@ def multi_gpu_test(model, data_loader, tmpdir=None, gpu_collect=False):
     This method tests model with multiple gpus and collects the results
     under two different modes: gpu and cpu modes. By setting 'gpu_collect=True'
     it encodes results to gpu tensors and use gpu communication for results
-    collection. On cpu mode it saves the results on different gpus to 'tmpdir'
+    collection. On cpu mode it saves the results of different gpus to 'tmpdir'
     and collects them by the rank 0 worker.
 
     Args:

--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -115,7 +115,7 @@ class DistEvalHook(BaseDistEvalHook):
             tmpdir = osp.join(runner.work_dir, '.eval_hook')
 
         from mmdet.apis import multi_gpu_test
-        results = multi_gpu_test(
+        self.results = multi_gpu_test(
             runner.model,
             self.dataloader,
             tmpdir=tmpdir,
@@ -123,7 +123,7 @@ class DistEvalHook(BaseDistEvalHook):
         if runner.rank == 0:
             print('\n')
             runner.log_buffer.output['eval_iter_num'] = len(self.dataloader)
-            key_score = self.evaluate(runner, results)
+            key_score = self.evaluate(runner, self.results)
 
             # the key_score may be `None` so it needs to skip
             # the action to save the best checkpoint

--- a/mmdet/core/evaluation/eval_hooks.py
+++ b/mmdet/core/evaluation/eval_hooks.py
@@ -53,9 +53,10 @@ class EvalHook(BaseEvalHook):
             return
 
         from mmdet.apis import single_gpu_test
-        results = single_gpu_test(runner.model, self.dataloader, show=False)
+        self.results = single_gpu_test(
+            runner.model, self.dataloader, show=False)
         runner.log_buffer.output['eval_iter_num'] = len(self.dataloader)
-        key_score = self.evaluate(runner, results)
+        key_score = self.evaluate(runner, self.results)
         # the key_score may be `None` so it needs to skip the action to save
         # the best checkpoint
         if self.save_best and key_score:

--- a/mmdet/core/hook/__init__.py
+++ b/mmdet/core/hook/__init__.py
@@ -4,11 +4,12 @@ from .ema import ExpMomentumEMAHook, LinearMomentumEMAHook
 from .set_epoch_info_hook import SetEpochInfoHook
 from .sync_norm_hook import SyncNormHook
 from .sync_random_size_hook import SyncRandomSizeHook
+from .wandblogger_hook import WandbLogger
 from .yolox_lrupdater_hook import YOLOXLrUpdaterHook
 from .yolox_mode_switch_hook import YOLOXModeSwitchHook
 
 __all__ = [
     'SyncRandomSizeHook', 'YOLOXModeSwitchHook', 'SyncNormHook',
     'ExpMomentumEMAHook', 'LinearMomentumEMAHook', 'YOLOXLrUpdaterHook',
-    'CheckInvalidLossHook', 'SetEpochInfoHook'
+    'CheckInvalidLossHook', 'SetEpochInfoHook', 'WandbLogger'
 ]

--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -23,6 +23,7 @@ class WandbLogger(WandbLoggerHook):
                  by_epoch=True,
                  with_step=True,
                  log_checkpoint=False,
+                 log_checkpoint_metadata=False,
                  log_evaluation=False):
         super(WandbLogger, self).__init__(
             init_kwargs,
@@ -35,7 +36,10 @@ class WandbLogger(WandbLoggerHook):
         )
 
         self.log_checkpoint = log_checkpoint
+        self.log_checkpoint_metadata = log_checkpoint_metadata
         self.log_evaluation = log_evaluation
+
+        self.best_map_score = 0
 
     @master_only
     def before_run(self, runner):
@@ -43,8 +47,8 @@ class WandbLogger(WandbLoggerHook):
         self.cfg = self.wandb.config
         if len(dict(self.cfg)) == 0:
             warnings.warn(
-                'To log mmdetection Config,\
-                pass it to init_kwargs of WandbLogger.', UserWarning)
+                'To log mmdetection Config,'
+                'pass it to init_kwargs of WandbLogger.', UserWarning)
 
         for hook in runner.hooks:
             if isinstance(hook, EvalHook):
@@ -53,21 +57,22 @@ class WandbLogger(WandbLoggerHook):
                 ckpt_hook = hook
 
         if 'ckpt_hook' in locals():
-            pass
+            self.ckpt_hook = ckpt_hook
         else:
             self.log_checkpoint = False
 
         if 'eval_hook' in locals():
-            self.dataloader = eval_hook.dataloader
-            self.dataset = self.dataloader.dataset
+            self.eval_hook = eval_hook
+            self.val_dataloader = eval_hook.dataloader
+            self.val_dataset = self.val_dataloader.dataset
         else:
             self.log_evaluation = False
             warnings.warn(
-                'To use log_evaluation turn validate\
-                to True in train_detector.', UserWarning)
+                'To use log_evaluation turn validate '
+                'to True in train_detector.', UserWarning)
 
         if self.log_checkpoint:
-            # Remove model checkpoint from previous run.
+            # Remove model checkpoints from previous run.
             files = glob.glob(f'{runner.work_dir}/*.pth')
             for f in files:
                 os.remove(f)
@@ -76,46 +81,104 @@ class WandbLogger(WandbLoggerHook):
             # Initialize data table
             self._init_data_table()
             # Add data to the table
-            self._add_data_table()
+            self._add_ground_truth()
 
     @master_only
     def after_train_epoch(self, runner):
-        # print(runner.hooks)
-        pass
+        if self.log_checkpoint:
+            if self.ckpt_hook.by_epoch:
+                if self.every_n_epochs(runner, self.ckpt_hook.interval) or (
+                        self.ckpt_hook.save_last
+                        and self.is_last_epoch(runner)):
+                    if self.log_checkpoint_metadata and self.eval_hook:
+                        metadata = self._get_ckpt_metadata(runner)
+                        aliases = [f'epoch_{runner.epoch+1}', 'latest']
+                        if self._is_best_ckpt(metadata):
+                            aliases.append('best')
+                        self._log_ckpt_as_artifact(self.ckpt_hook.out_dir,
+                                                   runner.epoch, aliases,
+                                                   metadata)
+                    else:
+                        aliases = [f'epoch_{runner.epoch+1}', 'latest']
+                        self._log_ckpt_as_artifact(self.ckpt_hook.out_dir,
+                                                   runner.epoch, aliases)
+
+        if self.log_evaluation:
+            if self.eval_hook.by_epoch:
+                if self.every_n_epochs(
+                        runner,
+                        self.eval_hook.interval) or self.is_last_epoch(runner):
+                    runner.logger.info(
+                        f'Running inference at epoch {runner.epoch+1} for W&B '
+                        f'evaluation table which will be saved as W&B Tables.')
+                    from mmdet.apis import single_gpu_test
+                    self.results = single_gpu_test(
+                        runner.model,
+                        self.val_dataloader,
+                        show=False,
+                        rescale=False)
+                    # Initialize evaluation table
+                    self._init_pred_table()
+                    # Log predictions
+                    self._log_predictions(runner.epoch + 1)
+                    # Log the table
+                    self._log_eval_table()
 
     @master_only
     def after_run(self, runner):
-        from mmdet.apis import single_gpu_test
-        self.results = single_gpu_test(
-            runner.model, self.dataloader, show=False, rescale=False)
-
-        # Model evaluation
-        if self.log_evaluation:
-            # Initialize evaluation table
-            self._init_pred_table(f'run_{self.wandb.run.id}_pred')
-            # Log predictions
-            self._log_predictions()
-            # Log the table
-            self._log_table()
-
         self.wandb.finish()
 
-    def _init_data_table(self, name='val'):
-        self.data_artifact = self.wandb.Artifact(name, type='dataset')
+    def _log_ckpt_as_artifact(self,
+                              path_to_model,
+                              epoch,
+                              aliases,
+                              metadata=None):
+        model_artifact = self.wandb.Artifact(
+            f'run_{self.wandb.run.id}_model', type='model', metadata=metadata)
+        model_artifact.add_file(f'{path_to_model}/epoch_{epoch+1}.pth')
+        self.wandb.log_artifact(model_artifact, aliases=aliases)
+
+    def _get_ckpt_metadata(self, runner):
+        runner.logger.info(
+            f'Evaluating for model checkpoint at epoch '
+            f'{runner.epoch+1} which will be saved as W&B Artifact.')
+        from mmdet.apis import single_gpu_test
+        results = single_gpu_test(
+            runner.model, self.val_dataloader, show=False, rescale=True)
+        eval_results = self.val_dataset.evaluate(results)
+        map_score = eval_results.get('mAP', None)
+        if map_score:
+            metadata = dict(epoch=runner.epoch + 1, map_score=map_score)
+            return metadata
+        else:
+            warnings.warn(
+                'Set eval metric to mAP to get metadata for checkpoint.',
+                UserWarning)
+            return {}
+
+    def _is_best_ckpt(self, metadata):
+        map_score = metadata.get('map_score', None)
+        if map_score:
+            if map_score > self.best_map_score:
+                self.best_map_score = map_score
+                return True
+            else:
+                return False
+
+    def _init_data_table(self):
         columns = ['image_name', 'image']
         self.data_table = self.wandb.Table(columns=columns)
 
-    def _init_pred_table(self, name):
-        self.pred_artifact = self.wandb.Artifact(name, type='evaluation')
-        columns = ['image_name', 'ground_truth', 'prediction'] + list(
+    def _init_pred_table(self):
+        columns = ['epoch', 'image_name', 'ground_truth', 'prediction'] + list(
             self.class_id_to_label.values())
         self.eval_table = self.wandb.Table(columns=columns)
 
-    def _add_data_table(self):
-        num_images = len(self.dataset)
-        assert num_images == len(self.dataset.data_infos)
+    def _add_ground_truth(self):
+        num_images = len(self.val_dataset)
+        assert num_images == len(self.val_dataset.data_infos)
 
-        classes = self.dataset.get_classes()
+        classes = self.val_dataset.get_classes()
         self.class_id_to_label = {id: name for id, name in enumerate(classes)}
         self.class_set = self.wandb.Classes([{
             'id': id,
@@ -123,8 +186,8 @@ class WandbLogger(WandbLoggerHook):
         } for id, name in self.class_id_to_label.items()])
 
         for idx in range(num_images):
-            data_sample = self.dataset.prepare_test_img(idx)
-            data_ann = self.dataset.get_ann_info(idx)
+            data_sample = self.val_dataset.prepare_test_img(idx)
+            data_ann = self.val_dataset.get_ann_info(idx)
 
             img_meta = data_sample['img_metas'][0].data
             image = data_sample['img'][0].data
@@ -161,9 +224,9 @@ class WandbLogger(WandbLoggerHook):
                 image_name,
                 self.wandb.Image(image, boxes=boxes, classes=self.class_set))
 
-    def _log_predictions(self):
+    def _log_predictions(self, epoch):
         table_idxs = self.data_table.get_index()
-        assert len(self.results) == len(self.dataset) == len(table_idxs)
+        assert len(self.results) == len(self.val_dataset) == len(table_idxs)
 
         for ndx in table_idxs:
             result = self.results[ndx]
@@ -207,15 +270,20 @@ class WandbLogger(WandbLoggerHook):
                 }
             }
             self.eval_table.add_data(
-                self.data_table.data[ndx][0], self.data_table.data[ndx][1],
+                epoch, self.data_table.data[ndx][0],
+                self.data_table.data[ndx][1],
                 self.wandb.Image(
                     self.data_table.data[ndx][1],
                     boxes=boxes,
                     classes=self.class_set), *tuple(class_scores))
 
-    def _log_table(self):
-        self.data_artifact.add(self.data_table, 'val_data')
-        self.pred_artifact.add(self.eval_table, 'eval_data')
-
+    def _log_data_table(self):
+        data_artifact = self.wandb.Artifact('val', type='dataset')
+        data_artifact.add(self.data_table, 'val_data')
         self.wandb.run.log_artifact(self.data_artifact)
-        self.wandb.run.log_artifact(self.pred_artifact)
+
+    def _log_eval_table(self):
+        pred_artifact = self.wandb.Artifact(
+            f'run_{self.wandb.run.id}_pred', type='evaluation')
+        pred_artifact.add(self.eval_table, 'eval_data')
+        self.wandb.run.log_artifact(pred_artifact)

--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -147,7 +147,7 @@ class WandbLogger(WandbLoggerHook):
                         results, logger='silent')
                     for key, val in eval_results.items():
                         if isinstance(val, str):
-                            pass
+                            continue
                         self.wandb.log({f'val/{key}': val}, commit=False)
                     self.wandb.log({'val/val_step': self.val_step})
                     self.val_step += 1

--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -1,0 +1,221 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import glob
+import os
+import warnings
+
+from mmcv.runner import HOOKS
+from mmcv.runner.dist_utils import master_only
+from mmcv.runner.hooks.checkpoint import CheckpointHook
+from mmcv.runner.hooks.logger.wandb import WandbLoggerHook
+
+from mmdet.core import EvalHook
+
+
+@HOOKS.register_module()
+class WandbLogger(WandbLoggerHook):
+
+    def __init__(self,
+                 init_kwargs=None,
+                 interval=10,
+                 ignore_last=True,
+                 reset_flag=False,
+                 commit=True,
+                 by_epoch=True,
+                 with_step=True,
+                 log_checkpoint=False,
+                 log_evaluation=False):
+        super(WandbLogger, self).__init__(
+            init_kwargs,
+            interval,
+            ignore_last,
+            reset_flag,
+            commit,
+            by_epoch,
+            with_step,
+        )
+
+        self.log_checkpoint = log_checkpoint
+        self.log_evaluation = log_evaluation
+
+    @master_only
+    def before_run(self, runner):
+        super(WandbLogger, self).before_run(runner)
+        self.cfg = self.wandb.config
+        if len(dict(self.cfg)) == 0:
+            warnings.warn(
+                'To log mmdetection Config,\
+                pass it to init_kwargs of WandbLogger.', UserWarning)
+
+        for hook in runner.hooks:
+            if isinstance(hook, EvalHook):
+                eval_hook = hook
+            if isinstance(hook, CheckpointHook):
+                ckpt_hook = hook
+
+        if 'ckpt_hook' in locals():
+            pass
+        else:
+            self.log_checkpoint = False
+
+        if 'eval_hook' in locals():
+            self.dataloader = eval_hook.dataloader
+            self.dataset = self.dataloader.dataset
+        else:
+            self.log_evaluation = False
+            warnings.warn(
+                'To use log_evaluation turn validate\
+                to True in train_detector.', UserWarning)
+
+        if self.log_checkpoint:
+            # Remove model checkpoint from previous run.
+            files = glob.glob(f'{runner.work_dir}/*.pth')
+            for f in files:
+                os.remove(f)
+
+        if self.log_evaluation:
+            # Initialize data table
+            self._init_data_table()
+            # Add data to the table
+            self._add_data_table()
+
+    @master_only
+    def after_train_epoch(self, runner):
+        # print(runner.hooks)
+        pass
+
+    @master_only
+    def after_run(self, runner):
+        from mmdet.apis import single_gpu_test
+        self.results = single_gpu_test(
+            runner.model, self.dataloader, show=False, rescale=False)
+
+        # Model evaluation
+        if self.log_evaluation:
+            # Initialize evaluation table
+            self._init_pred_table(f'run_{self.wandb.run.id}_pred')
+            # Log predictions
+            self._log_predictions()
+            # Log the table
+            self._log_table()
+
+        self.wandb.finish()
+
+    def _init_data_table(self, name='val'):
+        self.data_artifact = self.wandb.Artifact(name, type='dataset')
+        columns = ['image_name', 'image']
+        self.data_table = self.wandb.Table(columns=columns)
+
+    def _init_pred_table(self, name):
+        self.pred_artifact = self.wandb.Artifact(name, type='evaluation')
+        columns = ['image_name', 'ground_truth', 'prediction'] + list(
+            self.class_id_to_label.values())
+        self.eval_table = self.wandb.Table(columns=columns)
+
+    def _add_data_table(self):
+        num_images = len(self.dataset)
+        assert num_images == len(self.dataset.data_infos)
+
+        classes = self.dataset.get_classes()
+        self.class_id_to_label = {id: name for id, name in enumerate(classes)}
+        self.class_set = self.wandb.Classes([{
+            'id': id,
+            'name': name
+        } for id, name in self.class_id_to_label.items()])
+
+        for idx in range(num_images):
+            data_sample = self.dataset.prepare_test_img(idx)
+            data_ann = self.dataset.get_ann_info(idx)
+
+            img_meta = data_sample['img_metas'][0].data
+            image = data_sample['img'][0].data
+            bboxes = data_ann['bboxes']
+            labels = data_ann['labels']
+            scale_factor = img_meta['scale_factor']
+
+            image_name = img_meta['ori_filename']
+            # permute to get channel last configuration, followed by bgr -> rgb
+            image = image.permute(1, 2, 0).numpy()[..., ::-1]
+
+            box_data = []
+            assert len(bboxes) == len(labels)
+            for bbox, label in zip(bboxes, labels):
+                position = dict(
+                    minX=int(bbox[0] * scale_factor[0]),
+                    minY=int(bbox[1] * scale_factor[1]),
+                    maxX=int(bbox[2] * scale_factor[2]),
+                    maxY=int(bbox[3] * scale_factor[3]))
+                box_data.append({
+                    'position': position,
+                    'class_id': int(label),
+                    'box_caption': classes[label],
+                    'domain': 'pixel'
+                })
+
+            boxes = {
+                'ground_truth': {
+                    'box_data': box_data,
+                    'class_labels': self.class_id_to_label
+                }
+            }
+            self.data_table.add_data(
+                image_name,
+                self.wandb.Image(image, boxes=boxes, classes=self.class_set))
+
+    def _log_predictions(self):
+        table_idxs = self.data_table.get_index()
+        assert len(self.results) == len(self.dataset) == len(table_idxs)
+
+        for ndx in table_idxs:
+            result = self.results[ndx]
+            assert len(result) == len(self.class_id_to_label)
+
+            box_data = []
+            class_scores = []
+            for label_id, bbox_scores in enumerate(result):
+                if len(bbox_scores) != 0:
+                    class_score = 0
+                    count = 0
+                    for bbox_score in bbox_scores:
+                        confidence = float(bbox_score[4])
+                        if confidence > 0.3:
+                            class_score += confidence
+                            count += 1
+                            class_name = self.class_id_to_label[label_id]
+
+                            position = dict(
+                                minX=int(bbox_score[0]),
+                                minY=int(bbox_score[1]),
+                                maxX=int(bbox_score[2]),
+                                maxY=int(bbox_score[3]))
+
+                            box_data.append({
+                                'position': position,
+                                'class_id': label_id,
+                                'box_caption':
+                                f'{class_name}@{confidence:.2f}',
+                                'domain': 'pixel'
+                            })
+
+                    class_scores.append(class_score / (count + 1e-6))
+                else:
+                    class_scores.append(0)
+
+            boxes = {
+                'predictions': {
+                    'box_data': box_data,
+                    'class_labels': self.class_id_to_label
+                }
+            }
+            self.eval_table.add_data(
+                self.data_table.data[ndx][0], self.data_table.data[ndx][1],
+                self.wandb.Image(
+                    self.data_table.data[ndx][1],
+                    boxes=boxes,
+                    classes=self.class_set), *tuple(class_scores))
+
+    def _log_table(self):
+        self.data_artifact.add(self.data_table, 'val_data')
+        self.pred_artifact.add(self.eval_table, 'eval_data')
+
+        self.wandb.run.log_artifact(self.data_artifact)
+        self.wandb.run.log_artifact(self.pred_artifact)

--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -84,8 +84,10 @@ class WandbLogger(WandbLoggerHook):
                  interval=10,
                  log_checkpoint=False,
                  log_checkpoint_metadata=False,
-                 num_eval_images=100):
-        super(WandbLogger, self).__init__(wandb_init_kwargs, interval)
+                 num_eval_images=100,
+                 **kwargs):
+        super(WandbLogger, self).__init__(wandb_init_kwargs, interval,
+                                          **kwargs)
 
         self.log_checkpoint = log_checkpoint
         self.log_checkpoint_metadata = log_checkpoint_metadata
@@ -258,7 +260,6 @@ class WandbLogger(WandbLoggerHook):
         Returns:
             bool: Returns True, if the checkpoint has the best metric score.
         """
-        # map_score = metadata.get('map_score', None)
         keys = list(metadata.keys())
         map_metrics = [key for key in keys if 'mAP' in key]
         ar_metrics = [key for key in keys if 'AR' in key]

--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -14,31 +14,60 @@ class WandbLogger(WandbLoggerHook):
     """WandbLogger logs metrics, saves model checkpoints as W&B Artifact, and
     logs model prediction as interactive W&B Tables.
 
-    - Metrics: The
+    - Metrics: The WandbLogger will automatically log training
+        and validation metrics.
+
+    - Checkpointing: If log_checkpoint is True, the checkpoint saved at
+        every checkpoint interval will be saved as W&B Artifacts.
+        Please refer to https://docs.wandb.ai/guides/artifacts/model-versioning
+        to learn more about model versioning with W&B Artifacts.
+        Note: This depends on the CheckpointHook whose priority is more
+        than WandbLogger.
+
+    - Checkpoint Metadata: If log_checkpoint_metadata is True, every checkpoint
+        artifact will have a metadata associated with it. The metadata contains
+        the evaluation metrics computed on validation data with that checkpoint
+        along with the current epoch. If True, it also marks the checkpoint
+        version with the best evaluation metric with a 'best' alias. You can
+        choose the best checkpoint in the W&B Artifacts UI using this.
+        Note: It depends on EvalHook whose priority is more than WandbLogger.
+
+    - Evaluation: At every evaluation interval, the WandbLogger logs the
+        model prediction as interactive W&B Tables. Please refer to
+        https://docs.wandb.ai/guides/data-vis to learn more about W&B Tables.
+        Currently, the WandbLogger logs the predicted bounding boxes along with
+        the ground truth at every evaluation interval.
+        Note: This depends on the EvalHook whose priority is more than
+        WandbLogger. Also note that the data is just logged once and subsequent
+        evaluation tables uses reference to the logged data to save
+        memory usage.
 
     Args:
+        init_kwargs (dict): A dict passed to wandb.init to initialize
+            a W&B run. Please refer to https://docs.wandb.ai/ref/python/init
+            for possible key-value pairs.
+        interval (int): Logging interval (every k iterations).
+            Default 10.
+        log_checkpoint (bool): Save the checkpoint at every checkpoint interval
+            as W&B Artifacts. Use this for model versioning where each version
+            is a checkpoint.
+            Default: False
+        log_checkpoint_metadata (bool): Log the evaluation metrics computed
+            on the validation data with the checkpoint, along with current
+            epoch as a metadata to that checkpoint.
+            Default: True
+        log_evaulation (bool): Log the model predictions as interactive
+            W&B Tables.
+            Default: True
     """
 
     def __init__(self,
                  init_kwargs=None,
                  interval=10,
-                 ignore_last=True,
-                 reset_flag=False,
-                 commit=True,
-                 by_epoch=True,
-                 with_step=True,
                  log_checkpoint=False,
                  log_checkpoint_metadata=False,
                  log_evaluation=False):
-        super(WandbLogger, self).__init__(
-            init_kwargs,
-            interval,
-            ignore_last,
-            reset_flag,
-            commit,
-            by_epoch,
-            with_step,
-        )
+        super(WandbLogger, self).__init__(init_kwargs, interval)
 
         self.log_checkpoint = log_checkpoint
         self.log_checkpoint_metadata = log_checkpoint_metadata


### PR DESCRIPTION
As per the discussion in this issue #7391, I have opened this PR to introduce a dedicated `WandbLogger` for MMDetection.

## Motivation

The goal and motivation for this PR are mentioned in detail in this #7391 issue. 

## Modification

The PR adds a new file `wandblogger_hook.py` where all the Weights and Biases related logic lives. The features that are introduced are explained in detail in my initial issue.

Other than this file, there is a small modification to the `eval_hook.py` file. It was made so that the `WandbLogger` can access the evaluation results. 

I am really looking forward to all the feedback. I would love to answer questions if any. If you require a colab to test out the feature, I can provide that as well. However, using it is straightforward as shown in the code snippet below. 

```
log_config = dict(
            interval=10,
            hooks=[
                dict(type='WandbLogger',
                     wandb_init_kwargs={
                         'entity': WANDB_ENTITY,
                         'project': WANDB_PROJECT_NAME
                     },
                     logging_interval=10,
                     log_checkpoint=True,
                     log_checkpoint_metadata=True,
                     num_eval_images=100)
            ])
```

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.