### PR TITLE
add eiou impl

### DIFF
--- a/mmdet/models/losses/__init__.py
+++ b/mmdet/models/losses/__init__.py
@@ -9,8 +9,8 @@ from .focal_loss import FocalLoss, sigmoid_focal_loss
 from .gaussian_focal_loss import GaussianFocalLoss
 from .gfocal_loss import DistributionFocalLoss, QualityFocalLoss
 from .ghm_loss import GHMC, GHMR
-from .iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss, GIoULoss, IoULoss,
-                       bounded_iou_loss, iou_loss)
+from .iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss, EIoULoss, GIoULoss,
+                       IoULoss, bounded_iou_loss, iou_loss)
 from .kd_loss import KnowledgeDistillationKLDivLoss
 from .mse_loss import MSELoss, mse_loss
 from .pisa_loss import carl_loss, isr_p
@@ -24,9 +24,10 @@ __all__ = [
     'mask_cross_entropy', 'CrossEntropyLoss', 'sigmoid_focal_loss',
     'FocalLoss', 'smooth_l1_loss', 'SmoothL1Loss', 'balanced_l1_loss',
     'BalancedL1Loss', 'mse_loss', 'MSELoss', 'iou_loss', 'bounded_iou_loss',
-    'IoULoss', 'BoundedIoULoss', 'GIoULoss', 'DIoULoss', 'CIoULoss', 'GHMC',
-    'GHMR', 'reduce_loss', 'weight_reduce_loss', 'weighted_loss', 'L1Loss',
-    'l1_loss', 'isr_p', 'carl_loss', 'AssociativeEmbeddingLoss',
-    'GaussianFocalLoss', 'QualityFocalLoss', 'DistributionFocalLoss',
-    'VarifocalLoss', 'KnowledgeDistillationKLDivLoss', 'SeesawLoss', 'DiceLoss'
+    'IoULoss', 'BoundedIoULoss', 'GIoULoss', 'DIoULoss', 'CIoULoss',
+    'EIoULoss', 'GHMC', 'GHMR', 'reduce_loss', 'weight_reduce_loss',
+    'weighted_loss', 'L1Loss', 'l1_loss', 'isr_p', 'carl_loss',
+    'AssociativeEmbeddingLoss', 'GaussianFocalLoss', 'QualityFocalLoss',
+    'DistributionFocalLoss', 'VarifocalLoss', 'KnowledgeDistillationKLDivLoss',
+    'SeesawLoss', 'DiceLoss'
 ]

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -233,10 +233,9 @@ def ciou_loss(pred, target, eps=1e-7):
 
 @weighted_loss
 def eiou_loss(pred, target, smooth_point=0.1, eps=1e-7):
-    r"""Implementation of paper 'Extended-IoU Loss: A Systematic IoU-Related
-     Method: Beyond Simplified Regression for Better Localization,
-
-     <https://ieeexplore.ieee.org/abstract/document/9429909> '.
+    r"""Implementation of paper `Extended-IoU Loss: A Systematic
+    IoU-Related Method: Beyond Simplified Regression for Better
+    Localization <https://ieeexplore.ieee.org/abstract/document/9429909>`_
 
     Code is modified from https://github.com//ShiqiYu/libfacedetection.train.
 
@@ -244,7 +243,7 @@ def eiou_loss(pred, target, smooth_point=0.1, eps=1e-7):
         pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
             shape (n, 4).
         target (Tensor): Corresponding gt bboxes, shape (n, 4).
-        smooth_point (float): hyperparameter, default is 0.1
+        smooth_point (float): hyperparameter, default is 0.1.
         eps (float): Eps to avoid log(0).
     Return:
         Tensor: Loss tensor.
@@ -524,6 +523,21 @@ class CIoULoss(nn.Module):
 
 @MODELS.register_module()
 class EIoULoss(nn.Module):
