### PR TITLE
[Fix] Fix lint in dev branch

### DIFF
--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -5,7 +5,6 @@ import random
 import numpy as np
 import torch
 import torch.distributed as dist
-from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner,
                          Fp16OptimizerHook, OptimizerHook, build_optimizer,
                          build_runner, get_dist_info)
@@ -13,8 +12,9 @@ from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner,
 from mmdet.core import DistEvalHook, EvalHook
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
-from mmdet.utils import (compat_cfg, find_latest_checkpoint, get_root_logger,
-                        build_ddp, build_dp)
+from mmdet.utils import (build_ddp, build_dp, compat_cfg,
+                         find_latest_checkpoint, get_root_logger)
+
 
 def init_random_seed(seed=None, device='cuda'):
     """Initialize random seed.
@@ -153,10 +153,12 @@ def train_detector(model,
         find_unused_parameters = cfg.get('find_unused_parameters', False)
         # Sets the `find_unused_parameters` parameter in
         # torch.nn.parallel.DistributedDataParallel
-        model = build_ddp(model, cfg.device,
-                          device_ids=[int(os.environ['LOCAL_RANK'])],
-                          broadcast_buffers=False,
-                          find_unused_parameters=find_unused_parameters)
+        model = build_ddp(
+            model,
+            cfg.device,
+            device_ids=[int(os.environ['LOCAL_RANK'])],
+            broadcast_buffers=False,
+            find_unused_parameters=find_unused_parameters)
     else:
         model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
 

--- a/mmdet/datasets/samplers/distributed_sampler.py
+++ b/mmdet/datasets/samplers/distributed_sampler.py
@@ -7,6 +7,7 @@ from torch.utils.data import DistributedSampler as _DistributedSampler
 from mmdet.core.utils import sync_random_seed
 from mmdet.utils import get_device
 
+
 class DistributedSampler(_DistributedSampler):
 
     def __init__(self,
@@ -23,7 +24,7 @@ class DistributedSampler(_DistributedSampler):
         # is used to make sure that each rank shuffles the data indices
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
-        # same data list.        
+        # same data list.
         device = get_device()
         self.seed = sync_random_seed(seed, device)
 

--- a/mmdet/utils/__init__.py
+++ b/mmdet/utils/__init__.py
@@ -10,6 +10,6 @@ from .util_distribution import build_ddp, build_dp, get_device
 __all__ = [
     'get_root_logger', 'collect_env', 'find_latest_checkpoint',
     'update_data_root', 'setup_multi_processes', 'get_caller_name',
-    'log_img_scale', 'compat_cfg', 'split_batch', 'build_ddp',
-    'build_dp', 'get_device'
+    'log_img_scale', 'compat_cfg', 'split_batch', 'build_ddp', 'build_dp',
+    'get_device'
 ]

--- a/mmdet/utils/util_distribution.py
+++ b/mmdet/utils/util_distribution.py
@@ -2,28 +2,24 @@
 import torch
 from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 
-dp_factory = {
-        'cuda' : MMDataParallel,
-        'cpu' : MMDataParallel
-    }
+dp_factory = {'cuda': MMDataParallel, 'cpu': MMDataParallel}
 
-ddp_factory = {
-        'cuda' : MMDistributedDataParallel
-    }
+ddp_factory = {'cuda': MMDistributedDataParallel}
+
 
 def build_dp(model, device='cuda', dim=0, *args, **kwargs):
     """build DataParallel module by device type.
-    
+
     if device is cuda, return a MMDataParallel model; if device is mlu,
     return a MLUDataParallel model.
 
     Args:
-        model(:class:`nn.Module`): model to be parallelized.
-        device(str): device type, cuda, cpu or mlu. Defaults to cuda.
-        dim(int): Dimension used to scatter the data. Defaults to 0.
+        model (:class:`nn.Module`): model to be parallelized.
+        device (str): device type, cuda, cpu or mlu. Defaults to cuda.
+        dim (int): Dimension used to scatter the data. Defaults to 0.
 
     Returns:
-        model(nn.Module): the model to be parallelized.
+        nn.Module: the model to be parallelized.
     """
     if device == 'cuda':
         model = model.cuda()
@@ -38,15 +34,15 @@ def build_dp(model, device='cuda', dim=0, *args, **kwargs):
 def build_ddp(model, device='cuda', *args, **kwargs):
     """Build DistributedDataParallel module by device type.
 
-    If device is cuda, return a MMDistributedDataParallel model; if device is mlu,
-    return a MLUDistributedDataParallel model.
+    If device is cuda, return a MMDistributedDataParallel model;
+    if device is mlu, return a MLUDistributedDataParallel model.
 
     Args:
-        model(:class:`nn.Module`): module to be parallelized.
-        device(str): device type, mlu or cuda.
+        model (:class:`nn.Module`): module to be parallelized.
+        device (str): device type, mlu or cuda.
 
     Returns:
-        model(:class:`nn.Module`): the module to be parallelized
+        :class:`nn.Module`: the module to be parallelized
 
     References:
         .. [1] https://pytorch.org/docs/stable/generated/torch.nn.parallel.
