### PR TITLE
Add comments

### DIFF
--- a/mmdet/core/bbox/assigners/max_iou_assigner.py
+++ b/mmdet/core/bbox/assigners/max_iou_assigner.py
@@ -193,6 +193,10 @@ class MaxIoUAssigner(BaseAssigner):
             # This might be the reason that it is not used in ROI Heads.
             for i in range(num_gts):
                 if gt_max_overlaps[i] >= self.min_pos_iou:
+                    # `min_pos_iou` is set to avoid assigning bboxes with
+                    # extremely small iou as positive, which is different from
+                    # the behavior of detectron2. Comparison experiments can be
+                    # referred to URL.
                     if self.gt_max_assign_all:
                         max_iou_inds = overlaps[i, :] == gt_max_overlaps[i]
                         assigned_gt_inds[max_iou_inds] = i + 1


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation


mmdetection and detectron2 have different behaviors when assigning low quality boxes. mmdetection set `min_pos_iou` to avoid assigning boxes with extremely small iou as positive. But detectron2 doesn't have this operation, which is qual as `min_pos_iou` being 0. We conduct some comparison experiments here to explore the influence of `min_pos_iou`.

solve #6821

## Relating Code

mmdetection assigner: https://github.com/open-mmlab/mmdetection/blob/master/mmdet/core/bbox/assigners/max_iou_assigner.py#L194-L200
detectron2 matcher: https://github.com/facebookresearch/detectron2/blob/main/detectron2/modeling/matcher.py#L106-L127

## Experiments:

**1x schedule**
|    Methods   |  Style  | Backbone | Lr schd | Augmentation | minposiou | box AP |
|:------------:|:-------:|:--------:|:-------:|:------------:|:---------:|:------:|
| Faster R-CNN | pytorch |  R50-FPN |    1x   |       -      |    0.3    |  37.6  |
| Faster R-CNN | pytorch |  R50-FPN |    1x   |       -      |     0     |  36.9  |

|    Methods   | Style | Backbone | Lr schd | Augmentation | minposiou | box AP |
|:------------:|:-----:|:--------:|:-------:|:------------:|:---------:|:------:|
| Faster R-CNN | caffe |  R50-FPN |    1x   |    mstrain   |    0.3    |  38.0  |
| Faster R-CNN | caffe |  R50-FPN |    1x   |    mstrain   |     0     |  37.7  |

**3x schedule**
|    Methods   | Style | Backbone | Lr schd | Augmentation | minposiou | box AP |
|:------------:|:-----:|:--------:|:-------:|:------------:|:---------:|:------:|
| Faster R-CNN | caffe |  R50-FPN |    3x   |    mstrain   |    0.3    |  40.2  |
| Faster R-CNN | caffe |  R50-FPN |    3x   |    mstrain   |     0     |  40.2  |

**3x schedule with large-scale jittering**
|    Methods   | Style | Backbone | Lr schd |   Augmentation   | minposiou | box AP |
|:------------:|:-----:|:--------:|:-------:|:----------------:|:---------:|:------:|
| Faster R-CNN | caffe |  R50-FPN |    3x   | mscrop (0.5,2.0) |    0.3    |  40.1  |
| Faster R-CNN | caffe |  R50-FPN |    3x   | mscrop (0.5,2.0) |     0     |  39.6  |

`mstrain` is following the multi-scale training setting in detectron2. `mscrop` is using large-scale jittering.

As shown in experiments, `min_pos_iou` being 0.3 has an obvious advantage in the 1x schedule. In 3x schedule, the performances of different settings are basically the same. Thus, we keep the original setting of `min_pos_iou`.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
