### PR TITLE
[Fix] Add `ignore_key` in voc dataset to fix error

### DIFF
--- a/configs/_base_/datasets/voc0712.py
+++ b/configs/_base_/datasets/voc0712.py
@@ -38,6 +38,9 @@ train_dataloader = dict(
         times=3,
         dataset=dict(
             type='ConcatDataset',
+            # VOCDataset will add `DATASET_TYPE` in dataset.metainfo,
+            # which will get error if using Concatdataset. Adding
+            # `ignore_keys` can avoid this error.
             ignore_keys=['DATASET_TYPE'],
             datasets=[
                 dict(

--- a/configs/_base_/datasets/voc0712.py
+++ b/configs/_base_/datasets/voc0712.py
@@ -38,7 +38,7 @@ train_dataloader = dict(
         times=3,
         dataset=dict(
             type='ConcatDataset',
-            # VOCDataset will add `DATASET_TYPE` in dataset.metainfo,
+            # VOCDataset will add different `DATASET_TYPE` in dataset.metainfo,
             # which will get error if using ConcatDataset. Adding
             # `ignore_keys` can avoid this error.
             ignore_keys=['DATASET_TYPE'],

--- a/configs/_base_/datasets/voc0712.py
+++ b/configs/_base_/datasets/voc0712.py
@@ -38,6 +38,7 @@ train_dataloader = dict(
         times=3,
         dataset=dict(
             type='ConcatDataset',
+            ignore_keys=['DATASET_TYPE'],
             datasets=[
                 dict(
                     type=dataset_type,

--- a/configs/_base_/datasets/voc0712.py
+++ b/configs/_base_/datasets/voc0712.py
@@ -39,7 +39,7 @@ train_dataloader = dict(
         dataset=dict(
             type='ConcatDataset',
             # VOCDataset will add `DATASET_TYPE` in dataset.metainfo,
-            # which will get error if using Concatdataset. Adding
+            # which will get error if using ConcatDataset. Adding
             # `ignore_keys` can avoid this error.
             ignore_keys=['DATASET_TYPE'],
             datasets=[

--- a/configs/pascal_voc/ssd300_voc0712.py
+++ b/configs/pascal_voc/ssd300_voc0712.py
@@ -50,6 +50,10 @@ train_dataloader = dict(
         # so the actual epoch = 12 * 10 = 120.
         times=10,
         dataset=dict(  # ConcatDataset
+            # VOCDataset will add different `DATASET_TYPE` in dataset.metainfo,
+            # which will get error if using ConcatDataset. Adding
+            # `ignore_keys` can avoid this error.
+            ignore_keys=['DATASET_TYPE'],
             datasets=[
                 dict(
                     type=dataset_type,

--- a/configs/pascal_voc/ssd512_voc0712.py
+++ b/configs/pascal_voc/ssd512_voc0712.py
@@ -58,6 +58,10 @@ train_dataloader = dict(
         # so the actual epoch = 12 * 10 = 120.
         times=10,
         dataset=dict(  # ConcatDataset
+            # VOCDataset will add different `DATASET_TYPE` in dataset.metainfo,
+            # which will get error if using ConcatDataset. Adding
+            # `ignore_keys` can avoid this error.
+            ignore_keys=['DATASET_TYPE'],
             datasets=[
                 dict(
                     type=dataset_type,

--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -9,7 +9,7 @@ mmcv_minimum_version = '2.0.0rc0'
 mmcv_maximum_version = '2.1.0'
 mmcv_version = digit_version(mmcv.__version__)
 
-mmengine_minimum_version = '0.1.0'
+mmengine_minimum_version = '0.3.0'
 mmengine_maximum_version = '1.0.0'
 mmengine_version = digit_version(mmengine.__version__)
 


### PR DESCRIPTION
## Motivation

VOCDataset has `DATASET_TYPE` key in metainfo which is different in VOC2007 and VOC2012. This will get an error when using ConcatDataset. Hence, we add an `ignore_key` in ConcatDataset to fix this error.

## Modification

add an `ignore_key` in ConcatDataset to fix this error.


This PR should be merged after https://github.com/open-mmlab/mmengine/pull/556  has been merged in MMEngine.

Before merging this PR, https://github.com/open-mmlab/mmdetection/pull/8847 can be temporarily fixed VOC ConcatDataset error.

### NOTE
This PR change the minimum version of mmengine to 0.3.0.