### PR TITLE
[Fix] Add list to dict keys to avoid modify loss dict

### DIFF
--- a/mmdet/models/detectors/panoptic_two_stage_segmentor.py
+++ b/mmdet/models/detectors/panoptic_two_stage_segmentor.py
@@ -101,7 +101,7 @@ class TwoStagePanopticSegmentor(TwoStageDetector):
                 x, rpn_data_samples, proposal_cfg=proposal_cfg)
             # avoid get same name with roi_head loss
             keys = rpn_losses.keys()
-            for key in keys:
+            for key in list(keys):
                 if 'loss' in key and 'rpn' not in key:
                     rpn_losses[f'rpn_{key}'] = rpn_losses.pop(key)
             losses.update(rpn_losses)

--- a/mmdet/models/detectors/two_stage.py
+++ b/mmdet/models/detectors/two_stage.py
@@ -172,7 +172,7 @@ class TwoStageDetector(BaseDetector):
                 x, rpn_data_samples, proposal_cfg=proposal_cfg)
             # avoid get same name with roi_head loss
             keys = rpn_losses.keys()
-            for key in keys:
+            for key in list(keys):
                 if 'loss' in key and 'rpn' not in key:
                     rpn_losses[f'rpn_{key}'] = rpn_losses.pop(key)
             losses.update(rpn_losses)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

During an iteration, the dictionary should not be modified. Add `list` to make a list copy.

No error is raised when the value of the loss dict is a Tensor, but this does not make sense. The error raised when the value of the loss dict is a List.

The fix can support use retinanet as an rpn head.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
