### PR TITLE
[Enhance] Make scipy as a default dependency in runtime

### DIFF
--- a/mmdet/core/bbox/assigners/hungarian_assigner.py
+++ b/mmdet/core/bbox/assigners/hungarian_assigner.py
@@ -1,16 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from scipy.optimize import linear_sum_assignment
 
 from ..builder import BBOX_ASSIGNERS
 from ..match_costs import build_match_cost
 from ..transforms import bbox_cxcywh_to_xyxy
 from .assign_result import AssignResult
 from .base_assigner import BaseAssigner
-
-try:
-    from scipy.optimize import linear_sum_assignment
-except ImportError:
-    linear_sum_assignment = None
 
 
 @BBOX_ASSIGNERS.register_module()
@@ -127,9 +123,6 @@ class HungarianAssigner(BaseAssigner):
 
         # 3. do Hungarian matching on CPU using linear_sum_assignment
         cost = cost.detach().cpu()
-        if linear_sum_assignment is None:
-            raise ImportError('Please run "pip install scipy" '
-                              'to install scipy first.')
         matched_row_inds, matched_col_inds = linear_sum_assignment(cost)
         matched_row_inds = torch.from_numpy(matched_row_inds).to(
             bbox_pred.device)

--- a/mmdet/core/bbox/assigners/mask_hungarian_assigner.py
+++ b/mmdet/core/bbox/assigners/mask_hungarian_assigner.py
@@ -1,15 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
+from scipy.optimize import linear_sum_assignment
 
 from mmdet.core.bbox.builder import BBOX_ASSIGNERS
 from mmdet.core.bbox.match_costs.builder import build_match_cost
 from .assign_result import AssignResult
 from .base_assigner import BaseAssigner
-
-try:
-    from scipy.optimize import linear_sum_assignment
-except ImportError:
-    linear_sum_assignment = None
 
 
 @BBOX_ASSIGNERS.register_module()
@@ -112,9 +108,6 @@ class MaskHungarianAssigner(BaseAssigner):
 
         # 3. do Hungarian matching on CPU using linear_sum_assignment
         cost = cost.detach().cpu()
-        if linear_sum_assignment is None:
-            raise ImportError('Please run "pip install scipy" '
-                              'to install scipy first.')
 
         matched_row_inds, matched_col_inds = linear_sum_assignment(cost)
         matched_row_inds = torch.from_numpy(matched_row_inds).to(

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,3 @@
 cityscapesscripts
 imagecorruptions
-scipy
 sklearn

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 matplotlib
 numpy
 pycocotools
+scipy
 six
 terminaltables


### PR DESCRIPTION
Since DETR series become very popular, bipart matching becomes a default.
Therefore, it would be better to make scipy a default runtime dependency rather than optional

Resolve PR: https://github.com/open-mmlab/mmdetection/issues/8962