### PR TITLE
[Enhance] Support reading `gpu_collect` from cfg.evaluation.gpu_collect

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -238,7 +238,7 @@ def main():
             device_ids=[torch.cuda.current_device()],
             broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
-                                 args.gpu_collect)
+                                 args.gpu_collect or cfg.evaluation.gpu_collect)
 
     rank, _ = get_dist_info()
     if rank == 0:

--- a/tools/test.py
+++ b/tools/test.py
@@ -237,8 +237,9 @@ def main():
             model.cuda(),
             device_ids=[torch.cuda.current_device()],
             broadcast_buffers=False)
-        outputs = multi_gpu_test(model, data_loader, args.tmpdir,
-                                 args.gpu_collect or cfg.evaluation.gpu_collect)
+        outputs = multi_gpu_test(
+            model, data_loader, args.tmpdir, args.gpu_collect
+            or cfg.evaluation.gpu_collect)
 
     rank, _ = get_dist_info()
     if rank == 0:

--- a/tools/test.py
+++ b/tools/test.py
@@ -239,7 +239,7 @@ def main():
             broadcast_buffers=False)
         outputs = multi_gpu_test(
             model, data_loader, args.tmpdir, args.gpu_collect
-            or cfg.evaluation.gpu_collect)
+            or cfg.evaluation.get('gpu_collect', False))
 
     rank, _ = get_dist_info()
     if rank == 0:


### PR DESCRIPTION
## Motivation

During testing, the `cfg.evaluation.gpu_collect` does not take effect. Rather, users need to specify `gpu_collect` from the command line.

This behavior is inconsistent with the evaluation during training, where `cfg.evaluation.gpu_collect` decides whether to use `gpu_collect`.

## Modification

`gpu_collect = args.gpu_collect or cfg.evaluation.gpu_collect` in `tools/test.py` line 238-239

```python
        outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                 args.gpu_collect)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.

## Reference

Issue #7495 