### PR TITLE
[Fix] Fix `pixel_decoder_type` discrimination in MaskFormer Head.

### DIFF
--- a/mmdet/models/dense_heads/maskformer_head.py
+++ b/mmdet/models/dense_heads/maskformer_head.py
@@ -103,7 +103,7 @@ class MaskFormerHead(AnchorFreeHead):
         self.transformer_decoder = MODELS.build(transformer_decoder)
         self.decoder_embed_dims = self.transformer_decoder.embed_dims
         pixel_decoder_type = pixel_decoder.get('type')
-        if pixel_decoder_type == 'PixelDecoder' and (
+        if pixel_decoder_type.endswith('PixelDecoder') and (
                 self.decoder_embed_dims != in_channels[-1]
                 or enforce_decoder_input_project):
             self.decoder_input_proj = Conv2d(


### PR DESCRIPTION
## Motivation

Currently, MMDetection does not treat inter-codebases using modules very well. For example, in upstream codebase which `pip install mmdet` and uses type `mmdet.PixelDecoder`, the error would happen in this line because this `if else` would discriminate `mmdet.PixelDecoder` and `PixelDecoder` although they are the same.

![image](https://user-images.githubusercontent.com/24582831/198564261-9c62b315-d4da-4297-a029-c9d58e4413d4.png)
