### PR TITLE
[FIX] Enable YOLOX training on different devices

### DIFF
--- a/mmdet/models/detectors/yolox.py
+++ b/mmdet/models/detectors/yolox.py
@@ -97,7 +97,7 @@ class YOLOX(SingleStageDetector):
 
         # random resizing
         if (self._progress_in_iter + 1) % self._random_size_interval == 0:
-            self._input_size = self._random_resize()
+            self._input_size = self._random_resize(device=img.device)
         self._progress_in_iter += 1
 
         return losses
@@ -116,8 +116,8 @@ class YOLOX(SingleStageDetector):
                 gt_bbox[..., 1::2] = gt_bbox[..., 1::2] * scale_y
         return img, gt_bboxes
 
-    def _random_resize(self):
-        tensor = torch.LongTensor(2).cuda()
+    def _random_resize(self, device):
+        tensor = torch.LongTensor(2).to(device)
 
         if self.rank == 0:
             size = random.randint(*self._random_size_range)

--- a/tests/test_models/test_forward.py
+++ b/tests/test_models/test_forward.py
@@ -673,8 +673,6 @@ def test_inference_detector():
     assert len(result) == 2 and len(result[0]) == num_class
 
 
-@pytest.mark.skipif(
-    not torch.cuda.is_available(), reason='requires CUDA support')
 def test_yolox_random_size():
     from mmdet.models import build_detector
     model = _get_detector_cfg('yolox/yolox_tiny_8x8_300e_coco.py')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

YOLOX training is only available on Cuda. Make it possible to run on an arbitrary device.

## Modification

Send tensor to the appropriate device on the random resizing step.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
