### PR TITLE
ProfilerHook Bug Fix

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -168,6 +168,10 @@ def train_detector(model,
         cfg.get('momentum_config', None),
         custom_hooks_config=cfg.get('custom_hooks', None))
 
+
+    # register profiler hook
+    runner.register_profiler_hook(cfg.get('profiler_config',None))
+
     if distributed:
         if isinstance(runner, EpochBasedRunner):
             runner.register_hook(DistSamplerSeedHook())


### PR DESCRIPTION

The ProfilerHooks was not been able to trigger as it was missing to be registered inside the runner.

By adding the below statements inside the` /workspace/mmdetection/mmdet/apis/train.py` solved the issue.
```
 # register profiler hook
  runner.register_profiler_hook(cfg.get('profiler_config',None))
```
    