### PR TITLE
[Fix] Fixed MMDetWandbHook to operate on no-mask COCO

### DIFF
--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -369,14 +369,14 @@ class MMDetWandbHook(WandbLoggerHook):
             data_ann = self.val_dataset.get_ann_info(idx)
             bboxes = data_ann['bboxes']
             labels = data_ann['labels']
-            masks = data_ann.get('masks', None)
+            masks = data_ann.get('masks', [None])
 
             # Get dict of bounding boxes to be logged.
             assert len(bboxes) == len(labels)
             wandb_boxes = self._get_wandb_bboxes(bboxes, labels)
 
             # Get dict of masks to be logged.
-            if masks is not None:
+            if masks[0] is not None:
                 wandb_masks = self._get_wandb_masks(
                     masks,
                     labels,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

MMDetWandbHook induce error when I used no-mask COCO dataset. (custom COCO dataset which I made)

## Modification

I set default value of masks to `[None]`, which is similar to COCO's no-mask mask `[None, None, ...]`. Since single None value of masks can mean masks is not well-formed, I discriminated usage of mask by checking `masks[0] is not None`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
