### PR TITLE
fix the link to 3.x doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Apart from MMDetection, we also released [MMEngine](https://github.com/open-mmla
 
 - Unifies interfaces of all components based on [MMEngine](https://github.com/open-mmlab/mmengine).
 - Faster training and testing speed with complete support of mixed precision training.
-- Refactored and more flexible [architecture](https://mmdetection.readthedocs.io/en/v3.0.0rc0/overview.html).
-- Provides more strong baselines and a general semi-supervised object detection framework. See [tutorial of semi-supervised detection](https://mmdetection.readthedocs.io/en/v3.0.0rc0/user_guides/semi_det.html).
-- Allows any kind of single-stage model as an RPN in a two-stage model. See [tutorial](https://mmdetection.readthedocs.io/en/v3.0.0rc0/user_guides/single_stage_as_rpn.html).
+- Refactored and more flexible [architecture](https://mmdetection.readthedocs.io/en/3.x/overview.html).
+- Provides more strong baselines and a general semi-supervised object detection framework. See [tutorial of semi-supervised detection](https://mmdetection.readthedocs.io/en/3.x/user_guides/semi_det.html).
+- Allows any kind of single-stage model as an RPN in a two-stage model. See [tutorial](https://mmdetection.readthedocs.io/en/3.x/user_guides/single_stage_as_rpn.html).
 
 ## Installation
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -78,8 +78,8 @@ MMDetection 是一个基于 PyTorch 的目标检测开源工具箱。它是 [Ope
 
 - 基于 [MMEngine](https://github.com/open-mmlab/mmengine) 统一了各组件接口。
 - 全面支持混合精度，训练测试速度更快。
-- 提供了更强的基线模型，并支持了通用的半监督目标检测框架，详见[半监督目标检测教程](https://mmdetection.readthedocs.io/zh_CN/v3.0.0rc0/user_guides/semi_det.html)。
-- 支持使用任意单阶段检测器作为二阶段模型的 RPN，详见[教程](https://mmdetection.readthedocs.io/en/v3.0.0rc0/user_guides/single_stage_as_rpn.html)。
+- 提供了更强的基线模型，并支持了通用的半监督目标检测框架，详见[半监督目标检测教程](https://mmdetection.readthedocs.io/zh_CN/3.x/user_guides/semi_det.html)。
+- 支持使用任意单阶段检测器作为二阶段模型的 RPN，详见[教程](https://mmdetection.readthedocs.io/zh_CN/3.x/user_guides/single_stage_as_rpn.html)。
 
 ## 安装
 


### PR DESCRIPTION

## Motivation

The link to the tutorial(semi-supervise detection and RPN) does not work.

## Modification

edit the readme, and fix the semi-supervise detection and RPN link.

