### PR TITLE
fix: transpose scale_factors to match the shape of [batch_size, 4]

### DIFF
--- a/mmdet/models/roi_heads/test_mixins.py
+++ b/mmdet/models/roi_heads/test_mixins.py
@@ -238,7 +238,7 @@ class MaskTestMixin:
                 'ndarray with shape (4,) '
                 'arrange as (factor_w, factor_h, factor_w, factor_h), '
                 'The scale_factor with float type has been deprecated. ')
-            scale_factors = np.array([scale_factors] * 4, dtype=np.float32)
+            scale_factors = np.array([scale_factors] * 4, dtype=np.float32).T
 
         num_imgs = len(det_bboxes)
         if all(det_bbox.shape[0] == 0 for det_bbox in det_bboxes):


### PR DESCRIPTION
## Motivation

When using `mmdet.apis.inference.inference_detector` to infer a batch of images, I ran into the problem at the 258th line of test_mixins.py indicating the shape mismatch between `det_bboxes` and 'scale_factors`. It turns out that a float scale factor will be expanded by 4 at line 241, thus, outputting a vector of shape (4, batch_size). Whereas `det_bboxes` has a shape of [batch_size, 5]

## Modification

Transpose scale_factors to match the shape of [batch_size, 4] 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
