### PR TITLE
add assert

### DIFF
--- a/mmdet/datasets/transforms/formatting.py
+++ b/mmdet/datasets/transforms/formatting.py
@@ -112,6 +112,7 @@ class PackDetInputs(BaseTransform):
 
         img_meta = {}
         for key in self.meta_keys:
+            assert key in results, f'`{key}` is not found in `results`'
             img_meta[key] = results[key]
 
         data_sample.set_metainfo(img_meta)

--- a/mmdet/datasets/transforms/formatting.py
+++ b/mmdet/datasets/transforms/formatting.py
@@ -112,7 +112,7 @@ class PackDetInputs(BaseTransform):
 
         img_meta = {}
         for key in self.meta_keys:
-            assert key in results, f'`{key}` is not found in `results`'
+            assert key in results, f'`{key}` is not found in `results`, the valid keys are {list(results)}.'
             img_meta[key] = results[key]
 
         data_sample.set_metainfo(img_meta)

--- a/mmdet/datasets/transforms/formatting.py
+++ b/mmdet/datasets/transforms/formatting.py
@@ -112,7 +112,8 @@ class PackDetInputs(BaseTransform):
 
         img_meta = {}
         for key in self.meta_keys:
-            assert key in results, f'`{key}` is not found in `results`, the valid keys are {list(results)}.'
+            assert key in results, f'`{key}` is not found in `results`, ' \
+                f'the valid keys are {list(results)}.'
             img_meta[key] = results[key]
 
         data_sample.set_metainfo(img_meta)


### PR DESCRIPTION
When key is not in `results` may raise an exception.
```python
pipeline = [
    dict(type='LoadImageFromFile', file_client_args=file_client_args),
    dict(type='LoadAnnotations', with_bbox=True),
    dict(
        type='mmdet.PackDetInputs',
        meta_keys=('test'))
]
```
> KeyError: 'test'