### PR TITLE
[Fix] Avoid invalid bbox after deform_sampling

### DIFF
--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -273,7 +273,7 @@ class TOODHead(ATSSHead):
             invalid_bbox_idx = (bbox_pred[:, [0]] > bbox_pred[:, [2]]) | \
                                (bbox_pred[:, [1]] > bbox_pred[:, [3]])
             invalid_bbox_idx = invalid_bbox_idx.expand_as(bbox_pred)
-            bbox_pred[invalid_bbox_idx] = reg_bbox[invalid_bbox_idx]
+            bbox_pred = torch.where(invalid_bbox_idx, reg_bbox, bbox_pred)
 
             cls_scores.append(cls_score)
             bbox_preds.append(bbox_pred)
@@ -284,7 +284,7 @@ class TOODHead(ATSSHead):
 
         Args:
             feat (Tensor): Feature
-            offset (Tensor): Spatial offset for for feature sampliing
+            offset (Tensor): Spatial offset for feature sampling
         """
         # it is an equivalent implementation of bilinear interpolation
         b, c, h, w = feat.shape

--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -269,7 +269,9 @@ class TOODHead(ATSSHead):
             bbox_pred = self.deform_sampling(reg_bbox.contiguous(),
                                              reg_offset.contiguous())
 
-            # Avoid invalid bboxes after deform_sampling
+            # After deform_sampling, some boxes will become invalid (The
+            # left-top point is at the right or bottom of the right-bottom
+            # point), which will make the GIoULoss negative.
             invalid_bbox_idx = (bbox_pred[:, [0]] > bbox_pred[:, [2]]) | \
                                (bbox_pred[:, [1]] > bbox_pred[:, [3]])
             invalid_bbox_idx = invalid_bbox_idx.expand_as(bbox_pred)

--- a/mmdet/models/dense_heads/tood_head.py
+++ b/mmdet/models/dense_heads/tood_head.py
@@ -268,6 +268,13 @@ class TOODHead(ATSSHead):
             reg_offset = self.reg_offset_module(feat)
             bbox_pred = self.deform_sampling(reg_bbox.contiguous(),
                                              reg_offset.contiguous())
+
+            # Avoid invalid bboxes after deform_sampling
+            invalid_bbox_idx = (bbox_pred[:, [0]] > bbox_pred[:, [2]]) | \
+                               (bbox_pred[:, [1]] > bbox_pred[:, [3]])
+            invalid_bbox_idx = invalid_bbox_idx.expand_as(bbox_pred)
+            bbox_pred[invalid_bbox_idx] = reg_bbox[invalid_bbox_idx]
+
             cls_scores.append(cls_score)
             bbox_preds.append(bbox_pred)
         return tuple(cls_scores), tuple(bbox_preds)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

After deform_sampling, some boxes will become illegal (the left-top point is at the right or bottom of the right-bottom point), which will make the GIoULoss negative.
Have no effect on performance (origin: 42.3, after: 42.2 & 42.4).

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
