### PR TITLE
Fix floordiv warning.

### DIFF
--- a/mmdet/models/dense_heads/solo_head.py
+++ b/mmdet/models/dense_heads/solo_head.py
@@ -9,6 +9,7 @@ from mmcv.cnn import ConvModule
 from mmdet.core import InstanceData, mask_matrix_nms, multi_apply
 from mmdet.core.utils import center_of_mass, generate_coordinate
 from mmdet.models.builder import HEADS, build_loss
+from mmdet.utils.misc import floordiv
 from .base_mask_head import BaseMaskHead
 
 
@@ -375,38 +376,38 @@ class SOLOHead(BaseMaskHead):
                 center_h, center_w = center_of_mass(gt_mask)
 
                 coord_w = int(
-                    torch.div((center_w / upsampled_size[1]), (1. / num_grid),
-                              rounding_mode='trunc'))
+                    floordiv((center_w / upsampled_size[1]), (1. / num_grid),
+                             rounding_mode='trunc'))
                 coord_h = int(
-                    torch.div((center_h / upsampled_size[0]), (1. / num_grid),
-                              rounding_mode='trunc'))
+                    floordiv((center_h / upsampled_size[0]), (1. / num_grid),
+                             rounding_mode='trunc'))
 
                 # left, top, right, down
                 top_box = max(
                     0,
                     int(
-                        torch.div(
+                        floordiv(
                             (center_h - pos_h_range) / upsampled_size[0],
                             (1. / num_grid),
                             rounding_mode='trunc')))
                 down_box = min(
                     num_grid - 1,
                     int(
-                        torch.div(
+                        floordiv(
                             (center_h + pos_h_range) / upsampled_size[0],
                             (1. / num_grid),
                             rounding_mode='trunc')))
                 left_box = max(
                     0,
                     int(
-                        torch.div(
+                        floordiv(
                             (center_w - pos_w_range) / upsampled_size[1],
                             (1. / num_grid),
                             rounding_mode='trunc')))
                 right_box = min(
                     num_grid - 1,
                     int(
-                        torch.div(
+                        floordiv(
                             (center_w + pos_w_range) / upsampled_size[1],
                             (1. / num_grid),
                             rounding_mode='trunc')))

--- a/mmdet/models/dense_heads/solo_head.py
+++ b/mmdet/models/dense_heads/solo_head.py
@@ -375,27 +375,41 @@ class SOLOHead(BaseMaskHead):
                 center_h, center_w = center_of_mass(gt_mask)
 
                 coord_w = int(
-                    (center_w / upsampled_size[1]) // (1. / num_grid))
+                    torch.div((center_w / upsampled_size[1]), (1. / num_grid),
+                              rounding_mode='trunc'))
                 coord_h = int(
-                    (center_h / upsampled_size[0]) // (1. / num_grid))
+                    torch.div((center_h / upsampled_size[0]), (1. / num_grid),
+                              rounding_mode='trunc'))
 
                 # left, top, right, down
                 top_box = max(
                     0,
-                    int(((center_h - pos_h_range) / upsampled_size[0]) //
-                        (1. / num_grid)))
+                    int(
+                        torch.div(
+                            (center_h - pos_h_range) / upsampled_size[0],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 down_box = min(
                     num_grid - 1,
-                    int(((center_h + pos_h_range) / upsampled_size[0]) //
-                        (1. / num_grid)))
+                    int(
+                        torch.div(
+                            (center_h + pos_h_range) / upsampled_size[0],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 left_box = max(
                     0,
-                    int(((center_w - pos_w_range) / upsampled_size[1]) //
-                        (1. / num_grid)))
+                    int(
+                        torch.div(
+                            (center_w - pos_w_range) / upsampled_size[1],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 right_box = min(
                     num_grid - 1,
-                    int(((center_w + pos_w_range) / upsampled_size[1]) //
-                        (1. / num_grid)))
+                    int(
+                        torch.div(
+                            (center_w + pos_w_range) / upsampled_size[1],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
 
                 top = max(top_box, coord_h - 1)
                 down = min(down_box, coord_h + 1)

--- a/mmdet/models/dense_heads/solov2_head.py
+++ b/mmdet/models/dense_heads/solov2_head.py
@@ -12,6 +12,7 @@ from mmcv.runner import BaseModule, auto_fp16, force_fp32
 from mmdet.core import InstanceData, mask_matrix_nms, multi_apply
 from mmdet.core.utils import center_of_mass, generate_coordinate
 from mmdet.models.builder import HEADS
+from mmdet.utils.misc import floordiv
 from .solo_head import SOLOHead
 
 
@@ -382,27 +383,41 @@ class SOLOV2Head(SOLOHead):
                 center_h, center_w = center_of_mass(gt_mask)
 
                 coord_w = int(
-                    (center_w / upsampled_size[1]) // (1. / num_grid))
+                    floordiv((center_w / upsampled_size[1]), (1. / num_grid),
+                             rounding_mode='trunc'))
                 coord_h = int(
-                    (center_h / upsampled_size[0]) // (1. / num_grid))
+                    floordiv((center_h / upsampled_size[0]), (1. / num_grid),
+                             rounding_mode='trunc'))
 
                 # left, top, right, down
                 top_box = max(
                     0,
-                    int(((center_h - pos_h_range) / upsampled_size[0]) //
-                        (1. / num_grid)))
+                    int(
+                        floordiv(
+                            (center_h - pos_h_range) / upsampled_size[0],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 down_box = min(
                     num_grid - 1,
-                    int(((center_h + pos_h_range) / upsampled_size[0]) //
-                        (1. / num_grid)))
+                    int(
+                        floordiv(
+                            (center_h + pos_h_range) / upsampled_size[0],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 left_box = max(
                     0,
-                    int(((center_w - pos_w_range) / upsampled_size[1]) //
-                        (1. / num_grid)))
+                    int(
+                        floordiv(
+                            (center_w - pos_w_range) / upsampled_size[1],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
                 right_box = min(
                     num_grid - 1,
-                    int(((center_w + pos_w_range) / upsampled_size[1]) //
-                        (1. / num_grid)))
+                    int(
+                        floordiv(
+                            (center_w + pos_w_range) / upsampled_size[1],
+                            (1. / num_grid),
+                            rounding_mode='trunc')))
 
                 top = max(top_box, coord_h - 1)
                 down = min(down_box, coord_h + 1)

--- a/mmdet/utils/misc.py
+++ b/mmdet/utils/misc.py
@@ -5,7 +5,8 @@ import os.path as osp
 import warnings
 
 import mmcv
-from mmcv.utils import print_log
+import torch
+from mmcv.utils import TORCH_VERSION, digit_version, print_log
 
 
 def find_latest_checkpoint(path, suffix='pth'):
@@ -74,3 +75,15 @@ def update_data_root(cfg, logger=None):
 
     update(cfg.data, cfg.data_root, dst_root)
     cfg.data_root = dst_root
+
+
+_torch_version_div_indexing = (
+    'parrots' not in TORCH_VERSION
+    and digit_version(TORCH_VERSION) >= digit_version('1.8'))
+
+
+def floordiv(dividend, divisor, rounding_mode='trunc'):
+    if _torch_version_div_indexing:
+        return torch.div(dividend, divisor, rounding_mode=rounding_mode)
+    else:
+        return dividend // divisor


### PR DESCRIPTION
## Motivation

In SOLO code, __floordiv__ is deprecated, and its behavior will change in a future version of pytorch. 

## Modification

torch.div(a, b, rounding_mode='trunc') is used to replace floordiv.

