### PR TITLE
[Fix] Enable to set float mlp_ratio in SwinTransformer

### DIFF
--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -481,7 +481,7 @@ class SwinTransformer(BaseModule):
         embed_dims (int): The feature dimension. Default: 96.
         patch_size (int | tuple[int]): Patch size. Default: 4.
         window_size (int): Window size. Default: 7.
-        mlp_ratio (int): Ratio of mlp hidden dim to embedding dim.
+        mlp_ratio (int | float): Ratio of mlp hidden dim to embedding dim.
             Default: 4.
         depths (tuple[int]): Depths of each Swin Transformer stage.
             Default: (2, 2, 6, 2).
@@ -616,7 +616,7 @@ class SwinTransformer(BaseModule):
             stage = SwinBlockSequence(
                 embed_dims=in_channels,
                 num_heads=num_heads[i],
-                feedforward_channels=mlp_ratio * in_channels,
+                feedforward_channels=int(mlp_ratio * in_channels),
                 depth=depths[i],
                 window_size=window_size,
                 qkv_bias=qkv_bias,


### PR DESCRIPTION
## Motivation

In the original implementation, the `mlp_ratio` parameter in the `SwinTransformer`  can be float,  but the current mmdet's implementation does not support non-integer `mlp_ratio` (an Exception will be raised if a non-integer value is given).

I have found the same fix in mmsegmentation:
see, https://github.com/open-mmlab/mmsegmentation/pull/1274

## Modification

When a float `mlp_ratio` is given, dims of mlp's out channels are truncated to an integer.

## BC-breaking (Optional)

I think this does not break BC.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
