### PR TITLE
[Fix] Fix bugs of `empty_instances` when predicting without nms in roi_head.

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/bbox_head.py
@@ -514,7 +514,9 @@ class BBoxHead(BaseModule):
                                    task_type='bbox',
                                    instance_results=[results],
                                    box_type=self.predict_box_type,
-                                   use_box_type=False)[0]
+                                   use_box_type=False,
+                                   num_classes=self.num_classes,
+                                   score_per_cls=rcnn_test_cfg is None)[0]
 
         # some loss (Seesaw loss..) may have custom activation
         if self.custom_cls_channels:

--- a/mmdet/models/roi_heads/cascade_roi_head.py
+++ b/mmdet/models/roi_heads/cascade_roi_head.py
@@ -357,7 +357,12 @@ class CascadeRoIHead(BaseRoIHead):
 
         if rois.shape[0] == 0:
             return empty_instances(
-                batch_img_metas, rois.device, task_type='bbox')
+                batch_img_metas,
+                rois.device,
+                task_type='bbox',
+                box_type=self.bbox_head[-1].predict_box_type,
+                num_classes=self.bbox_head[-1].num_classes,
+                score_per_cls=rcnn_test_cfg is None)
 
         rois, cls_scores, bbox_preds = self._refine_roi(
             x=x,

--- a/mmdet/models/roi_heads/standard_roi_head.py
+++ b/mmdet/models/roi_heads/standard_roi_head.py
@@ -323,7 +323,9 @@ class StandardRoIHead(BaseRoIHead):
                 batch_img_metas,
                 rois.device,
                 task_type='bbox',
-                box_type=self.bbox_head.predict_box_type)
+                box_type=self.bbox_head.predict_box_type,
+                num_classes=self.bbox_head.num_classes,
+                score_per_cls=rcnn_test_cfg is None)
 
         bbox_results = self._bbox_forward(x, rois)
 

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -149,7 +149,8 @@ def empty_instances(batch_img_metas: List[dict],
             Defaults to False.
         num_classes (int): num_classes of bbox_head. Defaults to 80.
         score_per_cls (bool):  Whether to generate class-aware score for
-            the empty instance. Defaults to False.
+            the empty instance. ``score_per_cls`` will be True when the model
+            needs to result the raw results without nms. Defaults to False.
 
     Returns:
         list[:obj:`InstanceData`]: Detection results of each image

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -150,7 +150,7 @@ def empty_instances(batch_img_metas: List[dict],
         num_classes (int): num_classes of bbox_head. Defaults to 80.
         score_per_cls (bool):  Whether to generate classwise score for
             the empty instance. ``score_per_cls`` will be True when the model
-            needs to result the raw results without nms. Defaults to False.
+            needs to produce raw results without nms. Defaults to False.
 
     Returns:
         list[:obj:`InstanceData`]: Detection results of each image

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -147,6 +147,9 @@ def empty_instances(batch_img_metas: List[dict],
         box_type (str or type): The empty box type. Defaults to `hbox`.
         use_box_type (bool): Whether to warp boxes with the box type.
             Defaults to False.
+        num_classes (int): num_classes of bbox_head. Defaults to 80.
+        score_per_cls (bool):  Whether to generate class-aware score for
+            the empty instance. Defaults to False.
 
     Returns:
         list[:obj:`InstanceData`]: Detection results of each image
@@ -171,11 +174,8 @@ def empty_instances(batch_img_metas: List[dict],
             if use_box_type:
                 bboxes = box_type(bboxes, clone=False)
             results.bboxes = bboxes
-            if score_per_cls:
-                results.scores = torch.zeros((0, num_classes + 1),
-                                             device=device)
-            else:
-                results.scores = torch.zeros((0, ), device=device)
+            score_shape = (0, num_classes + 1) if score_per_cls else (0, )
+            results.scores = torch.zeros(score_shape, device=device)
             results.labels = torch.zeros((0, ),
                                          device=device,
                                          dtype=torch.long)

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -127,7 +127,9 @@ def empty_instances(batch_img_metas: List[dict],
                     instance_results: OptInstanceList = None,
                     mask_thr_binary: Union[int, float] = 0,
                     box_type: Union[str, type] = 'hbox',
-                    use_box_type: bool = False) -> List[InstanceData]:
+                    use_box_type: bool = False,
+                    num_classes: int = 80,
+                    score_per_cls: bool = False) -> List[InstanceData]:
     """Handle predicted instances when RoI is empty.
 
     Note: If ``instance_results`` is not None, it will be modified
@@ -169,7 +171,11 @@ def empty_instances(batch_img_metas: List[dict],
             if use_box_type:
                 bboxes = box_type(bboxes, clone=False)
             results.bboxes = bboxes
-            results.scores = torch.zeros((0, ), device=device)
+            if score_per_cls:
+                results.scores = torch.zeros((0, num_classes + 1),
+                                             device=device)
+            else:
+                results.scores = torch.zeros((0, ), device=device)
             results.labels = torch.zeros((0, ),
                                          device=device,
                                          dtype=torch.long)

--- a/mmdet/models/utils/misc.py
+++ b/mmdet/models/utils/misc.py
@@ -148,7 +148,7 @@ def empty_instances(batch_img_metas: List[dict],
         use_box_type (bool): Whether to warp boxes with the box type.
             Defaults to False.
         num_classes (int): num_classes of bbox_head. Defaults to 80.
-        score_per_cls (bool):  Whether to generate class-aware score for
+        score_per_cls (bool):  Whether to generate classwise score for
             the empty instance. ``score_per_cls`` will be True when the model
             needs to result the raw results without nms. Defaults to False.
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When `rcnn_test_cfg is None` the score of a empty instance need to have shape of (0, num_classes + 1). But now, it has shape (0, ). This will cause soft teacher crashes sometimes.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
