### PR TITLE
Add onnx_export method to PanopticFPN

### DIFF
--- a/mmdet/models/detectors/panoptic_two_stage_segmentor.py
+++ b/mmdet/models/detectors/panoptic_two_stage_segmentor.py
@@ -286,9 +286,10 @@ class TwoStagePanopticSegmentor(TwoStageDetector):
 
         if hasattr(self.roi_head, 'onnx_export') \
           and hasattr(self.semantic_head, 'onnx_export'):
-            detections = self.roi_head.onnx_export(x, proposals, img_metas)
-            sem_seg = self.semantic_head.onnx_export(x, img_metas)
-            return *detections, sem_seg
+            det_bboxes, det_labels, mask_results \
+              = self.roi_head.onnx_export(x, proposals, img_metas)
+            seg_preds = self.semantic_head.onnx_export(x, img_metas)
+            return det_bboxes, det_labels, mask_results, seg_preds
         else:
             raise NotImplementedError(
                 f'{self.__class__.__name__} can not '

--- a/mmdet/models/detectors/panoptic_two_stage_segmentor.py
+++ b/mmdet/models/detectors/panoptic_two_stage_segmentor.py
@@ -284,8 +284,9 @@ class TwoStagePanopticSegmentor(TwoStageDetector):
         x = self.extract_feat(img)
         proposals = self.rpn_head.onnx_export(x, img_metas)
 
-        if hasattr(self.roi_head, 'onnx_export') \
-          and hasattr(self.semantic_head, 'onnx_export'):
+        roi_head_exportable = hasattr(self.roi_head, 'onnx_export')
+        semantic_head_exportable = hasattr(self.semantic_head, 'onnx_export')
+        if roi_head_exportable and semantic_head_exportable:
             det_bboxes, det_labels, mask_results \
               = self.roi_head.onnx_export(x, proposals, img_metas)
             seg_preds = self.semantic_head.onnx_export(x, img_metas)

--- a/mmdet/models/seg_heads/base_semantic_head.py
+++ b/mmdet/models/seg_heads/base_semantic_head.py
@@ -84,3 +84,12 @@ class BaseSemanticHead(BaseModule, metaclass=ABCMeta):
             seg_preds = F.interpolate(
                 seg_preds, size=(h, w), mode='bilinear', align_corners=False)
         return seg_preds
+
+    def onnx_export(self, x, img_metas):
+        output = self.forward(x)
+        seg_preds = output['seg_preds']
+
+        h, w = img_metas[0]['img_shape_for_onnx']
+        seg_preds = F.interpolate(
+            seg_preds, size=(h, w), mode='bilinear', align_corners=False)
+        return seg_preds


### PR DESCRIPTION
## Motivation

Export PanopticFPN to ONNX.

## Modification

Please briefly describe what modification is made in this PR.

Implement `onnx_export` method to `mmdet/models/detectors/panoptic_two_stage_segmentor.py:TwoStagePanopticSegmentor and mmdet/models/seg_heads/base_semantic_head.py:BaseSemanticHead` used in standard PanopticFPN model.

## BC-breaking (Optional)

None.

## Use cases (Optional)

We can newly export PanopticFPN to ONNX.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.

## Example usage

I have checked the modification work properly, see details here: https://github.com/daigo0927/blog/tree/master/mmdet-onnx