### PR TITLE
[Enhance] Accelerate analyze result

### DIFF
--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -588,6 +588,8 @@ def eval_map(det_results,
     area_ranges = ([(rg[0]**2, rg[1]**2) for rg in scale_ranges]
                    if scale_ranges is not None else None)
 
+    # There is no need to use multi processes to process
+    # when num_imgs = 1 .
     if num_imgs > 1:
         assert nproc > 0, 'nproc must be at least one.'
         nproc = min(nproc, num_imgs)
@@ -629,8 +631,6 @@ def eval_map(det_results,
                     [area_ranges for _ in range(num_imgs)],
                     [use_legacy_coordinate for _ in range(num_imgs)], *args))
         else:
-            # There is no need to use multi processes to process
-            # when num_imgs = 1 .
             tpfp = tpfp_fn(
                 cls_dets[0],
                 cls_gts[0],

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -626,8 +626,16 @@ def eval_map(det_results,
         else:
             # There is no need to use multi processes to process
             # when num_imgs = 1 .
-            tpfp = tpfp_fn(cls_dets[0], cls_gts[0], cls_gts_ignore[0], iou_thr,
-                           area_ranges, use_legacy_coordinate)
+            tpfp = tpfp_fn(
+                cls_dets[0],
+                cls_gts[0],
+                cls_gts_ignore[0],
+                iou_thr,
+                area_ranges,
+                use_legacy_coordinate,
+                gt_bboxes_group_of=args[0][0],
+                use_group_of=args[1][0],
+                ioa_thr=args[2][0])
             tpfp = [tpfp]
 
         if use_group_of:

--- a/tests/test_metrics/test_mean_ap.py
+++ b/tests/test_metrics/test_mean_ap.py
@@ -84,7 +84,27 @@ def test_eval_map():
     mean_ap, eval_results = eval_map(
         det_results, annotations, use_legacy_coordinate=True)
     assert 0.291 < mean_ap < 0.293
-    eval_map(det_results, annotations, use_legacy_coordinate=False)
+    mean_ap, eval_results = eval_map(
+        det_results, annotations, use_legacy_coordinate=False)
+    assert 0.291 < mean_ap < 0.293
+
+    # 1 image and 2 classes
+    det_results = [[det_bboxes, det_bboxes]]
+
+    labels = np.array([0, 1, 1])
+    labels_ignore = np.array([0, 1])
+    gt_info = {
+        'bboxes': gt_bboxes,
+        'bboxes_ignore': gt_ignore,
+        'labels': labels,
+        'labels_ignore': labels_ignore
+    }
+    annotations = [gt_info]
+    mean_ap, eval_results = eval_map(
+        det_results, annotations, use_legacy_coordinate=True)
+    assert 0.291 < mean_ap < 0.293
+    mean_ap, eval_results = eval_map(
+        det_results, annotations, use_legacy_coordinate=False)
     assert 0.291 < mean_ap < 0.293
 
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix #7631


The time spent on [`eval_fn`](https://github.com/open-mmlab/mmdetection/blob/73b4e65a6a30435ef6a35f405e3474a4d9cfb234/tools/analysis_tools/analyze_results.py#L130) costs 1.5s, and on ['dataset.prepare_train_img(i)'](https://github.com/open-mmlab/mmdetection/blob/73b4e65a6a30435ef6a35f405e3474a4d9cfb234/tools/analysis_tools/analyze_results.py#L129) costs 0.01~0.05s. It is clear that we should accelerate the `eval_fn`. There are three nested loops in eval_fn: a loop for iou_thresh(0.5 ~ 0.95), a nested loop for classes, a nested loop for images. And the multi-processes design for fptp computing of list of images does not have expired effect when only one image passed in one time. The multi-proccesses design is unnecessary in this condition (one image a time).  But multi-proccesses design to compute mAP with different iou_thresh is necessary and effective.


![image](https://user-images.githubusercontent.com/26483343/166188391-ca44663f-cb9d-453d-b31d-dc89ae7876a3.png)


After optimization, the time spend on `eval_fn` is reduced to less then one fifteenth of the original when `nproc = 4` (which is set by defualt). The evaluation time on results generated by retinanet_r50_fpn_1x_coco takes 10~15 mins.


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
