### PR TITLE
[Enhance] Add box_type support for `DynamicSoftLabelAssigner`

### DIFF
--- a/tests/test_models/test_task_modules/test_assigners/test_dynamic_soft_label_assigner.py
+++ b/tests/test_models/test_task_modules/test_assigners/test_dynamic_soft_label_assigner.py
@@ -1,0 +1,74 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+import torch
+from mmengine.structures import InstanceData
+from mmengine.testing import assert_allclose
+
+from mmdet.models.task_modules.assigners import DynamicSoftLabelAssigner
+from mmdet.structures.bbox import HorizontalBoxes
+
+
+class TestDynamicSoftLabelAssigner(TestCase):
+
+    def test_assign(self):
+        assigner = DynamicSoftLabelAssigner(
+            soft_center_radius=3.0, topk=1, iou_weight=3.0)
+        pred_instances = InstanceData(
+            bboxes=torch.Tensor([[23, 23, 43, 43], [4, 5, 6, 7]]),
+            scores=torch.FloatTensor([[0.2], [0.8]]),
+            priors=torch.Tensor([[30, 30, 8, 8], [4, 5, 6, 7]]))
+        gt_instances = InstanceData(
+            bboxes=torch.Tensor([[23, 23, 43, 43]]),
+            labels=torch.LongTensor([0]))
+        assign_result = assigner.assign(
+            pred_instances=pred_instances, gt_instances=gt_instances)
+
+        expected_gt_inds = torch.LongTensor([1, 0])
+        assert_allclose(assign_result.gt_inds, expected_gt_inds)
+
+    def test_assign_with_no_valid_bboxes(self):
+        assigner = DynamicSoftLabelAssigner(
+            soft_center_radius=3.0, topk=1, iou_weight=3.0)
+        pred_instances = InstanceData(
+            bboxes=torch.Tensor([[123, 123, 143, 143], [114, 151, 161, 171]]),
+            scores=torch.FloatTensor([[0.2], [0.8]]),
+            priors=torch.Tensor([[30, 30, 8, 8], [55, 55, 8, 8]]))
+        gt_instances = InstanceData(
+            bboxes=torch.Tensor([[0, 0, 1, 1]]), labels=torch.LongTensor([0]))
+        assign_result = assigner.assign(
+            pred_instances=pred_instances, gt_instances=gt_instances)
+
+        expected_gt_inds = torch.LongTensor([0, 0])
+        assert_allclose(assign_result.gt_inds, expected_gt_inds)
+
+    def test_assign_with_empty_gt(self):
+        assigner = DynamicSoftLabelAssigner(
+            soft_center_radius=3.0, topk=1, iou_weight=3.0)
+        pred_instances = InstanceData(
+            bboxes=torch.Tensor([[[30, 40, 50, 60]], [[4, 5, 6, 7]]]),
+            scores=torch.FloatTensor([[0.2], [0.8]]),
+            priors=torch.Tensor([[0, 12, 23, 34], [4, 5, 6, 7]]))
+        gt_instances = InstanceData(
+            bboxes=torch.empty(0, 4), labels=torch.empty(0))
+
+        assign_result = assigner.assign(
+            pred_instances=pred_instances, gt_instances=gt_instances)
+        expected_gt_inds = torch.LongTensor([0, 0])
+        assert_allclose(assign_result.gt_inds, expected_gt_inds)
+
+    def test_box_type_input(self):
+        assigner = DynamicSoftLabelAssigner(
+            soft_center_radius=3.0, topk=1, iou_weight=3.0)
+        pred_instances = InstanceData(
+            bboxes=torch.Tensor([[23, 23, 43, 43], [4, 5, 6, 7]]),
+            scores=torch.FloatTensor([[0.2], [0.8]]),
+            priors=torch.Tensor([[30, 30, 8, 8], [4, 5, 6, 7]]))
+        gt_instances = InstanceData(
+            bboxes=HorizontalBoxes(torch.Tensor([[23, 23, 43, 43]])),
+            labels=torch.LongTensor([0]))
+        assign_result = assigner.assign(
+            pred_instances=pred_instances, gt_instances=gt_instances)
+
+        expected_gt_inds = torch.LongTensor([1, 0])
+        assert_allclose(assign_result.gt_inds, expected_gt_inds)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add box_type support for Dynamic Soft Label Assigner.

Allow mmrotate to use `DynamicSoftLabelAssigner` directly with out any modify.

Also i found that the `find_inside_points` method results are slightly different than the original version, `find_inside_points` allow the points on the edge.
https://github.com/open-mmlab/mmdetection/blob/816637e1677146d790b4b4a1fc05c400d9260dfb/mmdet/structures/bbox/horizontal_boxes.py#L333-L334

I think we could add a `keep_edge` or `eps` arg in `find_inside_points` to control that behavior, also looking forward to your suggestions.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
