### PR TITLE
minor typo

### DIFF
--- a/mmdet/core/bbox/samplers/random_sampler.py
+++ b/mmdet/core/bbox/samplers/random_sampler.py
@@ -12,7 +12,7 @@ class RandomSampler(BaseSampler):
     Args:
         num (int): Number of samples
         pos_fraction (float): Fraction of positive samples
-        neg_pos_up (int, optional): Upper bound number of negative and
+        neg_pos_ub (int, optional): Upper bound number of negative and
             positive samples. Defaults to -1.
         add_gt_as_proposals (bool, optional): Whether to add ground truth
             boxes as proposals. Defaults to True.


### PR DESCRIPTION
neg_pos_up -> neg_pos_ub
minor typo fix

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Debugging today was difficult because searching with ctrl+shift+f was not possible due to a typo.

## Modification

I just changed one letter. neg_pos_up -> neg_pos_ub

I just want to fix this typo, and I was thinking about whether to drop it in an issue or make a pull request and post it here. If you've read this, I'd appreciate it if you could correct the typo. thx !

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.