### PR TITLE
Fix swin backbone absolute pos_embed

### DIFF
--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -753,7 +753,7 @@ class SwinTransformer(BaseModule):
                 ).flatten(2).transpose(1, 2)
             else:
                 absolute_pos_embed = self.absolute_pos_embed\
-                        .flatten(2).transpose(1, 2)
+                    .flatten(2).transpose(1, 2)
             x = x + absolute_pos_embed
         x = self.drop_after_pos(x)
 

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -588,9 +588,8 @@ class SwinTransformer(BaseModule):
         if self.use_abs_pos_embed:
             patch_row = pretrain_img_size[0] // patch_size
             patch_col = pretrain_img_size[1] // patch_size
-            num_patches = patch_row * patch_col
             self.absolute_pos_embed = nn.Parameter(
-                torch.zeros((1, num_patches, embed_dims)))
+                torch.zeros((1, embed_dims, patch_row, patch_col)))
 
         self.drop_after_pos = nn.Dropout(p=drop_rate)
 
@@ -746,7 +745,16 @@ class SwinTransformer(BaseModule):
         x, hw_shape = self.patch_embed(x)
 
         if self.use_abs_pos_embed:
-            x = x + self.absolute_pos_embed
+            h, w = self.absolute_pos_embed.shape[1:3]
+            if hw_shape[0] != h or hw_shape[1] != w:
+                absolute_pos_embed = F.interpolate(
+                    self.absolute_pos_embed, size=hw_shape,
+                    mode='bicubic', align_corners=False
+                ).flatten(2).transpose(1, 2)
+            else:
+                absolute_pos_embed = self.absolute_pos_embed\
+                        .flatten(2).transpose(1, 2)
+            x = x + absolute_pos_embed
         x = self.drop_after_pos(x)
 
         outs = []

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -748,9 +748,10 @@ class SwinTransformer(BaseModule):
             h, w = self.absolute_pos_embed.shape[1:3]
             if hw_shape[0] != h or hw_shape[1] != w:
                 absolute_pos_embed = F.interpolate(
-                    self.absolute_pos_embed, size=hw_shape,
-                    mode='bicubic', align_corners=False
-                ).flatten(2).transpose(1, 2)
+                    self.absolute_pos_embed,
+                    size=hw_shape,
+                    mode='bicubic',
+                    align_corners=False).flatten(2).transpose(1, 2)
             else:
                 absolute_pos_embed = self.absolute_pos_embed\
                     .flatten(2).transpose(1, 2)

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -753,8 +753,8 @@ class SwinTransformer(BaseModule):
                     mode='bicubic',
                     align_corners=False).flatten(2).transpose(1, 2)
             else:
-                absolute_pos_embed = self.absolute_pos_embed\
-                    .flatten(2).transpose(1, 2)
+                absolute_pos_embed = self.absolute_pos_embed.flatten(
+                    2).transpose(1, 2)
             x = x + absolute_pos_embed
         x = self.drop_after_pos(x)
 

--- a/tests/test_models/test_backbones/test_swin.py
+++ b/tests/test_models/test_backbones/test_swin.py
@@ -44,6 +44,11 @@ def test_swin_transformer():
     model = SwinTransformer(pretrain_img_size=224, use_abs_pos_embed=True)
     model.init_weights()
     model(temp)
+    # Test different inputs when use absolute position embedding
+    temp = torch.randn((1, 3, 112, 112))
+    model(temp)
+    temp = torch.randn((1, 3, 256, 256))
+    model(temp)
 
     # Test patch norm
     model = SwinTransformer(patch_norm=False)


### PR DESCRIPTION
## Motivation

The Swin transformer backbone is currently unable to process input images differing in size from the pretraining resolution when absolute positional embedding is enabled, due to lack of dynamic pos embed resizing in the forward pass.

## Modification

When absolute positional embedding is enabled, the backbone now checks the input shape against the pos embed shape and performs a bicubic interpolation to the correct shape if necessary. This is based on the original Mask2former code: https://github.com/facebookresearch/Mask2Former/blob/main/mask2former/modeling/backbone/swin.py#L656.

The pos embed parameter's shape has also been changed from [B * (H*W) * D] -> [B * D * H * W] to bring the model into consistency with the checkpoint loading code, which expects the new shape.

## BC-breaking (Optional)

This fix should not break backwards compatibility. No existing configs using the Swin backbone have absolute positional embedding enabled, or load from 

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
