### PR TITLE
Fix CircleCI and readthedoc build failed

### DIFF
--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -37,8 +37,6 @@ jobs:
         type: string
       torchvision:
         type: string
-      mmcv:
-        type: string
     docker:
       - image: cimg/python:<< parameters.python >>
     resource_class: large
@@ -70,7 +68,8 @@ jobs:
           # force reinstall pycocotools to ensure pycocotools being built under the currenct numpy
           command: |
             python -m pip install git+ssh://git@github.com/open-mmlab/mmengine.git@main
-            python -m pip install << parameters.mmcv >>
+            pip install -U openmim
+            mim install 'mmcv >= 2.0.0rc0'
             pip install -r requirements/tests.txt -r requirements/optional.txt
             pip install --force-reinstall pycocotools
             pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
@@ -96,8 +95,6 @@ jobs:
       cudnn:
         type: integer
         default: 7
-      mmcv:
-        type: string
     machine:
       image: ubuntu-2004-cuda-11.4:202110-01
       # docker_layer_caching: true
@@ -117,10 +114,10 @@ jobs:
             docker exec mmdetection apt-get install -y git
       - run:
           name: Install mmdet dependencies
-          # pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch${{matrix.torch_version}}/index.html
           command: |
             docker exec mmdetection pip install -e /mmengine
-            docker exec mmdetection pip install << parameters.mmcv >>
+            docker exec mmdetection pip install -U openmim
+            docker exec mmdetection mim install 'mmcv >= 2.0.0rc0'
             docker exec mmdetection pip install -r requirements/tests.txt -r requirements/optional.txt
             docker exec mmdetection pip install pycocotools
             docker exec mmdetection pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
@@ -161,7 +158,6 @@ workflows:
           torch: 1.6.0
           torchvision: 0.7.0
           python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
-          mmcv: https://download.openmmlab.com/mmcv/dev-2.x/cpu/torch1.6.0/mmcv_full-2.0.0rc0-cp36-cp36m-manylinux1_x86_64.whl
           requires:
             - lint
       - build_cpu:
@@ -169,7 +165,6 @@ workflows:
           torch: 1.9.0
           torchvision: 0.10.0
           python: 3.9.0
-          mmcv: https://download.openmmlab.com/mmcv/dev-2.x/cpu/torch1.9.0/mmcv_full-2.0.0rc0-cp39-cp39-manylinux1_x86_64.whl
           requires:
             - minimum_version_cpu
       - hold:
@@ -182,7 +177,6 @@ workflows:
           # Use double quotation mark to explicitly specify its type
           # as string instead of number
           cuda: "10.2"
-          mmcv: https://download.openmmlab.com/mmcv/dev-2.x/cu102/torch1.8.0/mmcv_full-2.0.0rc0-cp37-cp37m-manylinux1_x86_64.whl
           requires:
             - hold
   merge_stage_test:
@@ -193,9 +187,6 @@ workflows:
       - build_cuda:
           name: minimum_version_gpu
           torch: 1.6.0
-          # Use double quotation mark to explicitly specify its type
-          # as string instead of number
-          mmcv: https://download.openmmlab.com/mmcv/dev-2.x/cu101/torch1.6.0/mmcv_full-2.0.0rc0-cp37-cp37m-manylinux1_x86_64.whl
           cuda: "10.1"
           filters:
             branches:

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -81,64 +81,6 @@ jobs:
       - run:
           name: Run unittests
           command: |
