### PR TITLE
Fix the log plot error when evaluation interval != 1

### DIFF
--- a/docs/en/useful_tools.md
+++ b/docs/en/useful_tools.md
@@ -7,7 +7,7 @@ Apart from training/testing scripts, We provide lots of useful tools under the
  log file. Run `pip install seaborn` first to install the dependency.
 
  ```shell
-python tools/analysis_tools/analyze_logs.py plot_curve [--keys ${KEYS}] [--title ${TITLE}] [--legend ${LEGEND}] [--backend ${BACKEND}] [--style ${STYLE}] [--out ${OUT_FILE}]
+python tools/analysis_tools/analyze_logs.py plot_curve [--keys ${KEYS}] [--eval-interval ${EVALUATION_INTERVAL}] [--title ${TITLE}] [--legend ${LEGEND}] [--backend ${BACKEND}] [--style ${STYLE}] [--out ${OUT_FILE}]
  ```
 
 ![loss curve image](../../resources/loss_curve.png)

--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -54,7 +54,7 @@ def plot_curve(log_dicts, args):
         epochs = list(log_dict.keys())
         for j, metric in enumerate(metrics):
             print(f'plot curve of {args.json_logs[i]}, metric is {metric}')
-            if metric not in log_dict[epochs[int(args.start_epoch) - 1]]:
+            if metric not in log_dict[epochs[int(args.eval_interval) - 1]]:
                 if 'mAP' in metric:
                     raise KeyError(
                         f'{args.json_logs[i]} does not contain metric '
@@ -66,14 +66,12 @@ def plot_curve(log_dicts, args):
                     'interval is less than iterations of one epoch.')
 
             if 'mAP' in metric:
-                xs = np.arange(
-                    int(args.start_epoch),
-                    max(epochs) + 1, int(args.eval_interval))
+                xs = []
                 ys = []
                 for epoch in epochs:
                     ys += log_dict[epoch][metric]
-                ax = plt.gca()
-                ax.set_xticks(xs)
+                    if 'val' in log_dict[epoch]['mode']:
+                        xs.append(epoch)
                 plt.xlabel('epoch')
                 plt.plot(xs, ys, label=legend[i * num_metrics + j], marker='o')
             else:


### PR DESCRIPTION

Thanks for maintaining such a wonderful project. I encountered some problems and tried to fix them as the following.

## Motivation
I encountered three small problems while using [analyze_logs.py](https://github.com/open-mmlab/mmdetection/blob/master/tools/analysis_tools/analyze_logs.py). When **plotting epoch-based metrics**:
1. It can't work with evaluation interval greater than 1. Although the parameter `--eval-interval` allows a value to be entered, it will raise error in practice. The reason is that [line 57](https://github.com/open-mmlab/mmdetection/blob/master/tools/analysis_tools/analyze_logs.py#L57) requires the metric to be present in the starting epoch. Use [log of yolox-l ](https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/yolox_l_8x8_300e_coco_20211126_140236.log.json) as an example, command
```
python tools/analysis_tools/analyze_logs.py plot_curve yolox_l_8x8_300e_coco_20211126_140236.log.json --eval-interval 10
```
The error is
```
Traceback (most recent call last):
  File "tools/analysis_tools/analyze_logs.py", line 206, in <module>
    main()
  File "tools/analysis_tools/analyze_logs.py", line 202, in main
    eval(args.task)(log_dicts, args)
  File "tools/analysis_tools/analyze_logs.py", line 60, in plot_curve
    f'{args.json_logs[i]} does not contain metric '
KeyError: 'yolox_l_8x8_300e_coco_20211126_140236.log.json does not contain metric bbox_mAP. Please check if "--no-validate" is specified when you trained the model.'
```
2. The tool cannot handle flexible evaluation interval changes. For example, in the [log of yolox-l ](https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/yolox_l_8x8_300e_coco_20211126_140236.log.json) , the evaluation interval of the last few epochs is different from the previous epochs.
3. When the number of epochs is large, the x-axis display will be too dense.
![Inkedtoomuchx_LI](https://user-images.githubusercontent.com/44496446/164511418-d0eb00ee-4f9c-4625-bb63-d1481f80517e.jpg)


## Modification

1. Modify the judgment statement to determine whether the metric is in the log.
2. Change the method of generating xs in epoch-based plotting.
3. Remove two statements to ensure that the x-axis is displayed appropriately.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

Use [log of yolox-l ](https://download.openmmlab.com/mmdetection/v2.0/yolox/yolox_l_8x8_300e_coco/yolox_l_8x8_300e_coco_20211126_140236.log.json)as an example, it has flexible evaluation intervals. 
 ```
python tools/analysis_tools/analyze_logs_pr.py plot_curve yolox_l_8x8_300e_coco_20211126_140236.log.json --eval-interval 10 --legend yolox_mAP
```
![yolox_l_right](https://user-images.githubusercontent.com/44496446/164508224-143ce856-fdae-4dd9-8653-f325fffbff29.png)

It looks good. And the display of x is not too dense.

It also works well when evaluation interval = 1. Use [log of sparse_rcnn](https://download.openmmlab.com/mmdetection/v2.0/sparse_rcnn/sparse_rcnn_r50_fpn_300_proposals_crop_mstrain_480-800_3x_coco/sparse_rcnn_r50_fpn_300_proposals_crop_mstrain_480-800_3x_coco_20201223_024605-9fe92701.log.json) as an example.
```
python tools/analysis_tools/analyze_logs_pr.py plot_curve sparse_rcnn_r50_fpn_300_proposals_crop_mstrain_480-800_3x_coco_20201223_024605-9fe92701.log.json --legend mAP
```
![sparse_rcnn_right](https://user-images.githubusercontent.com/44496446/164508144-4cbbdbfd-0abe-450a-918d-afe0a78d01a7.png)


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
5. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
6. The documentation has been modified accordingly, like docstring or example tutorials.
