### PR TITLE
[Fix] Lint depend on importlib-metadata < 5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,10 @@ jobs:
       - checkout
       - run:
           name: Install pre-commit hook
+          # flake8 3.8.3 needs importlib-metadata < 5
+          # https://github.com/python/importlib_metadata/issues/406
           command: |
+            pip install importlib-metadata < 5
             pip install pre-commit
             pre-commit install
       - run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,7 @@ jobs:
           python-version: 3.7
       - name: Install pre-commit hook
         run: |
+          pip install importlib-metadata < 5
           pip install pre-commit
           pre-commit install
       - name: Linting


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

flake8 depends on importlib-metadata < 5.
related issue: https://github.com/python/importlib_metadata/issues/406

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
