### PR TITLE
Fix bugs when ploting loss curve by analyze_logs.py

### DIFF
--- a/tools/analysis_tools/analyze_logs.py
+++ b/tools/analysis_tools/analyze_logs.py
@@ -170,6 +170,7 @@ def load_json_logs(json_logs):
             epoch = 1
             for i, line in enumerate(log_file):
                 log = json.loads(line.strip())
+                val_flag = False
                 # skip lines only contains one key
                 if not len(log) > 1:
                     continue
@@ -180,6 +181,9 @@ def load_json_logs(json_logs):
                 for k, v in log.items():
                     if '/' in k:
                         log_dict[epoch][k.split('/')[-1]].append(v)
+                        val_flag = True
+                    elif val_flag:
+                        continue
                     else:
                         log_dict[epoch][k].append(v)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When ploting loss_cls of some run using analyze_logs.py, the numbers of xs and ys in function plot_curve(line 83,84) are not the same! Therefore causing error when running plt.plot().
After debug, I found that this problem was caused by the quantity mismatch of values of key 'step' and key 'loss_cls' in log_dicts returned by function load_json_logs. And this problem occured because validation lines in json log file producing after training also contains key 'step', causing the number of key 'step' in log_dicts 12 more than that in key 'loss_cls'.

## Modification

Simply add val_flag variable to judge whether current line is validation line, if it is, do not add the step info into the log_dicts.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
no