+    r"""Implementation of paper `Extended-IoU Loss: A Systematic
+    IoU-Related Method: Beyond Simplified Regression for Better
+    Localization <https://ieeexplore.ieee.org/abstract/document/9429909>`_
+
+    Code is modified from https://github.com//ShiqiYu/libfacedetection.train.
+
+    Args:
+        pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
+            shape (n, 4).
+        target (Tensor): Corresponding gt bboxes, shape (n, 4).
+        smooth_point (float): hyperparameter, default is 0.1.
+        eps (float): Eps to avoid log(0).
+    Return:
+        Tensor: Loss tensor.
+    """
 
     def __init__(self,
                  eps=1e-6,

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -231,6 +231,60 @@ def ciou_loss(pred, target, eps=1e-7):
     return loss
 
 
+@weighted_loss
+def eiou_loss(pred, target, smooth_point=0.1, eps=1e-7):
+    r"""Implementation of paper 'Extended-IoU Loss: A Systematic IoU-Related
+     Method: Beyond Simplified Regression for Better Localization,
+
+     <https://ieeexplore.ieee.org/abstract/document/9429909> '.
+
+    Code is modified from https://github.com//ShiqiYu/libfacedetection.train.
+
+    Args:
+        pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
+            shape (n, 4).
+        target (Tensor): Corresponding gt bboxes, shape (n, 4).
+        smooth_point (float): hyperparameter, default is 0.1
+        eps (float): Eps to avoid log(0).
+    Return:
+        Tensor: Loss tensor.
+    """
+    px1, py1, px2, py2 = pred[:, 0], pred[:, 1], pred[:, 2], pred[:, 3]
+    tx1, ty1, tx2, ty2 = target[:, 0], target[:, 1], target[:, 2], target[:, 3]
+
+    # extent top left
+    ex1 = torch.min(px1, tx1)
+    ey1 = torch.min(py1, ty1)
+
+    # intersection coordinates
+    ix1 = torch.max(px1, tx1)
+    iy1 = torch.max(py1, ty1)
+    ix2 = torch.min(px2, tx2)
+    iy2 = torch.min(py2, ty2)
+
+    # extra
+    xmin = torch.min(ix1, ix2)
+    ymin = torch.min(iy1, iy2)
+    xmax = torch.max(ix1, ix2)
+    ymax = torch.max(iy1, iy2)
+
+    # Intersection
+    intersection = (ix2 - ex1) * (iy2 - ey1) + (xmin - ex1) * (ymin - ey1) - (
+        ix1 - ex1) * (ymax - ey1) - (xmax - ex1) * (
+            iy1 - ey1)
+    # Union
+    union = (px2 - px1) * (py2 - py1) + (tx2 - tx1) * (
+        ty2 - ty1) - intersection + eps
+    # IoU
+    ious = 1 - (intersection / union)
+
+    # Smooth-EIoU
+    smooth_sign = (ious < smooth_point).detach().float()
+    loss = 0.5 * smooth_sign * (ious**2) / smooth_point + (1 - smooth_sign) * (
+        ious - 0.5 * smooth_point)
+    return loss
+
+
 @MODELS.register_module()
 class IoULoss(nn.Module):
     """IoULoss.
@@ -461,6 +515,49 @@ class CIoULoss(nn.Module):
             pred,
             target,
             weight,
+            eps=self.eps,
+            reduction=reduction,
+            avg_factor=avg_factor,
+            **kwargs)
+        return loss
+
+
+@MODELS.register_module()
+class EIoULoss(nn.Module):
+
+    def __init__(self,
+                 eps=1e-6,
+                 reduction='mean',
+                 loss_weight=1.0,
+                 smooth_point=0.1):
+        super(EIoULoss, self).__init__()
+        self.eps = eps
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.smooth_point = smooth_point
+
+    def forward(self,
+                pred,
+                target,
+                weight=None,
+                avg_factor=None,
+                reduction_override=None,
+                **kwargs):
+        if weight is not None and not torch.any(weight > 0):
+            if pred.dim() == weight.dim() + 1:
+                weight = weight.unsqueeze(1)
+            return (pred * weight).sum()  # 0
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+        if weight is not None and weight.dim() > 1:
+            assert weight.shape == pred.shape
+            weight = weight.mean(-1)
+        loss = self.loss_weight * eiou_loss(
+            pred,
+            target,
+            weight,
+            smooth_point=self.smooth_point,
             eps=self.eps,
             reduction=reduction,
             avg_factor=avg_factor,

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -530,13 +530,10 @@ class EIoULoss(nn.Module):
     Code is modified from https://github.com//ShiqiYu/libfacedetection.train.
 
     Args:
-        pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
-            shape (n, 4).
-        target (Tensor): Corresponding gt bboxes, shape (n, 4).
-        smooth_point (float): hyperparameter, default is 0.1.
         eps (float): Eps to avoid log(0).
-    Return:
-        Tensor: Loss tensor.
+        reduction (str): Options are "none", "mean" and "sum".
+        loss_weight (float): Weight of loss.
+        smooth_point (float): hyperparameter, default is 0.1.
     """
 
     def __init__(self,

--- a/tests/test_models/test_losses/test_loss.py
+++ b/tests/test_models/test_losses/test_loss.py
@@ -11,11 +11,12 @@ from mmdet.models.losses import (BalancedL1Loss, CrossEntropyLoss, DiceLoss,
                                  SmoothL1Loss, VarifocalLoss)
 from mmdet.models.losses.ghm_loss import GHMC, GHMR
 from mmdet.models.losses.iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss,
-                                          GIoULoss, IoULoss)
+                                          EIoULoss, GIoULoss, IoULoss)
 
 
 @pytest.mark.parametrize(
-    'loss_class', [IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss])
+    'loss_class',
+    [IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss])
 def test_iou_type_loss_zeros_weight(loss_class):
     pred = torch.rand((10, 4))
     target = torch.rand((10, 4))
