### PR TITLE
Refactor filtering mask, fix attribute error

### DIFF
--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -603,30 +603,26 @@ class FilterAnnotations:
             assert 'gt_bboxes' in results
             gt_bboxes = results['gt_bboxes']
             instance_num = gt_bboxes.shape[0]
+            keep = np.ones(gt_bboxes.shape[0], dtype=bool)
         if self.by_mask:
             assert 'gt_masks' in results
             gt_masks = results['gt_masks']
             instance_num = len(gt_masks)
+            keep = np.ones(len(gt_masks), dtype=bool)
 
         if instance_num == 0:
             return results
 
-        tests = []
         if self.by_box:
             w = gt_bboxes[:, 2] - gt_bboxes[:, 0]
             h = gt_bboxes[:, 3] - gt_bboxes[:, 1]
-            tests.append((w > self.min_gt_bbox_wh[0])
-                         & (h > self.min_gt_bbox_wh[1]))
+            keep = keep & ((w > self.min_gt_bbox_wh[0])
+                           & (h > self.min_gt_bbox_wh[1]))
         if self.by_mask:
             gt_masks = results['gt_masks']
-            tests.append(gt_masks.areas >= self.min_gt_mask_area)
-
-        keep = tests[0]
-        for t in tests[1:]:
-            keep = keep & t
+            keep = keep & (gt_masks.areas >= self.min_gt_mask_area)
 
         keep = keep.nonzero()[0]
-
         keys = ('gt_bboxes', 'gt_labels', 'gt_masks')
         for key in keys:
             if key in results:
@@ -642,4 +638,4 @@ class FilterAnnotations:
             f'min_gt_mask_area={self.min_gt_mask_area},' \
             f'by_box={self.by_box},' \
             f'by_mask={self.by_mask},' \
-            f'always_keep={self.always_keep})'
+            f'keep_empty={self.keep_empty})'

--- a/mmdet/datasets/pipelines/loading.py
+++ b/mmdet/datasets/pipelines/loading.py
@@ -603,13 +603,11 @@ class FilterAnnotations:
             assert 'gt_bboxes' in results
             gt_bboxes = results['gt_bboxes']
             instance_num = gt_bboxes.shape[0]
-            keep = np.ones(gt_bboxes.shape[0], dtype=bool)
         if self.by_mask:
             assert 'gt_masks' in results
             gt_masks = results['gt_masks']
             instance_num = len(gt_masks)
-            keep = np.ones(len(gt_masks), dtype=bool)
-
+        keep = np.ones(instance_num, dtype=bool)
         if instance_num == 0:
             return results
 


### PR DESCRIPTION
## Motivation

Filtering annotations for a dataset is great (besides the gt_bboxes_ignore option) I changed the implementation of the keep mask and added the attribute error fix in repr as also discussed here [#8214](https://github.com/open-mmlab/mmdetection/issues/8214) but not included in [#8136](https://github.com/open-mmlab/mmdetection/pull/8136)

## Modification

Change of filter annotation masking from appending boolean mask to a list and iterating, to now a bumpy array. Additionally small fix discussed but not included from #8214

## BC-breaking (Optional)

I don't think it will break BC.

## Use cases (Optional)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
