### PR TITLE
[fix] fix error of 'unrecognized arguments: --load-from'

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -29,6 +29,8 @@ def parse_args():
     parser.add_argument(
         '--resume-from', help='the checkpoint file to resume from')
     parser.add_argument(
+        '--load-from', help='the checkpoint file to load from')
+    parser.add_argument(
         '--auto-resume',
         action='store_true',
         help='resume from the latest checkpoint automatically')
@@ -147,8 +149,12 @@ def main():
         cfg.work_dir = osp.join('./work_dirs',
                                 osp.splitext(osp.basename(args.config))[0])
 
+    # If resume_from and load_from are both not None, behave as resume_from.
     if args.resume_from is not None:
         cfg.resume_from = args.resume_from
+    elif args.load_from is not None:
+        cfg.load_from = args.load_from
+
     cfg.auto_resume = args.auto_resume
     if args.gpus is not None:
         cfg.gpu_ids = range(1)


### PR DESCRIPTION
## Motivation

In the [document](https://mmdetection.readthedocs.io/en/latest/1_exist_data_model.html#train-predefined-models-on-standard-datasets) of mmdetection, users can use `--load-from` options to load the certain checkpoints when training. 

However, when I run the script of training as follow
```bash
python tools/train.py ${CONFIG_FILE} \
    --work-dir ${WORK_DIR} \
    --load-from ${CHECKPOINT_FILE} \
    --deterministic
```

The error happens like
```bash
train.py: error: unrecognized arguments: --load-from *****.pth
```
So, I fixed it by simply modify the `tools/train.py` script.

## Modification
- Add `--load-from` option in `parse_args()`
- Assign the `load_from` value for cfg

NOTE: If resume-from and load-from options are **both** setted, the training process will behave as the resume-from mode. 