### PR TITLE
[Fix] Fix a bug of `NumClassCheckHook` when the model is wrapped.

### DIFF
--- a/mmdet/engine/hooks/num_class_check_hook.py
+++ b/mmdet/engine/hooks/num_class_check_hook.py
@@ -38,9 +38,9 @@ class NumClassCheckHook(Hook):
                  f'CLASSES = ({CLASSES},)')
             from mmdet.models.roi_heads.mask_heads import FusedSemanticHead
             for name, module in model.named_modules():
-                if hasattr(module, 'num_classes'
-                           ) and name != 'rpn_head' and not isinstance(
-                               module, (VGG, FusedSemanticHead)):
+                if hasattr(module, 'num_classes') and not name.endswith(
+                        'rpn_head') and not isinstance(
+                            module, (VGG, FusedSemanticHead)):
                     assert module.num_classes == len(CLASSES), \
                         (f'The `num_classes` ({module.num_classes}) in '
                          f'{module.__class__.__name__} of '


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When the model is wrapped by model wrappers, the `NumClassCheckHook` may fail to avoid checking `num_classes` of `rpn_head`.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