-            python -m coverage run --branch --source mmdet -m pytest tests/ -k 'not timm'
-            python -m coverage xml
-            python -m coverage report -m
-
-  build_cpu_with_timm:
-    parameters:
-      # The python version must match available image tags in
-      # https://circleci.com/developer/images/image/cimg/python
-      python:
-        type: string
-      torch:
-        type: string
-      torchvision:
-        type: string
-    docker:
-      - image: cimg/python:<< parameters.python >>
-    resource_class: large
-    steps:
-      - checkout
-      - run:
-          name: Install Libraries
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5
-      - run:
-          name: Configure Python & pip
-          command: |
-            pip install --upgrade pip
-            pip install wheel
-      - run:
-          name: Install PyTorch
-          command: |
-            python -V
-            python -m pip install torch==<< parameters.torch >>+cpu torchvision==<< parameters.torchvision >>+cpu -f https://download.pytorch.org/whl/torch_stable.html
-      - when:
-          condition:
-            equal: [ "3.9.0", << parameters.python >> ]
-          steps:
-            - run: pip install "protobuf <= 3.20.1" && sudo apt-get update && sudo apt-get -y install libprotobuf-dev protobuf-compiler cmake
-      - run:
-          name: Install mmdet dependencies
-          # numpy may be downgraded after building pycocotools, which causes `ImportError: numpy.core.multiarray failed to import`
-          # force reinstall pycocotools to ensure pycocotools being built under the currenct numpy
-          command: |
-            python -m pip install git+ssh://git@github.com/open-mmlab/mmengine.git@main
-            pip install -U openmim
-            mim install 'mmcv >= 2.0.0rc0'
-            pip install -r requirements/tests.txt -r requirements/optional.txt
-            pip install --force-reinstall pycocotools
-            pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
-            pip install git+https://github.com/cocodataset/panopticapi.git
-      - run:
-          name: Build and install
-          command: |
-            pip install -e .
-      - run:
-          name: Run unittests
-          command: |
             python -m coverage run --branch --source mmdet -m pytest tests/
             python -m coverage xml
             python -m coverage report -m
@@ -188,7 +130,7 @@ jobs:
       - run:
           name: Run unittests
           command: |
-            docker exec mmdetection python -m pytest tests/ -k 'not timm'
+            docker exec mmdetection python -m pytest tests/
 
 workflows:
   pr_stage_lint:
@@ -218,7 +160,7 @@ workflows:
           python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
           requires:
             - lint
-      - build_cpu_with_timm:
+      - build_cpu:
           name: maximum_version_cpu
           torch: 1.12.1
           torchvision: 0.13.1

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -218,13 +218,6 @@ workflows:
           python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
           requires:
             - lint
-      - build_cpu:
-          name: maximum_version_cpu
-          torch: 1.12.0
-          torchvision: 0.13.0
-          python: 3.9.0
-          requires:
-            - minimum_version_cpu
       - build_cpu_with_timm:
           name: maximum_version_cpu
           torch: 1.12.1

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -81,6 +81,64 @@ jobs:
       - run:
           name: Run unittests
           command: |
+            python -m coverage run --branch --source mmdet -m pytest tests/ -k 'not timm'
+            python -m coverage xml
+            python -m coverage report -m
+
+  build_cpu_with_timm:
+    parameters:
+      # The python version must match available image tags in
+      # https://circleci.com/developer/images/image/cimg/python
+      python:
+        type: string
+      torch:
+        type: string
+      torchvision:
+        type: string
+    docker:
+      - image: cimg/python:<< parameters.python >>
+    resource_class: large
+    steps:
+      - checkout
+      - run:
+          name: Install Libraries
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 libgl1-mesa-glx libjpeg-dev zlib1g-dev libtinfo-dev libncurses5
+      - run:
+          name: Configure Python & pip
+          command: |
+            pip install --upgrade pip
+            pip install wheel
+      - run:
+          name: Install PyTorch
+          command: |
+            python -V
+            python -m pip install torch==<< parameters.torch >>+cpu torchvision==<< parameters.torchvision >>+cpu -f https://download.pytorch.org/whl/torch_stable.html
+      - when:
+          condition:
+            equal: [ "3.9.0", << parameters.python >> ]
+          steps:
+            - run: pip install "protobuf <= 3.20.1" && sudo apt-get update && sudo apt-get -y install libprotobuf-dev protobuf-compiler cmake
+      - run:
+          name: Install mmdet dependencies
+          # numpy may be downgraded after building pycocotools, which causes `ImportError: numpy.core.multiarray failed to import`
+          # force reinstall pycocotools to ensure pycocotools being built under the currenct numpy
+          command: |
+            python -m pip install git+ssh://git@github.com/open-mmlab/mmengine.git@main
+            pip install -U openmim
+            mim install 'mmcv >= 2.0.0rc0'
+            pip install -r requirements/tests.txt -r requirements/optional.txt
+            pip install --force-reinstall pycocotools
+            pip install albumentations>=0.3.2 --no-binary imgaug,albumentations
+            pip install git+https://github.com/cocodataset/panopticapi.git
+      - run:
+          name: Build and install
+          command: |
+            pip install -e .
+      - run:
+          name: Run unittests
+          command: |
             python -m coverage run --branch --source mmdet -m pytest tests/
             python -m coverage xml
             python -m coverage report -m
