### PR TITLE
[Fix] Fix KeyError: 'ori_filename' when using --show-dir with centernet_resnet18_dcnv2_140e_coco.py

### DIFF
--- a/configs/centernet/centernet_resnet18_dcnv2_140e_coco.py
+++ b/configs/centernet/centernet_resnet18_dcnv2_140e_coco.py
@@ -78,9 +78,9 @@ test_pipeline = [
             dict(type='DefaultFormatBundle'),
             dict(
                 type='Collect',
-                meta_keys=('filename', 'ori_shape', 'img_shape', 'pad_shape',
-                           'scale_factor', 'flip', 'flip_direction',
-                           'img_norm_cfg', 'border'),
+                meta_keys=('filename', 'ori_filename', 'ori_shape',
+                           'img_shape', 'pad_shape', 'scale_factor', 'flip',
+                           'flip_direction', 'img_norm_cfg', 'border'),
                 keys=['img'])
         ])
 ]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

solve #7842
Fix KeyError: 'ori_filename' in testing the config named centernet_resnet18_dcnv2_140e_coco.py

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
