### PR TITLE
Updated INF to 100000.0 to be in line with original YOLOX implementation

### DIFF
--- a/mmdet/core/bbox/assigners/sim_ota_assigner.py
+++ b/mmdet/core/bbox/assigners/sim_ota_assigner.py
@@ -119,7 +119,7 @@ class SimOTAAssigner(BaseAssigner):
         Returns:
             :obj:`AssignResult`: The assigned result.
         """
-        INF = 100000000
+        INF = 100000.0
         num_gt = gt_bboxes.size(0)
         num_bboxes = decoded_bboxes.size(0)
 


### PR DESCRIPTION
## Motivation

Changing INF to 100000.0 in sim_ota_assigner.py is in line with Megvii YOLOX repo and it also gave better result on my custom dataset. Might close the gap with Megvii YOLOX results if retrained with COCO.

## Modification

Updated INF to 100000.0 in sim_ota_assigner.py.
