### PR TITLE
add solo style dicecost and modify MaskHungarianAssigner

### DIFF
--- a/mmdet/core/bbox/assigners/mask_hungarian_assigner.py
+++ b/mmdet/core/bbox/assigners/mask_hungarian_assigner.py
@@ -70,15 +70,15 @@ class MaskHungarianAssigner(BaseAssigner):
         """
         assert gt_bboxes_ignore is None, \
             'Only case when gt_bboxes_ignore is None is supported.'
-        num_gt, num_query = gt_labels.shape[0], cls_pred.shape[0]
+        num_gt, num_query = gt_labels.shape[0], mask_pred.shape[0]
 
         # 1. assign -1 by default
-        assigned_gt_inds = cls_pred.new_full((num_query, ),
+        assigned_gt_inds = mask_pred.new_full((num_query, ),
+                                              -1,
+                                              dtype=torch.long)
+        assigned_labels = mask_pred.new_full((num_query, ),
                                              -1,
                                              dtype=torch.long)
-        assigned_labels = cls_pred.new_full((num_query, ),
-                                            -1,
-                                            dtype=torch.long)
         if num_gt == 0 or num_query == 0:
             # No ground truth or boxes, return empty assignment
             if num_gt == 0:
@@ -116,9 +116,9 @@ class MaskHungarianAssigner(BaseAssigner):
 
         matched_row_inds, matched_col_inds = linear_sum_assignment(cost)
         matched_row_inds = torch.from_numpy(matched_row_inds).to(
-            cls_pred.device)
+            mask_pred.device)
         matched_col_inds = torch.from_numpy(matched_col_inds).to(
-            cls_pred.device)
+            mask_pred.device)
 
         # 4. assign backgrounds and foregrounds
         # assign all indices to backgrounds first

--- a/mmdet/core/bbox/match_costs/match_cost.py
+++ b/mmdet/core/bbox/match_costs/match_cost.py
@@ -246,11 +246,11 @@ class DiceCost:
         eps (float, optional): default 1e-12.
     """
 
-    def __init__(self, weight=1., pred_act=False, eps=1e-3, solo_style_dice_loss=False):
+    def __init__(self, weight=1., pred_act=False, eps=1e-3, solo_style=False):
         self.weight = weight
         self.pred_act = pred_act
         self.eps = eps
-        self.naive_dice_loss = solo_style_dice_loss
+        self.solo_style = solo_style
 
     def binary_mask_dice_loss(self, mask_preds, gt_masks):
         """
@@ -269,6 +269,7 @@ class DiceCost:
         denominator = mask_preds.sum(-1)[:, None] + gt_masks.sum(-1)[None, :]
         loss = 1 - (numerator + self.eps) / (denominator + self.eps)
         return loss
+
     def solo_style_dice_loss(self, mask_preds, gt_masks):
         """
         Args:
@@ -298,7 +299,7 @@ class DiceCost:
         """
         if self.pred_act:
             mask_preds = mask_preds.sigmoid()
-        if self.naive_dice_loss:
+        if self.solo_style:
             dice_cost = self.solo_style_dice_loss(mask_preds, gt_masks)
         else:
             dice_cost = self.binary_mask_dice_loss(mask_preds, gt_masks)

--- a/tests/test_utils/test_assigner.py
+++ b/tests/test_utils/test_assigner.py
@@ -628,3 +628,15 @@ def test_mask_hungarian_match_assigner():
         dice_cost=dict(type='DiceCost', weight=0.0, pred_act=True, eps=1.0))
     with pytest.raises(AssertionError):
         self = MaskHungarianAssigner(**assigner_cfg)
+
+    # test with solo_style mode of DiceLossCost which is not supported yet
+    assigner_cfg = dict(
+        cls_cost=dict(type='ClassificationCost', weight=0.0),
+        dice_cost=dict(
+            type='DiceCost',
+            weight=0.0,
+            pred_act=True,
+            eps=1.0,
+            solo_style=True))
+    with pytest.raises(AssertionError):
+        self = MaskHungarianAssigner(**assigner_cfg)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

add solo style `DiceCost`, as used in `K-net`, and fixed an error in `MaskHungarianAssigner` when `cls_pred` is `None`.

## Modification

add a `solo_style` option for diceloss init.

## BC-breaking (Optional)

never

## Use cases (Optional)

we can add `solo_style_dice_loss option  ` which is used in `SOLO` and `K-Net` when we init `DiceLoss`