@@ -56,19 +52,23 @@ def build_ddp(model, device='cuda', *args, **kwargs):
     if device == 'cuda':
         model = model.cuda()
     elif device == 'mlu':
-        from mmcv.device.mlu import  MLUDistributedDataParallel
+        from mmcv.device.mlu import MLUDistributedDataParallel
         ddp_factory['mlu'] = MLUDistributedDataParallel
         model = model.mlu()
 
     return ddp_factory[device](model, *args, **kwargs)
 
+
 def is_mlu_available():
-    """ Returns a bool indicating if MLU is currently available. """
+    """Returns a bool indicating if MLU is currently available."""
     return hasattr(torch, 'is_mlu_available') and torch.is_mlu_available()
 
+
 def get_device():
-    """ Returns an available device, cpu, cuda or mlu. """
-    is_device_available = {'cuda': torch.cuda.is_available(),
-                           'mlu': is_mlu_available()}
-    device_list = [k for k, v in is_device_available.items() if v ]
+    """Returns an available device, cpu, cuda or mlu."""
+    is_device_available = {
+        'cuda': torch.cuda.is_available(),
+        'mlu': is_mlu_available()
+    }
+    device_list = [k for k, v in is_device_available.items() if v]
     return device_list[0] if len(device_list) == 1 else 'cpu'

--- a/tools/test.py
+++ b/tools/test.py
@@ -9,7 +9,6 @@ import mmcv
 import torch
 from mmcv import Config, DictAction
 from mmcv.cnn import fuse_conv_bn
-from mmcv.parallel import MMDataParallel, MMDistributedDataParallel
 from mmcv.runner import (get_dist_info, init_dist, load_checkpoint,
                          wrap_fp16_model)
 
@@ -17,8 +16,9 @@ from mmdet.apis import multi_gpu_test, single_gpu_test
 from mmdet.datasets import (build_dataloader, build_dataset,
                             replace_ImageToTensor)
 from mmdet.models import build_detector
-from mmdet.utils import (compat_cfg, setup_multi_processes, update_data_root,
-                         build_ddp, build_dp, get_device)
+from mmdet.utils import (build_ddp, build_dp, compat_cfg, get_device,
+                         setup_multi_processes, update_data_root)
+
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -234,9 +234,11 @@ def main():
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
                                   args.show_score_thr)
     else:
-        model = build_ddp(model, cfg.device,
-                          device_ids=[int(os.environ['LOCAL_RANK'])],
-                          broadcast_buffers=False)
+        model = build_ddp(
+            model,
+            cfg.device,
+            device_ids=[int(os.environ['LOCAL_RANK'])],
+            broadcast_buffers=False)
         outputs = multi_gpu_test(model, data_loader, args.tmpdir,
                                  args.gpu_collect)
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -17,8 +17,8 @@ from mmdet import __version__
 from mmdet.apis import init_random_seed, set_random_seed, train_detector
 from mmdet.datasets import build_dataset
 from mmdet.models import build_detector
-from mmdet.utils import (collect_env, get_root_logger, setup_multi_processes,
-                         update_data_root, get_device)
+from mmdet.utils import (collect_env, get_device, get_root_logger,
+                         setup_multi_processes, update_data_root)
 
 
 def parse_args():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Fix lint in dev branch
flake8...................................................................Failed

- hook id: flake8
- exit code: 1
mmdet/apis/train.py:8:1: F401 'mmcv.parallel.MMDataParallel' imported but unused
mmdet/apis/train.py:8:1: F401 'mmcv.parallel.MMDistributedDataParallel' imported but unused
mmdet/apis/train.py:17:25: E128 continuation line under-indented for visual indent
mmdet/apis/train.py:19:1: E302 expected 2 blank lines, found 1
mmdet/datasets/samplers/distributed_sampler.py:10:1: E302 expected 2 blank lines, found 1
mmdet/datasets/samplers/distributed_sampler.py:26:26: W291 trailing whitespace
mmdet/utils/util_distribution.py:6:15: E203 whitespace before ':'
mmdet/utils/util_distribution.py:7:14: E203 whitespace before ':'
mmdet/utils/util_distribution.py:11:15: E203 whitespace before ':'
mmdet/utils/util_distribution.py:14:1: E302 expected 2 blank lines, found 1
mmdet/utils/util_distribution.py:16:1: W293 blank line contains whitespace
mmdet/utils/util_distribution.py:41:80: E501 line too long (82 > 79 characters)
mmdet/utils/util_distribution.py:59:36: E271 multiple spaces after keyword
mmdet/utils/util_distribution.py:65:1: E302 expected 2 blank lines, found 1
mmdet/utils/util_distribution.py:69:1: E302 expected 2 blank lines, found 1
mmdet/utils/util_distribution.py:73:66: E202 whitespace before ']'
tools/test.py:12:1: F401 'mmcv.parallel.MMDataParallel' imported but unused
tools/test.py:12:1: F401 'mmcv.parallel.MMDistributedDataParallel' imported but unused
tools/test.py:23:1: E302 expected 2 blank lines, found 1


## Modification

fix lint