### PR TITLE
make compatible with `ConfigDict` and `dict`

### DIFF
--- a/mmdet/models/dense_heads/anchor_head.py
+++ b/mmdet/models/dense_heads/anchor_head.py
@@ -86,10 +86,10 @@ class AnchorHead(BaseDenseHead):
         self.train_cfg = train_cfg
         self.test_cfg = test_cfg
         if self.train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
             if train_cfg.get('sampler', None) is not None:
                 self.sampler = TASK_UTILS.build(
-                    self.train_cfg.sampler, default_args=dict(context=self))
+                    self.train_cfg['sampler'], default_args=dict(context=self))
             else:
                 self.sampler = PseudoSampler(context=self)
 
@@ -239,7 +239,7 @@ class AnchorHead(BaseDenseHead):
         """
         inside_flags = anchor_inside_flags(flat_anchors, valid_flags,
                                            img_meta['img_shape'][:2],
-                                           self.train_cfg.allowed_border)
+                                           self.train_cfg['allowed_border'])
         if not inside_flags.any():
             raise ValueError(
                 'There is no valid anchor inside the image boundary. Please '
@@ -284,10 +284,10 @@ class AnchorHead(BaseDenseHead):
             bbox_weights[pos_inds, :] = 1.0
 
             labels[pos_inds] = sampling_result.pos_gt_labels
-            if self.train_cfg.pos_weight <= 0:
+            if self.train_cfg['pos_weight'] <= 0:
                 label_weights[pos_inds] = 1.0
             else:
-                label_weights[pos_inds] = self.train_cfg.pos_weight
+                label_weights[pos_inds] = self.train_cfg['pos_weight']
         if len(neg_inds) > 0:
             label_weights[neg_inds] = 1.0
 

--- a/mmdet/models/dense_heads/cascade_rpn_head.py
+++ b/mmdet/models/dense_heads/cascade_rpn_head.py
@@ -236,7 +236,7 @@ class StageCascadeRPNHead(RPNHead):
             self.anchor_scales[0],
             self.anchor_strides,
             gt_instances_ignore=gt_instances_ignore,
-            allowed_border=self.train_cfg.allowed_border)
+            allowed_border=self.train_cfg['allowed_border'])
         sampling_result = self.sampler.sample(assign_result, pred_instances,
                                               gt_instances)
 
@@ -257,10 +257,10 @@ class StageCascadeRPNHead(RPNHead):
             bbox_targets[pos_inds, :] = pos_bbox_targets
             bbox_weights[pos_inds, :] = 1.0
             labels[pos_inds] = sampling_result.pos_gt_labels
-            if self.train_cfg.pos_weight <= 0:
+            if self.train_cfg['pos_weight'] <= 0:
                 label_weights[pos_inds] = 1.0
             else:
-                label_weights[pos_inds] = self.train_cfg.pos_weight
+                label_weights[pos_inds] = self.train_cfg['pos_weight']
         if len(neg_inds) > 0:
             label_weights[neg_inds] = 1.0
 

--- a/mmdet/models/dense_heads/gfl_head.py
+++ b/mmdet/models/dense_heads/gfl_head.py
@@ -128,7 +128,7 @@ class GFLHead(AnchorHead):
             **kwargs)
 
         if self.train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
             if self.train_cfg.get('sampler', None) is not None:
                 self.sampler = TASK_UTILS.build(
                     self.train_cfg['sampler'], default_args=dict(context=self))

--- a/mmdet/models/dense_heads/guided_anchor_head.py
+++ b/mmdet/models/dense_heads/guided_anchor_head.py
@@ -202,14 +202,15 @@ class GuidedAnchorHead(AnchorHead):
             # use PseudoSampler when no sampler in train_cfg
             if train_cfg.get('sampler', None) is not None:
                 self.sampler = TASK_UTILS.build(
-                    self.train_cfg.sampler, default_args=dict(context=self))
+                    self.train_cfg['sampler'], default_args=dict(context=self))
             else:
                 self.sampler = PseudoSampler()
 
             self.ga_assigner = TASK_UTILS.build(self.train_cfg['ga_assigner'])
             if train_cfg.get('ga_sampler', None) is not None:
                 self.ga_sampler = TASK_UTILS.build(
-                    self.train_cfg.ga_sampler, default_args=dict(context=self))
+                    self.train_cfg['ga_sampler'],
+                    default_args=dict(context=self))
             else:
                 self.ga_sampler = PseudoSampler()
 
@@ -293,7 +294,7 @@ class GuidedAnchorHead(AnchorHead):
                     inside_flags = anchor_inside_flags(
                         split_approxs, split_valid_flags,
                         img_meta['img_shape'][:2],
-                        self.train_cfg.allowed_border)
+                        self.train_cfg['allowed_border'])
                     inside_flags_list.append(inside_flags)
                 # inside_flag for a position is true if any anchor in this
                 # position is true
@@ -417,8 +418,8 @@ class GuidedAnchorHead(AnchorHead):
             assert (stride[0] == stride[1])
         anchor_strides = [stride[0] for stride in anchor_strides]
 
-        center_ratio = self.train_cfg.center_ratio
-        ignore_ratio = self.train_cfg.ignore_ratio
+        center_ratio = self.train_cfg['center_ratio']
+        ignore_ratio = self.train_cfg['ignore_ratio']
         img_per_gpu = len(batch_gt_instances)
         num_lvls = len(featmap_sizes)
         r1 = (1 - center_ratio) / 2

--- a/mmdet/models/dense_heads/mask2former_head.py
+++ b/mmdet/models/dense_heads/mask2former_head.py
@@ -141,9 +141,9 @@ class Mask2FormerHead(MaskFormerHead):
         self.test_cfg = test_cfg
         self.train_cfg = train_cfg
         if train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
             self.sampler = TASK_UTILS.build(
-                self.train_cfg.sampler, default_args=dict(context=self))
+                self.train_cfg['sampler'], default_args=dict(context=self))
             self.num_points = self.train_cfg.get('num_points', 12544)
             self.oversample_ratio = self.train_cfg.get('oversample_ratio', 3.0)
             self.importance_sample_ratio = self.train_cfg.get(

--- a/mmdet/models/dense_heads/maskformer_head.py
+++ b/mmdet/models/dense_heads/maskformer_head.py
@@ -122,9 +122,9 @@ class MaskFormerHead(AnchorFreeHead):
         self.test_cfg = test_cfg
         self.train_cfg = train_cfg
         if train_cfg:
-            self.assigner = TASK_UTILS.build(train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(train_cfg['assigner'])
             self.sampler = TASK_UTILS.build(
-                train_cfg.sampler, default_args=dict(context=self))
+                train_cfg['sampler'], default_args=dict(context=self))
 
         self.class_weight = loss_cls.class_weight
         self.loss_cls = MODELS.build(loss_cls)

--- a/mmdet/models/dense_heads/pisa_retinanet_head.py
+++ b/mmdet/models/dense_heads/pisa_retinanet_head.py
@@ -117,7 +117,7 @@ class PISARetinaHead(RetinaHead):
                     bbox_coder=self.bbox_coder,
                     loss_cls=self.loss_cls,
                     num_class=self.num_classes,
-                    **self.train_cfg.isr)
+                    **self.train_cfg['isr'])
             (flatten_labels, flatten_label_weights, flatten_bbox_targets,
              flatten_bbox_weights) = all_targets
 
@@ -145,7 +145,7 @@ class PISARetinaHead(RetinaHead):
                 flatten_bbox_preds,
                 flatten_bbox_targets,
                 self.loss_bbox,
-                **self.train_cfg.carl,
+                **self.train_cfg['carl'],
                 avg_factor=avg_factor,
                 sigmoid=True,
                 num_class=self.num_classes)

--- a/mmdet/models/dense_heads/reppoints_head.py
+++ b/mmdet/models/dense_heads/reppoints_head.py
@@ -112,9 +112,10 @@ class RepPointsHead(AnchorFreeHead):
             self.point_strides, offset=0.)
 
         if self.train_cfg:
-            self.init_assigner = TASK_UTILS.build(self.train_cfg.init.assigner)
+            self.init_assigner = TASK_UTILS.build(
+                self.train_cfg['init']['assigner'])
             self.refine_assigner = TASK_UTILS.build(
-                self.train_cfg.refine.assigner)
+                self.train_cfg['refine']['assigner'])
 
             if self.train_cfg.get('sampler', None) is not None:
                 self.sampler = TASK_UTILS.build(
@@ -435,10 +436,10 @@ class RepPointsHead(AnchorFreeHead):
 
         if stage == 'init':
             assigner = self.init_assigner
-            pos_weight = self.train_cfg.init.pos_weight
+            pos_weight = self.train_cfg['init']['pos_weight']
         else:
             assigner = self.refine_assigner
-            pos_weight = self.train_cfg.refine.pos_weight
+            pos_weight = self.train_cfg['refine']['pos_weight']
 
         assign_result = assigner.assign(pred_instances, gt_instances,
                                         gt_instances_ignore)
@@ -693,7 +694,7 @@ class RepPointsHead(AnchorFreeHead):
                                                        batch_img_metas, device)
         pts_coordinate_preds_init = self.offset_to_pts(center_list,
                                                        pts_preds_init)
-        if self.train_cfg.init.assigner['type'] == 'PointAssigner':
+        if self.train_cfg['init']['assigner']['type'] == 'PointAssigner':
             # Assign target for center list
             candidate_list = center_list
         else:

--- a/mmdet/models/dense_heads/rtmdet_head.py
+++ b/mmdet/models/dense_heads/rtmdet_head.py
@@ -43,7 +43,7 @@ class RTMDetHead(ATSSHead):
         self.with_objectness = with_objectness
         super().__init__(num_classes, in_channels, **kwargs)
         if self.train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
 
     def _init_layers(self):
         """Initialize layers of the head."""
@@ -427,7 +427,7 @@ class RTMDetHead(ATSSHead):
         """
         inside_flags = anchor_inside_flags(flat_anchors, valid_flags,
                                            img_meta['img_shape'][:2],
-                                           self.train_cfg.allowed_border)
+                                           self.train_cfg['allowed_border'])
         if not inside_flags.any():
             return (None, ) * 7
         # assign gt and sample anchors