@@ -130,7 +188,7 @@ jobs:
       - run:
           name: Run unittests
           command: |
-            docker exec mmdetection python -m pytest tests/
+            docker exec mmdetection python -m pytest tests/ -k 'not timm'
 
 workflows:
   pr_stage_lint:
@@ -162,8 +220,15 @@ workflows:
             - lint
       - build_cpu:
           name: maximum_version_cpu
-          torch: 1.9.0
-          torchvision: 0.10.0
+          torch: 1.12.0
+          torchvision: 0.13.0
+          python: 3.9.0
+          requires:
+            - minimum_version_cpu
+      - build_cpu_with_timm:
+          name: maximum_version_cpu
+          torch: 1.12.1
+          torchvision: 0.13.1
           python: 3.9.0
           requires:
             - minimum_version_cpu

--- a/docs/en/user_guides/useful_hooks.md
+++ b/docs/en/user_guides/useful_hooks.md
@@ -6,9 +6,9 @@ MMDetection and MMEngine provide users with various useful hooks including log h
 
 ## NumClassCheckHook
 
-## [MemoryProfilerHook](../../../mmdet/engine/hooks/memory_profiler_hook.py)
+## MemoryProfilerHook
 
-Memory profiler hook records memory information including virtual memory, swap memory, and the memory of the current process. This hook helps grasp the memory usage of the system and discover potential memory leak bugs. To use this hook, users should install `memory_profiler` and `psutil` by `pip install memory_profiler psutil` first.
+[Memory profiler hook](https://github.com/open-mmlab/mmdetection/blob/3.x/mmdet/engine/hooks/memory_profiler_hook.py) records memory information including virtual memory, swap memory, and the memory of the current process. This hook helps grasp the memory usage of the system and discover potential memory leak bugs. To use this hook, users should install `memory_profiler` and `psutil` by `pip install memory_profiler psutil` first.
 
 ### Usage
 

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -2,4 +2,3 @@ cityscapesscripts
 imagecorruptions
 scipy
 sklearn
-timm

--- a/tests/test_models/test_seg_heads/test_panoptic_fpn_head.py
+++ b/tests/test_models/test_seg_heads/test_panoptic_fpn_head.py
@@ -15,7 +15,7 @@ class TestPanopticFPNHead(unittest.TestCase):
             num_things_classes=2,
             num_stuff_classes=2,
             in_channels=32,
-            inner_channels=1)
+            inner_channels=32)
         head.init_weights()
         assert_allclose(head.conv_logits.bias.data,
                         torch.zeros_like(head.conv_logits.bias.data))

--- a/tests/test_models/test_seg_heads/test_panoptic_fpn_head.py
+++ b/tests/test_models/test_seg_heads/test_panoptic_fpn_head.py
@@ -14,7 +14,7 @@ class TestPanopticFPNHead(unittest.TestCase):
         head = PanopticFPNHead(
             num_things_classes=2,
             num_stuff_classes=2,
-            in_channels=1,
+            in_channels=32,
             inner_channels=1)
         head.init_weights()
         assert_allclose(head.conv_logits.bias.data,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Fix CI

## Modification

Note: 

The following writing will cause `readthedoc` to fail to build and the code can't use relative paths

`## [MemoryProfilerHook](../../../mmdet/engine/hooks/memory_profiler_hook.py)`

The correct writing is as follows

```shell
## MemoryProfilerHook

[Memory profiler hook](https://github.com/open-mmlab/mmdetection/blob/3.x/mmdet/engine/hooks/memory_profiler_hook.py) 
```

## BC-breaking (Optional)

None

