### PR TITLE
feat(mlu): Support PyTorch backend on MLU.

### DIFF
--- a/mmdet/core/data_structures/general_data.py
+++ b/mmdet/core/data_structures/general_data.py
@@ -274,6 +274,16 @@ class GeneralData(NiceRepr):
         return new_data
 
     # Tensor-like methods
+    def mlu(self):
+        """Apply same name function to all tensors in data_fields."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, torch.Tensor):
+                v = v.mlu()
+            new_data[k] = v
+        return new_data
+
+    # Tensor-like methods
     def cuda(self):
         """Apply same name function to all tensors in data_fields."""
         new_data = self.new()

--- a/mmdet/datasets/samplers/distributed_sampler.py
+++ b/mmdet/datasets/samplers/distributed_sampler.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import DistributedSampler as _DistributedSampler
 
 from mmdet.core.utils import sync_random_seed
-
+from mmdet.utils import select_device
 
 class DistributedSampler(_DistributedSampler):
 
@@ -23,8 +23,9 @@ class DistributedSampler(_DistributedSampler):
         # is used to make sure that each rank shuffles the data indices
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
-        # same data list.
-        self.seed = sync_random_seed(seed)
+        # same data list.        
+        device = select_device()
+        self.seed = sync_random_seed(seed, device)
 
     def __iter__(self):
         # deterministically shuffle based on epoch

--- a/mmdet/datasets/samplers/distributed_sampler.py
+++ b/mmdet/datasets/samplers/distributed_sampler.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import DistributedSampler as _DistributedSampler
 
 from mmdet.core.utils import sync_random_seed
-from mmdet.utils import select_device
+from mmdet.utils import get_device
 
 class DistributedSampler(_DistributedSampler):
 
@@ -24,7 +24,7 @@ class DistributedSampler(_DistributedSampler):
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
         # same data list.        
-        device = select_device()
+        device = get_device()
         self.seed = sync_random_seed(seed, device)
 
     def __iter__(self):

--- a/mmdet/utils/__init__.py
+++ b/mmdet/utils/__init__.py
@@ -5,9 +5,11 @@ from .logger import get_caller_name, get_root_logger, log_img_scale
 from .misc import find_latest_checkpoint, update_data_root
 from .setup_env import setup_multi_processes
 from .split_batch import split_batch
+from .util_distribution import build_ddp, build_dp, get_device
 
 __all__ = [
     'get_root_logger', 'collect_env', 'find_latest_checkpoint',
     'update_data_root', 'setup_multi_processes', 'get_caller_name',
-    'log_img_scale', 'compat_cfg', 'split_batch'
+    'log_img_scale', 'compat_cfg', 'split_batch', 'build_ddp',
+    'build_dp', 'get_device'
 ]

--- a/mmdet/utils/util_distribution.py
+++ b/mmdet/utils/util_distribution.py
@@ -2,18 +2,30 @@
 import torch
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 
-USE_DEVICE = ''
-
 dp_factory = {
-        'cuda' : MMDataParallel
+        'cuda' : MMDataParallel,
+        'cpu' : MMDataParallel
     }
 
 ddp_factory = {
         'cuda' : MMDistributedDataParallel
     }
 
-def build_dp(model, device = 'cuda'):
-    assert device in ['cuda', 'mlu'], "Only available for cuda or mlu devices."
+def build_dp(model, device='cuda', device_ids=None):
+    """build DataParallel module by device type.
+    
+    if device is cuda, return a MMDataParallel model; if device is mlu,
+    return a MLUDataParallel model.
+
+    Args:
+        model(nn.Moudle): model to be parallelized.
+        device(str): device type, cuda, cpu or mlu. Defaults to cuda.
+        device_ids(int): device ids of modules to be scattered to.
+            Defaults to None when GPU or MLU is not available.
+
+    Returns:
+        model(nn.Module): the model to be parallelized.
+    """
     if device == 'cuda':
         model = model.cuda()
     elif device == 'mlu':
@@ -21,10 +33,41 @@ def build_dp(model, device = 'cuda'):
         dp_factory['mlu'] = MLUDataParallel
         model = model.mlu()
 
-    return model, dp_factory[device]
+    return dp_factory[device](model, device_ids=device_ids)
 
-def build_ddp(model, device = 'cuda'):
-    assert device in ['cuda', 'mlu'], "Only available for cuda or mlu devices."
+
+def build_ddp(model, device='cuda', device_ids=None,
+        broadcast_buffers=False, find_unused_parameters=False):
+    """Build DistributedDataParallel module by device type.
+
+    If device is cuda, return a MMDistributedDataParallel model; if device is mlu,
+    return a MLUDistributedDataParallel model.
+
+    Args:
+        model(:class:`nn.Moudle`): module to be parallelized.
+        device(str): device type, mlu or cuda.
+        device_ids(int): which represents the only device where the input module
+            corresponding to this process resides. Defaults to None.
+        broadcast_buffers(bool): Flag that enables syncing (broadcasting) buffers of
+            the module at beginning of the forward function. Defaults to True.
+        find_unused_parameters(bool): Traverse the autograd graph of all tensors
+            contained in the return value of the wrapped module's ``forward`` function.
+            Parameters that don't receive gradients as part of this graph are preemptively
+            marked as being ready to be reduced. Note that all ``forward`` outputs that
+            are derived from module parameters must participate in calculating loss and
+            later the gradient computation. If they don't, this wrapper will hang waiting
+            for autograd to produce gradients for those parameters. Any outputs derived from
+            module parameters that are otherwise unused can be detached from the autograd
+            graph using ``torch.Tensor.detach``. Defaults to False.
+
+    Returns:
+        model(nn.Module): the module to be parallelized
+
+    References:
+        .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
+                     DistributedDataParallel.html
+    """
+    assert device in ['cuda', 'mlu'], 'Only available for cuda or mlu devices.'
     if device == 'cuda':
         model = model.cuda()
     elif device == 'mlu':
@@ -32,16 +75,17 @@ def build_ddp(model, device = 'cuda'):
         ddp_factory['mlu'] = MLUDistributedDataParallel
         model = model.mlu()
 
-    return model, ddp_factory[device]
+    return ddp_factory[device](model, device_ids=device_ids,
+                               broadcast_buffers=broadcast_buffers,
+                               find_unused_parameters=find_unused_parameters)
 
-def select_device():
-    global USE_DEVICE
-    if USE_DEVICE != '' :
-        return USE_DEVICE
+def is_mlu_available():
+    """ Returns a bool indicating if MLU is currently available. """
+    return hasattr(torch, 'is_mlu_available') and torch.is_mlu_available()
+
+def get_device():
+    """ Returns an available device, cpu, cuda or mlu. """
     is_device_available = {'cuda': torch.cuda.is_available(),
-                       'mlu': hasattr(torch, 'is_mlu_available') and torch.is_mlu_available()}
-    # st_device = dict(filter(lambda x : x[1] , is_device_available.items()))
-    st_device = [k for k, v in is_device_available.items() if v ]
-    assert len(st_device) == 1, "Only one device type is available, please check!"
-    USE_DEVICE = st_device[0]
-    return USE_DEVICE
+                           'mlu': is_mlu_available()}
+    device_list = [k for k, v in is_device_available.items() if v ]
+    return device_list[0] if len(device_list) == 1 else 'cpu'

--- a/mmdet/utils/util_distribution.py
+++ b/mmdet/utils/util_distribution.py
@@ -1,0 +1,47 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
+
+USE_DEVICE = ''
+
+dp_factory = {
+        'cuda' : MMDataParallel
+    }
+
+ddp_factory = {
+        'cuda' : MMDistributedDataParallel
+    }
+
+def build_dp(model, device = 'cuda'):
+    assert device in ['cuda', 'mlu'], "Only available for cuda or mlu devices."
+    if device == 'cuda':
+        model = model.cuda()
+    elif device == 'mlu':
+        from mmcv.device.mlu import MLUDataParallel
+        dp_factory['mlu'] = MLUDataParallel
+        model = model.mlu()
+
+    return model, dp_factory[device]
+
+def build_ddp(model, device = 'cuda'):
+    assert device in ['cuda', 'mlu'], "Only available for cuda or mlu devices."
+    if device == 'cuda':
+        model = model.cuda()
+    elif device == 'mlu':
+        from mmcv.device.mlu import  MLUDistributedDataParallel
+        ddp_factory['mlu'] = MLUDistributedDataParallel
+        model = model.mlu()
+
+    return model, ddp_factory[device]
+
+def select_device():
+    global USE_DEVICE
+    if USE_DEVICE != '' :
+        return USE_DEVICE
+    is_device_available = {'cuda': torch.cuda.is_available(),
+                       'mlu': hasattr(torch, 'is_mlu_available') and torch.is_mlu_available()}
+    # st_device = dict(filter(lambda x : x[1] , is_device_available.items()))
+    st_device = [k for k, v in is_device_available.items() if v ]
+    assert len(st_device) == 1, "Only one device type is available, please check!"
+    USE_DEVICE = st_device[0]
+    return USE_DEVICE

--- a/mmdet/utils/util_distribution.py
+++ b/mmdet/utils/util_distribution.py
@@ -11,17 +11,16 @@ ddp_factory = {
         'cuda' : MMDistributedDataParallel
     }
 
-def build_dp(model, device='cuda', device_ids=None):
+def build_dp(model, device='cuda', dim=0, *args, **kwargs):
     """build DataParallel module by device type.
     
     if device is cuda, return a MMDataParallel model; if device is mlu,
     return a MLUDataParallel model.
 
     Args:
-        model(nn.Moudle): model to be parallelized.
+        model(:class:`nn.Module`): model to be parallelized.
         device(str): device type, cuda, cpu or mlu. Defaults to cuda.
-        device_ids(int): device ids of modules to be scattered to.
-            Defaults to None when GPU or MLU is not available.
+        dim(int): Dimension used to scatter the data. Defaults to 0.
 
     Returns:
         model(nn.Module): the model to be parallelized.
@@ -33,35 +32,21 @@ def build_dp(model, device='cuda', device_ids=None):
         dp_factory['mlu'] = MLUDataParallel
         model = model.mlu()
 
-    return dp_factory[device](model, device_ids=device_ids)
+    return dp_factory[device](model, dim=dim, *args, **kwargs)
 
 
-def build_ddp(model, device='cuda', device_ids=None,
-        broadcast_buffers=False, find_unused_parameters=False):
+def build_ddp(model, device='cuda', *args, **kwargs):
     """Build DistributedDataParallel module by device type.
 
     If device is cuda, return a MMDistributedDataParallel model; if device is mlu,
     return a MLUDistributedDataParallel model.
 
     Args:
-        model(:class:`nn.Moudle`): module to be parallelized.
+        model(:class:`nn.Module`): module to be parallelized.
         device(str): device type, mlu or cuda.
-        device_ids(int): which represents the only device where the input module
-            corresponding to this process resides. Defaults to None.
-        broadcast_buffers(bool): Flag that enables syncing (broadcasting) buffers of
-            the module at beginning of the forward function. Defaults to True.
-        find_unused_parameters(bool): Traverse the autograd graph of all tensors
-            contained in the return value of the wrapped module's ``forward`` function.
-            Parameters that don't receive gradients as part of this graph are preemptively
-            marked as being ready to be reduced. Note that all ``forward`` outputs that
-            are derived from module parameters must participate in calculating loss and
-            later the gradient computation. If they don't, this wrapper will hang waiting
-            for autograd to produce gradients for those parameters. Any outputs derived from
-            module parameters that are otherwise unused can be detached from the autograd
-            graph using ``torch.Tensor.detach``. Defaults to False.
 
     Returns:
-        model(nn.Module): the module to be parallelized
+        model(:class:`nn.Module`): the module to be parallelized
 
     References:
         .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
@@ -75,9 +60,7 @@ def build_ddp(model, device='cuda', device_ids=None,
         ddp_factory['mlu'] = MLUDistributedDataParallel
         model = model.mlu()
 
-    return ddp_factory[device](model, device_ids=device_ids,
-                               broadcast_buffers=broadcast_buffers,
-                               find_unused_parameters=find_unused_parameters)
+    return ddp_factory[device](model, *args, **kwargs)
 
 def is_mlu_available():
     """ Returns a bool indicating if MLU is currently available. """

--- a/tools/test.py
+++ b/tools/test.py
@@ -17,8 +17,8 @@ from mmdet.apis import multi_gpu_test, single_gpu_test
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
 from mmdet.models import build_detector
-from mmdet.utils import compat_cfg, setup_multi_processes, update_data_root
-                         build_ddp, build_dp, select_device)
+from mmdet.utils import (compat_cfg, setup_multi_processes, update_data_root,
+                         build_ddp, build_dp, get_device)
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -172,7 +172,7 @@ def main():
                       'in `gpu_ids` now.')
     else:
         cfg.gpu_ids = [args.gpu_id]
-    cfg.device = select_device()
+    cfg.device = get_device()
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':
         distributed = False
@@ -230,15 +230,13 @@ def main():
         model.CLASSES = dataset.CLASSES
 
     if not distributed:
-        model, DP = build_dp(model, cfg.device)
-        model = DP(model, device_ids=cfg.gpu_ids)
+        model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
                                   args.show_score_thr)
     else:
-        model, DDP = build_ddp(model, cfg.device)
-        model = DDP(model,
-                   device_ids=[LOCAL_RANK],
-                   broadcast_buffers=False)
+        model = build_ddp(model, cfg.device,
+                          device_ids=[int(os.environ['LOCAL_RANK'])],
+                          broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                  args.gpu_collect)
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -18,7 +18,7 @@ from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
 from mmdet.models import build_detector
 from mmdet.utils import compat_cfg, setup_multi_processes, update_data_root
-
+                         build_ddp, build_dp, select_device)
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -172,7 +172,7 @@ def main():
                       'in `gpu_ids` now.')
     else:
         cfg.gpu_ids = [args.gpu_id]
-
+    cfg.device = select_device()
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':
         distributed = False
@@ -230,14 +230,15 @@ def main():
         model.CLASSES = dataset.CLASSES
 
     if not distributed:
-        model = MMDataParallel(model, device_ids=cfg.gpu_ids)
+        model, DP = build_dp(model, cfg.device)
+        model = DP(model, device_ids=cfg.gpu_ids)
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
                                   args.show_score_thr)
     else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
-            device_ids=[torch.cuda.current_device()],
-            broadcast_buffers=False)
+        model, DDP = build_ddp(model, cfg.device)
+        model = DDP(model,
+                   device_ids=[LOCAL_RANK],
+                   broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                  args.gpu_collect)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -18,7 +18,7 @@ from mmdet.apis import init_random_seed, set_random_seed, train_detector
 from mmdet.datasets import build_dataset
 from mmdet.models import build_detector
 from mmdet.utils import (collect_env, get_root_logger, setup_multi_processes,
-                         update_data_root)
+                         update_data_root, select_device)
 
 
 def parse_args():
@@ -193,8 +193,9 @@ def main():
     logger.info(f'Distributed training: {distributed}')
     logger.info(f'Config:\n{cfg.pretty_text}')
 
+    cfg.device = select_device()
     # set random seeds
-    seed = init_random_seed(args.seed)
+    seed = init_random_seed(args.seed, device=cfg.device)
     seed = seed + dist.get_rank() if args.diff_seed else seed
     logger.info(f'Set random seed to {seed}, '
                 f'deterministic: {args.deterministic}')

--- a/tools/train.py
+++ b/tools/train.py
@@ -18,7 +18,7 @@ from mmdet.apis import init_random_seed, set_random_seed, train_detector
 from mmdet.datasets import build_dataset
 from mmdet.models import build_detector
 from mmdet.utils import (collect_env, get_root_logger, setup_multi_processes,
-                         update_data_root, select_device)
+                         update_data_root, get_device)
 
 
 def parse_args():
@@ -193,7 +193,7 @@ def main():
     logger.info(f'Distributed training: {distributed}')
     logger.info(f'Config:\n{cfg.pretty_text}')
 
-    cfg.device = select_device()
+    cfg.device = get_device()
     # set random seeds
     seed = init_random_seed(args.seed, device=cfg.device)
     seed = seed + dist.get_rank() if args.diff_seed else seed


### PR DESCRIPTION
* Mmdet support PyTorch backend on MLU (with Cambricon PyTorch).

## Motivation

Support Cambricon MLU device for PyTorch backend.

## Modification

mmdet/apis/train.py : model copy and get current device before MMDataParallel and MMDistributedDataParallel

tool/train.py : moifyed to support mlu init_random_seed;

mmdet/core/data_structures/general_data.py: add Tensor-like methods.


## BC-breaking (Optional)

No BC-breaking