@@ -27,9 +28,10 @@ def test_iou_type_loss_zeros_weight(loss_class):
 
 @pytest.mark.parametrize('loss_class', [
     BalancedL1Loss, BoundedIoULoss, CIoULoss, CrossEntropyLoss, DIoULoss,
-    FocalLoss, DistributionFocalLoss, MSELoss, SeesawLoss, GaussianFocalLoss,
-    GIoULoss, IoULoss, L1Loss, QualityFocalLoss, VarifocalLoss, GHMR, GHMC,
-    SmoothL1Loss, KnowledgeDistillationKLDivLoss, DiceLoss
+    EIoULoss, FocalLoss, DistributionFocalLoss, MSELoss, SeesawLoss,
+    GaussianFocalLoss, GIoULoss, IoULoss, L1Loss, QualityFocalLoss,
+    VarifocalLoss, GHMR, GHMC, SmoothL1Loss, KnowledgeDistillationKLDivLoss,
+    DiceLoss
 ])
 def test_loss_with_reduction_override(loss_class):
     pred = torch.rand((10, 4))
@@ -45,8 +47,8 @@ def test_loss_with_reduction_override(loss_class):
 
 
 @pytest.mark.parametrize('loss_class', [
-    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, MSELoss, L1Loss,
-    SmoothL1Loss, BalancedL1Loss
+    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss, MSELoss,
+    L1Loss, SmoothL1Loss, BalancedL1Loss
 ])
 @pytest.mark.parametrize('input_shape', [(10, 4), (0, 4)])
 def test_regression_losses(loss_class, input_shape):


### PR DESCRIPTION
## Motivation
In paper: [A Systematic IoU-Related Method: Beyond Simplified Regression for Better Localization](https://ieeexplore.ieee.org/document/9429909) of TIP2021, we propose a new Extended-IOU loss, which outperforms the commonly used GIOU and DIOU in object detection.

## Modification
add implementation of the proposed Extended-IOU Loss (EIOU).

## Use cases (Optional)
In config:
`loss_bbox=dict(type='EIoULoss',  loss_weight=1.0, smooth_point=0.1)`
