### PR TITLE
[Fix] Fix solov2 cannot dealing with empty gt image

### DIFF
--- a/mmdet/models/dense_heads/solov2_head.py
+++ b/mmdet/models/dense_heads/solov2_head.py
@@ -586,7 +586,7 @@ class SOLOV2Head(SOLOHead):
         if num_pos > 0:
             loss_mask = torch.cat(loss_mask).sum() / num_pos
         else:
-            loss_mask = mask_feats.new_zeros(1).mean()
+            loss_mask = mask_feats.sum() * 0
 
         # cate
         flatten_labels = [


### PR DESCRIPTION
Solve PR: https://github.com/open-mmlab/mmdetection/issues/9159

loss_mask may empty when num_pos = 0. Hence, fix the num_pos=0 case to support dealing with empty gt image