### PR TITLE
Upgrade pre commit hooks in dev-3.x

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort
@@ -8,11 +8,11 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.32.0
     hooks:
       - id: yapf
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -25,7 +25,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.1
     hooks:
       - id: codespell
   - repo: https://github.com/executablebooks/mdformat

--- a/docs/en/advanced_guides/customize_runtime.md
+++ b/docs/en/advanced_guides/customize_runtime.md
@@ -234,7 +234,7 @@ Actually, both [`IterBasedTrainLoop`](https://github.com/open-mmlab/mmengine/blo
 
 ```python
 # Before 365001th iteration, we do evaluation every 5000 iterations.
-# After 365000th iteration, we do evaluation every 368750 iteraions,
+# After 365000th iteration, we do evaluation every 368750 iterations,
 # which means that we do evaluation at the end of training.
 
 interval = 5000

--- a/docs/en/advanced_guides/customize_transforms.md
+++ b/docs/en/advanced_guides/customize_transforms.md
@@ -45,5 +45,5 @@
 
    To visualize the output of your transforms pipeline, `tools/misc/browse_dataset.py`
    can help the user to browse a detection dataset (both images and bounding box annotations)
-   visually, or save the image to a designated directory. More detials can refer to
+   visually, or save the image to a designated directory. More details can refer to
    [visualization documentation](../user_guides/visualization.md)

--- a/docs/en/notes/changelog_v2.x.md
+++ b/docs/en/notes/changelog_v2.x.md
@@ -578,7 +578,7 @@ Thanks @Boyden, @onnkeat, @st9007a, @vealocia, @yhcao6, @DapangpangX, @yellowdol
 - Support [PVT](https://arxiv.org/abs/2102.12122) and [PVTv2](https://arxiv.org/abs/2106.13797) (#5780)
 - Support [SOLO](https://arxiv.org/abs/1912.04488) (#5832)
 - Support large scale jittering and New Mask R-CNN baselines (#6132)
-- Add a general data structrue for the results of models (#5508)
+- Add a general data structure for the results of models (#5508)
 - Added a base class for one-stage instance segmentation (#5904)
 - Speed up `YOLOv3` inference (#5991)
 - Release Swin Transformer pre-trained models (#6100)

--- a/docs/en/user_guides/config.md
+++ b/docs/en/user_guides/config.md
@@ -325,7 +325,7 @@ param_scheduler = [
 
 ### Hook config
 
-Users can attach Hooks to training, validation, and testing loops to insert some oprations during running. There are two different hook fields, one is `default_hooks` and the other is `custom_hooks`.
+Users can attach Hooks to training, validation, and testing loops to insert some operations during running. There are two different hook fields, one is `default_hooks` and the other is `custom_hooks`.
 
 `default_hooks` is a dict of hook configs, and they are the hooks must be required at the runtime. They have default priority which should not be modified. If not set, runner will use the default values. To disable a default hook, users can set its config to `None`.
 

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -151,7 +151,7 @@ Assume that you have got [Mask R-CNN checkpoint file](https://download.openmmlab
 You can modify the test_evaluator to save the results bbox by:
 
 1. Find which dataset in 'configs/base/datasets' the current config corresponds to.
-2. Replace the original test_evaluator and test_dataloader with test_evaluator and test_dataloader in the comment in dateset config.
+2. Replace the original test_evaluator and test_dataloader with test_evaluator and test_dataloader in the comment in dataset config.
 3. Use the following command to get the results bbox and segmentation json file.
 
 ```shell

--- a/mmdet/models/dense_heads/detr_head.py
+++ b/mmdet/models/dense_heads/detr_head.py
@@ -113,7 +113,7 @@ class DETRHead(AnchorFreeHead):
             assigner = train_cfg['assigner']
             self.assigner = TASK_UTILS.build(assigner)
             if train_cfg.get('sampler', None) is not None:
-                raise RuntimeError('DETR donot build sampler.')
+                raise RuntimeError('DETR do not build sampler.')
         self.num_query = num_query
         self.num_classes = num_classes
         self.in_channels = in_channels

--- a/mmdet/models/losses/focal_loss.py
+++ b/mmdet/models/losses/focal_loss.py
@@ -117,7 +117,7 @@ def sigmoid_focal_loss(pred,
                        alpha=0.25,
                        reduction='mean',
                        avg_factor=None):
-    r"""A warpper of cuda version `Focal Loss
+    r"""A wrapper of cuda version `Focal Loss
     <https://arxiv.org/abs/1708.02002>`_.
 
     Args:

--- a/mmdet/models/losses/mse_loss.py
+++ b/mmdet/models/losses/mse_loss.py
@@ -8,7 +8,7 @@ from .utils import weighted_loss
 
 @weighted_loss
 def mse_loss(pred, target):
-    """Warpper of mse loss."""
+    """Wrapper of mse loss."""
     return F.mse_loss(pred, target, reduction='none')
 
 

--- a/mmdet/models/roi_heads/htc_roi_head.py
+++ b/mmdet/models/roi_heads/htc_roi_head.py
@@ -32,7 +32,7 @@ class HybridTaskCascadeRoIHead(CascadeRoIHead):
         interleaved (bool): Whether to interleaves the box branch and mask
             branch. If True, the mask branch can take the refined bounding
             box predictions. Defaults to True.
-        mask_info_flow (bool): Whether ro turn on the mask information flow,
+        mask_info_flow (bool): Whether to turn on the mask information flow,
             which means that feeding the mask features of the preceding stage
             to the current stage. Defaults to True.
     """

--- a/mmdet/models/task_modules/samplers/sampling_result.py
+++ b/mmdet/models/task_modules/samplers/sampling_result.py
@@ -205,7 +205,7 @@ class SamplingResult(util_mixins.NiceRepr):
         from mmdet.models.task_modules.samplers import RandomSampler
         rng = ensure_rng(rng)
 
-        # make probabalistic?
+        # make probabilistic?
         num = 32
         pos_fraction = 0.5
         neg_pos_ub = -1

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,Nam

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,4 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,Nam
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,nam

--- a/tests/test_structures/test_bbox/test_box_type.py
+++ b/tests/test_structures/test_bbox/test_box_type.py
@@ -90,7 +90,8 @@ class TestBoxType(TestCase):
         def converter_B(bboxes):
             return bboxes
 
-        register_box_converter('B' 'A', converter_B)
+        register_box_converter('B'
+                               'A', converter_B)
 
         # register uncallable object
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation to upgrade some versions of pre-commit hooks to latest is that importlib-metadata v5.0.0 which removed deprecated endpoint breaks the flake8. More details at https://stackoverflow.com/questions/73929564/entrypoints-object-has-no-attribute-get-digital-ocean/73932581#73932581.

## Modification

Upgrade some versions of pre-commit hooks in dev-3.x.

## BC-breaking (Optional)

No
## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
