### PR TITLE
[Enhance] Make scipy as a default dependency in runtime

### DIFF
--- a/mmdet/evaluation/metrics/crowdhuman_metric.py
+++ b/mmdet/evaluation/metrics/crowdhuman_metric.py
@@ -8,16 +8,11 @@ from multiprocessing import Process, Queue
 from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
-
-try:
-    from scipy.sparse import csr_matrix
-    from scipy.sparse.csgraph import maximum_bipartite_matching
-except ImportError:
-    csr_matrix, maximum_bipartite_matching = None, None
-
 from mmengine.evaluator import BaseMetric
 from mmengine.fileio import FileClient, dump, load
 from mmengine.logging import MMLogger
+from scipy.sparse import csr_matrix
+from scipy.sparse.csgraph import maximum_bipartite_matching
 
 from mmdet.evaluation.functional.bbox_overlaps import bbox_overlaps
 from mmdet.registry import METRICS
@@ -82,10 +77,6 @@ class CrowdHumanMetric(BaseMetric):
                  mr_ref: str = 'CALTECH_-2',
                  num_ji_process: int = 10) -> None:
         super().__init__(collect_device=collect_device, prefix=prefix)
-
-        if csr_matrix is None or maximum_bipartite_matching is None:
-            raise ImportError(
-                'Please run "pip install scipy" to install scipy first.')
 
         self.ann_file = ann_file
         # crowdhuman evaluation metrics

--- a/mmdet/models/task_modules/assigners/hungarian_assigner.py
+++ b/mmdet/models/task_modules/assigners/hungarian_assigner.py
@@ -1,19 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Optional, Union
+
 import torch
+from mmengine import ConfigDict
+from mmengine.structures import InstanceData
+from scipy.optimize import linear_sum_assignment
+from torch import Tensor
 
 from mmdet.registry import TASK_UTILS
 from .assign_result import AssignResult
 from .base_assigner import BaseAssigner
-
-try:
-    from scipy.optimize import linear_sum_assignment
-except ImportError:
-    linear_sum_assignment = None
-from typing import List, Optional, Union
-
-from mmengine import ConfigDict
-from mmengine.structures import InstanceData
-from torch import Tensor
 
 
 @TASK_UTILS.register_module()

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,3 @@
 cityscapesscripts
 imagecorruptions
-scipy
 sklearn

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 matplotlib
 numpy
 pycocotools
+scipy
 six
 terminaltables


### PR DESCRIPTION
Since DETR series become very popular, bipart matching becomes a default.
Therefore, it would be better to make scipy a default runtime dependency rather than optional

Resolve PR: https://github.com/open-mmlab/mmdetection/issues/8962