### PR TITLE
自定义数据集的文档缺少一些细节，增加了这部分

### DIFF
--- a/docs/en/tutorials/customize_dataset.md
+++ b/docs/en/tutorials/customize_dataset.md
@@ -276,7 +276,22 @@ class MyDataset(CustomDataset):
 
     def get_ann_info(self, idx):
         return self.data_infos[idx]['ann']
+```
+Add MyDataset to `mmdet/datasets/__init__.py`
+```python
+from .my_datasets import MyDataset
 
+__all__ = [
+    # ......
+    'OpenImagesDataset', 'OpenImagesChallengeDataset',
+    # add class name in the end
+    'MyDataset'
+]
+```
+last step, recompile source code
+```shell
+pip install -r requirements/build.txt
+pip install -v -e .  # or "python setup.py develop"
 ```
 
 Then in the config, to use `MyDataset` you can modify the config as the following

--- a/docs/zh_cn/tutorials/customize_dataset.md
+++ b/docs/zh_cn/tutorials/customize_dataset.md
@@ -269,6 +269,23 @@ class MyDataset(CustomDataset):
         return self.data_infos[idx]['ann']
 
 ```
+然后在 `mmdet/datasets__init__.py` 中引入MyDataset
+
+```python
+from .my_datasets import MyDataset
+__all__ = [
+    # 省略一部分
+    'OpenImagesDataset', 'OpenImagesChallengeDataset',
+    # 这里加类名
+    'MyDataset'
+]
+
+```
+重新编译源码
+```shell
+pip install -r requirements/build.txt
+pip install -v -e .  # or "python setup.py develop"
+```
 
 配置文件中，可以使用 `MyDataset` 进行如下修改
 

--- a/mmdet/datasets/__init__.py
+++ b/mmdet/datasets/__init__.py
@@ -16,6 +16,8 @@ from .voc import VOCDataset
 from .wider_face import WIDERFaceDataset
 from .xml_style import XMLDataset
 
+
+
 __all__ = [
     'CustomDataset', 'XMLDataset', 'CocoDataset', 'DeepFashionDataset',
     'VOCDataset', 'CityscapesDataset', 'LVISDataset', 'LVISV05Dataset',


### PR DESCRIPTION
## Motivation
按照官方文档在`mmdet/datasets`增加了自定义数据集类，但是总是无法使用，报错该数据集类型不存在，因此增加了如何在自定义数据集类之后的两步，以解决我这样小白可能遇到的问题。 
第一次pull request，如有不规范之处，还请见谅

## Modification
修改了:
- `docs/en/tutorials/customize_dataset.md`
- `docs/zh_cn/tutorials/customize_dataset.md`

