### PR TITLE
fix config file error

### DIFF
--- a/configs/_base_/datasets/openimages_detection.py
+++ b/configs/_base_/datasets/openimages_detection.py
@@ -66,8 +66,8 @@ test_dataloader = val_dataloader
 
 val_evaluator = dict(
     type='OpenImagesMetric',
-    iou_thr=0.5,
-    ioa_thr=0.5,
+    iou_thrs=0.5,
+    ioa_thrs=0.5,
     use_group_of=True,
     get_supercategory=True)
 test_evaluator = val_evaluator


### PR DESCRIPTION
we found an error in openimages config file: parameters "iou_thr" and "ioa_thr" in `OpenImagesMetric`  should actually be ""iou_thrs" and "ioa_thrs" according to it's defination.  
![image](https://user-images.githubusercontent.com/34300920/196335500-d92410ba-1997-490d-b441-ed4095c03454.png)
