### PR TITLE
Bug fix: RuntimeError: Expected all tensors to be on the same device,…

### DIFF
--- a/mmdet/models/dense_heads/free_anchor_retina_head.py
+++ b/mmdet/models/dense_heads/free_anchor_retina_head.py
@@ -78,8 +78,8 @@ class FreeAnchorRetinaHead(RetinaHead):
         """
         featmap_sizes = [featmap.size()[-2:] for featmap in cls_scores]
         assert len(featmap_sizes) == self.prior_generator.num_levels
-
-        anchor_list, _ = self.get_anchors(featmap_sizes, img_metas)
+        device = cls_scores[0].device
+        anchor_list, _ = self.get_anchors(featmap_sizes, img_metas, device=device)
         anchors = [torch.cat(anchor) for anchor in anchor_list]
 
         # concatenate each level


### PR DESCRIPTION
RuntimeError: Expected all tensors to be on the same device but found at least two devices, cuda:0 and cuda:2!

修复Free anchor Retinanet网络训练时，可能会遇到计算得到的anchor与pre_bboxes不在同一个cuda device的bug。

## Motivation

修复Free anchor RetinaNet在非0卡上进行训练出错的bug。

## Modification

修复Free anchor Retinanet网络训练时，可能会遇到计算得到的anchor与pre_bboxes不在同一个cuda device的bug。

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
