### PR TITLE
[Fix] Memory leaking in panpotic segmentation evaluation

### DIFF
--- a/configs/mask2former/mask2former_r50_lsj_8x2_50e_coco.py
+++ b/configs/mask2former/mask2former_r50_lsj_8x2_50e_coco.py
@@ -248,4 +248,6 @@ checkpoint_config = dict(
 # which means that we do evaluation at the end of training.
 dynamic_intervals = [(max_iters // interval * interval + 1, max_iters)]
 evaluation = dict(
-    interval=interval, dynamic_intervals=dynamic_intervals, metric='PQ')
+    interval=interval,
+    dynamic_intervals=dynamic_intervals,
+    metric=['PQ', 'bbox', 'segm'])

--- a/configs/mask2former/mask2former_r50_lsj_8x2_50e_coco.py
+++ b/configs/mask2former/mask2former_r50_lsj_8x2_50e_coco.py
@@ -238,16 +238,14 @@ log_config = dict(
         dict(type='TextLoggerHook', by_epoch=False),
         dict(type='TensorboardLoggerHook', by_epoch=False)
     ])
-interval = 200000
+interval = 5000
 workflow = [('train', interval)]
 checkpoint_config = dict(
     by_epoch=False, interval=interval, save_last=True, max_keep_ckpts=3)
 
-# Before 365001th iteration, we do evaluation every 200000 iterations.
+# Before 365001th iteration, we do evaluation every 5000 iterations.
 # After 365000th iteration, we do evaluation every 368750 iterations,
-# which means do evaluation at the end of training.
-# In all, we do evaluation at the 200000th iteration and the
-# last iteratoin.
+# which means that we do evaluation at the end of training.
 dynamic_intervals = [(max_iters // interval * interval + 1, max_iters)]
 evaluation = dict(
     interval=interval, dynamic_intervals=dynamic_intervals, metric='PQ')

--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -212,6 +212,8 @@ def pq_compute_multi_core(matched_annotations_list,
                                  pred_folder, categories, file_client))
         processes.append(p)
 
+    # Close the process pool, otherwise it will lead to memory
+    # leaking problems.
     workers.close()
     workers.join()
 

--- a/mmdet/datasets/api_wrappers/panoptic_evaluation.py
+++ b/mmdet/datasets/api_wrappers/panoptic_evaluation.py
@@ -211,7 +211,12 @@ def pq_compute_multi_core(matched_annotations_list,
                                 (proc_id, annotation_set, gt_folder,
                                  pred_folder, categories, file_client))
         processes.append(p)
+
+    workers.close()
+    workers.join()
+
     pq_stat = PQStat()
     for p in processes:
         pq_stat += p.get()
+
     return pq_stat

--- a/tests/test_utils/test_assigner.py
+++ b/tests/test_utils/test_assigner.py
@@ -620,7 +620,7 @@ def test_mask_hungarian_match_assigner():
     assert (assign_result.gt_inds > 0).sum() == gt_labels.size(0)
     assert (assign_result.labels > -1).sum() == gt_labels.size(0)
 
-    # test with mask ce mode which is not supported yet
+    # test with ce mode of CrossEntropyLossCost which is not supported yet
     assigner_cfg = dict(
         cls_cost=dict(type='ClassificationCost', weight=0.0),
         mask_cost=dict(

--- a/tests/test_utils/test_assigner.py
+++ b/tests/test_utils/test_assigner.py
@@ -620,7 +620,7 @@ def test_mask_hungarian_match_assigner():
     assert (assign_result.gt_inds > 0).sum() == gt_labels.size(0)
     assert (assign_result.labels > -1).sum() == gt_labels.size(0)
 
-    # test with mask ce mode
+    # test with mask ce mode which is not supported yet
     assigner_cfg = dict(
         cls_cost=dict(type='ClassificationCost', weight=0.0),
         mask_cost=dict(

--- a/tests/test_utils/test_assigner.py
+++ b/tests/test_utils/test_assigner.py
@@ -626,7 +626,5 @@ def test_mask_hungarian_match_assigner():
         mask_cost=dict(
             type='CrossEntropyLossCost', weight=1.0, use_sigmoid=False),
         dice_cost=dict(type='DiceCost', weight=0.0, pred_act=True, eps=1.0))
-    self = MaskHungarianAssigner(**assigner_cfg)
-    with pytest.raises(NotImplementedError):
-        assign_result = self.assign(cls_pred, mask_pred, gt_labels, gt_masks,
-                                    img_meta)
+    with pytest.raises(AssertionError):
+        self = MaskHungarianAssigner(**assigner_cfg)


### PR DESCRIPTION
Related issue https://github.com/cocodataset/panopticapi/issues/27

## Motivation

## Modification

Add `workers.close()` and `workers.join()`  after https://github.com/open-mmlab/mmdetection/blob/14f0e9585c15c28f0c31dcc3ea352449bbe5eb96/mmdet/datasets/api_wrappers/panoptic_evaluation.py#L207

## BC-breaking (Optional)

## Use cases (Optional)


## Checklist