@@ -461,10 +461,10 @@ class RTMDetHead(ATSSHead):
             bbox_targets[pos_inds, :] = pos_bbox_targets
 
             labels[pos_inds] = sampling_result.pos_gt_labels
-            if self.train_cfg.pos_weight <= 0:
+            if self.train_cfg['pos_weight'] <= 0:
                 label_weights[pos_inds] = 1.0
             else:
-                label_weights[pos_inds] = self.train_cfg.pos_weight
+                label_weights[pos_inds] = self.train_cfg['pos_weight']
         if len(neg_inds) > 0:
             label_weights[neg_inds] = 1.0
 

--- a/mmdet/models/dense_heads/sabl_retina_head.py
+++ b/mmdet/models/dense_heads/sabl_retina_head.py
@@ -411,10 +411,10 @@ class SABLRetinaHead(BaseDenseHead):
             bbox_cls_weights[pos_inds, :] = pos_bbox_cls_weights
             bbox_reg_weights[pos_inds, :] = pos_bbox_reg_weights
             labels[pos_inds] = sampling_result.pos_gt_labels
-            if self.train_cfg.pos_weight <= 0:
+            if self.train_cfg['pos_weight'] <= 0:
                 label_weights[pos_inds] = 1.0
             else:
-                label_weights[pos_inds] = self.train_cfg.pos_weight
+                label_weights[pos_inds] = self.train_cfg['pos_weight']
         if len(neg_inds) > 0:
             label_weights[neg_inds] = 1.0
 

