### PR TITLE
[Fix ] MMDetWandbHook does not support offline mode

### DIFF
--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -566,10 +566,12 @@ class MMDetWandbHook(WandbLoggerHook):
         data_artifact = self.wandb.Artifact('val', type='dataset')
         data_artifact.add(self.data_table, 'val_data')
 
-        self.wandb.run.use_artifact(data_artifact)
-        data_artifact.wait()
-
-        self.data_table_ref = data_artifact.get('val_data')
+        if not self.wandb.run.offline:
+            self.wandb.run.use_artifact(data_artifact)
+            data_artifact.wait()
+            self.data_table_ref = data_artifact.get('val_data')
+        else:
+            self.data_table_ref = self.data_table
 
     def _log_eval_table(self, idx):
         """Log the W&B Tables for model evaluation.


### PR DESCRIPTION
## Motivation

I got the following error when I used `MMDetWandbHook` in the offline mode:

```
wandb: Tracking run with wandb version 0.13.2
wandb: W&B syncing is set to `offline` in this directory.  
wandb: Run `wandb online` or set WANDB_MODE=online to enable cloud syncing.
Traceback (most recent call last):
  File "tools/train.py", line 242, in <module>
    main()
  File "tools/train.py", line 238, in main
    meta=meta)
  File "/content/mmdetection/mmdet/apis/train.py", line 244, in train_detector
    runner.run(data_loaders, cfg.workflow)
  File "/usr/local/lib/python3.7/dist-packages/mmcv/runner/epoch_based_runner.py", line 117, in run
    self.call_hook('before_run')
  File "/usr/local/lib/python3.7/dist-packages/mmcv/runner/base_runner.py", line 317, in call_hook
    getattr(hook, fn_name)(self)
  File "/usr/local/lib/python3.7/dist-packages/mmcv/runner/dist_utils.py", line 135, in wrapper
    return func(*args, **kwargs)
  File "/content/mmdetection/mmdet/core/hook/wandblogger_hook.py", line 203, in before_run
    self._log_data_table()
  File "/content/mmdetection/mmdet/core/hook/wandblogger_hook.py", line 569, in _log_data_table
    self.wandb.run.use_artifact(data_artifact)
  File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_run.py", line 255, in wrapper
    return func(self, *args, **kwargs)
  File "/usr/local/lib/python3.7/dist-packages/wandb/sdk/wandb_run.py", line 2491, in use_artifact
    raise TypeError("Cannot use artifact when in offline mode.")
TypeError: Cannot use artifact when in offline mode.
wandb: Waiting for W&B process to finish... (failed 1).
```

The log_config is the following:

```
log_config = dict(
    hooks=[
        dict(type='TextLoggerHook'),
        dict(type='MMDetWandbHook',
             init_kwargs={'project':'mmdet','mode':'offline'},
             interval=1,
             log_checkpoint=True,
             log_checkpoint_metadata=True,
             num_eval_images=1)
    ]
)
```

## Modification

I think the `use_artifact` and `wait` methods in the following codes can be skipped when the wandb is offline:

https://github.com/open-mmlab/mmdetection/blob/df28da98926bc410e16bed1e9fc7d425d9a89495/mmdet/core/hook/wandblogger_hook.py#L559-L573

## BC-breaking (Optional)

When the wandb is in the online mode (it is the default mode),  there is no change.

## Use cases (Optional)

I use the offline mode when I debug and test the codes.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.

About unit test:
To test the MMDetwandbHook, we need a full training setup (prepare dataset and install wandb and login), but I am not sure how to write this type of test efficiently.
I would appreciate any advice about this.

