### PR TITLE
[Enhance] Update docstring of cross entropy loss

### DIFF
--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -81,7 +81,10 @@ def binary_cross_entropy(pred,
     """Calculate the binary CrossEntropy loss.
 
     Args:
-        pred (torch.Tensor): The prediction with shape (N, 1).
+        pred (torch.Tensor): The prediction with shape (N, 1) or (N, ).
+            When pred is of shape (N, 1) it will be expanded to one-hot
+            format, while for pred of shape (N, ) it will not be expanded
+            to one-hot format.
         label (torch.Tensor): The learning label of the prediction.
         weight (torch.Tensor, optional): Sample-wise loss weight.
         reduction (str, optional): The method used to reduce the loss.

--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -82,10 +82,11 @@ def binary_cross_entropy(pred,
 
     Args:
         pred (torch.Tensor): The prediction with shape (N, 1) or (N, ).
-            When pred is of shape (N, 1) it will be expanded to one-hot
-            format, while for pred of shape (N, ) it will not be expanded
-            to one-hot format.
-        label (torch.Tensor): The learning label of the prediction.
+            When the shape of pred is (N, 1), label will be expanded to
+            one-hot format, and when the shape of pred is (N, ), label
+            will not be expanded to one-hot format.
+        label (torch.Tensor): The learning label of the prediction,
+            with shape (N, ).
         weight (torch.Tensor, optional): Sample-wise loss weight.
         reduction (str, optional): The method used to reduce the loss.
             Options are "none", "mean" and "sum".


### PR DESCRIPTION
## Motivation

This is part of Mask2Former( PR #6938 )

## Modification

1. update docstring in `binary_cross_entropy`. When `pred`  have shape (N, 1), it will be  expanded to onehot, while for `pred` with shape (N, ), it will not be expanded to onehot.

## BC-breaking (Optional)


## Use cases (Optional)


## Checklist

