### PR TITLE
[CI] Fix CI for timm, pycocotools, onnx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,8 @@ jobs:
       - name: Install mmdet dependencies
         run: |
           python -V
+          export CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'`
+          export CXXFLAGS="${CFLAGS}"
           python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch${{matrix.mmcv}}/index.html
           python -m pip install pycocotools
           python -m pip install -r requirements/tests.txt -r requirements/optional.txt
@@ -206,6 +208,8 @@ jobs:
       - name: Install mmdet dependencies
         run: |
           python -V
+          export CFLAGS=`python -c 'import sysconfig;print("-I"+sysconfig.get_paths()["include"])'`
+          export CXXFLAGS="${CFLAGS}"
           python -m pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu102/torch${{matrix.mmcv}}/index.html
           python -m pip install pycocotools
           python -m pip install -r requirements/tests.txt -r requirements/optional.txt

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -2,4 +2,3 @@ cityscapesscripts
 imagecorruptions
 scipy
 sklearn
-timm


### PR DESCRIPTION
## Modification

1. Remove timm from requirements/optional.txt like https://github.com/open-mmlab/mmdetection/pull/8980 because timm v0.6.11 requires torch>=1.7 and breaks CI.
    Another possible way to fix this issue: https://github.com/open-mmlab/mmaction2/pull/1975
2. Fix CI for pycocotools by setting CFLAGS like https://github.com/open-mmlab/mmaction2/pull/1831 and https://github.com/open-mmlab/mmdeploy/pull/945
3. Fix CI for onnx by setting CXXFLAGS

For 2. and 3., a more direct cause of behavioral change in GitHub Actions may be related to https://github.com/actions/setup-python/issues/485 and https://github.com/actions/setup-python/issues/507 .