### PR TITLE
[Fix] Use torch.initial_seed to guarantee the randomness of numpy

### DIFF
--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -209,7 +209,7 @@ def worker_init_fn(worker_id, num_workers, rank):
     # numpy may be set the same seed at each epoch.
     # Thus, # we use the return torch.initail_seed here to make sure numpy
     # is set a new seed in each epoch.
-    initial_seed = torch.initial_seed() % 2 ** 31
+    initial_seed = torch.initial_seed() % 2**31
     # The seed of each worker equals to
     # num_worker * rank + worker_id + user_seed
     worker_seed = num_workers * rank + worker_id + initial_seed

--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -204,7 +204,7 @@ def build_dataloader(dataset,
     return data_loader
 
 
-def worker_init_fn(worker_id, num_workers, rank):
+def worker_init_fn(worker_id, num_workers, rank, seed=None):
     # according to https://github.com/open-mmlab/mmdetection/issues/8110
     # numpy may be set the same seed at each epoch.
     # The solution can be found at

--- a/mmdet/datasets/builder.py
+++ b/mmdet/datasets/builder.py
@@ -207,9 +207,9 @@ def build_dataloader(dataset,
 def worker_init_fn(worker_id, num_workers, rank):
     # according to https://github.com/open-mmlab/mmdetection/issues/8110
     # numpy may be set the same seed at each epoch.
-    # Thus, # we use the return torch.initail_seed here to make sure numpy
-    # is set a new seed in each epoch.
-    initial_seed = torch.initial_seed() % 2**31
+    # The solution can be found at
+    # https://pytorch.org/docs/stable/data.html#randomness-in-multi-process-data-loading # noqa
+    initial_seed = torch.initial_seed() % 2**32
     # The seed of each worker equals to
     # num_worker * rank + worker_id + user_seed
     worker_seed = num_workers * rank + worker_id + initial_seed


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

solve https://github.com/open-mmlab/mmdetection/issues/8110
numpy will be set the same seed in each epoch when pytorch < 1.8

I reproduce the same bug.
test code:
<img width="745" alt="image" src="https://user-images.githubusercontent.com/32032453/172138338-f82f48bc-bd4c-402c-acb4-e3356ad6e00f.png">
the results:
<img width="206" alt="image" src="https://user-images.githubusercontent.com/32032453/172138477-ad22f07e-56de-42e3-8094-f4b8fb3fa2d1.png">

after modification:
<img width="179" alt="image" src="https://user-images.githubusercontent.com/32032453/172138596-e356cceb-ca5e-44a8-a161-4b4549e93822.png">

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
