### PR TITLE
FIx error when import mmcv

### DIFF
--- a/tools/misc/print_config.py
+++ b/tools/misc/print_config.py
@@ -2,7 +2,7 @@
 import argparse
 import warnings
 
-from mmcv import Config, DictAction
+from mmengine import Config, DictAction
 
 from mmdet.utils import replace_cfg_vals, update_data_root
 


### PR DESCRIPTION
The Config in mmcv is transferred to MMEngine, fix the import.

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When go through the tutorial of MMYOLO to generate complete config file, we found an error caused by MMDetection-3.0 that  caused by MMCV. 

Refer to ISSUE:  https://github.com/open-mmlab/mmyolo/issues/158

## Modification

Modify MMCV -> MMEngine in print_config.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
