### PR TITLE
[Fix] Bug in reppoints_head and fsaf_head

### DIFF
--- a/mmdet/models/dense_heads/fsaf_head.py
+++ b/mmdet/models/dense_heads/fsaf_head.py
@@ -193,7 +193,9 @@ class FSAFHead(RetinaHead):
         # map up to original set of anchors
         if unmap_outputs:
             num_total_anchors = flat_anchors.size(0)
-            labels = unmap(labels, num_total_anchors, inside_flags)
+            labels = unmap(
+                labels, num_total_anchors, inside_flags,
+                fill=self.num_classes)  # fill bg label
             label_weights = unmap(label_weights, num_total_anchors,
                                   inside_flags)
             bbox_targets = unmap(bbox_targets, num_total_anchors, inside_flags)

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -473,7 +473,11 @@ class RepPointsHead(AnchorFreeHead):
         # map up to original set of proposals
         if unmap_outputs:
             num_total_proposals = flat_proposals.size(0)
-            labels = unmap(labels, num_total_proposals, inside_flags)
+            labels = unmap(
+                labels,
+                num_total_proposals,
+                inside_flags,
+                fill=self.num_classes)  # fill bg label
             label_weights = unmap(label_weights, num_total_proposals,
                                   inside_flags)
             bbox_gt = unmap(bbox_gt, num_total_proposals, inside_flags)


### PR DESCRIPTION
We should fill the background label just like other dense heads, not 0.