--- a/mmdet/models/dense_heads/yolo_head.py
+++ b/mmdet/models/dense_heads/yolo_head.py
@@ -96,10 +96,10 @@ class YOLOV3Head(BaseDenseHead):
         self.train_cfg = train_cfg
         self.test_cfg = test_cfg
         if self.train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
             if train_cfg.get('sampler', None) is not None:
                 self.sampler = TASK_UTILS.build(
-                    self.train_cfg.sampler, context=self)
+                    self.train_cfg['sampler'], context=self)
             else:
                 self.sampler = PseudoSampler()
 

--- a/mmdet/models/dense_heads/yolox_head.py
+++ b/mmdet/models/dense_heads/yolox_head.py
@@ -134,7 +134,7 @@ class YOLOXHead(BaseDenseHead):
         self.train_cfg = train_cfg
 
         if self.train_cfg:
-            self.assigner = TASK_UTILS.build(self.train_cfg.assigner)
+            self.assigner = TASK_UTILS.build(self.train_cfg['assigner'])
             # YOLOX does not support sampling
             self.sampler = PseudoSampler()
 


### PR DESCRIPTION
If `AnchorHead` is used as the net head and `dict` is used as the `train_cfg` parameter, an error will be reported. 
That is because `dict` does not support python object attributes interface like `train_cfg.assigner`, but `ConfigDict` does.

```python
cfg = dict(
    type='mmdet.AnchorHead',
    num_classes=80,
    in_channels=256,
    train_cfg=dict(
        assigner=dict(type='MaxIoUAssigner', pos_iou_thr=0.5,
                      neg_iou_thr=0.3)))

anchor_head = MODELS.build(cfg)
```
> AttributeError: class `AnchorHead` in mmdet/models/dense_heads/anchor_head.py: 'dict' object has no attribute 'assigner'