### PR TITLE
[Fix]: fix handle coco subsets on MMDet 3.x

### DIFF
--- a/configs/faster_rcnn/faster-rcnn_r50-caffe_fpn_ms-1x_coco-person-bicycle-car.py
+++ b/configs/faster_rcnn/faster-rcnn_r50-caffe_fpn_ms-1x_coco-person-bicycle-car.py
@@ -1,9 +1,16 @@
 _base_ = './faster-rcnn_r50-caffe_fpn_ms-1x_coco.py'
 model = dict(roi_head=dict(bbox_head=dict(num_classes=3)))
-classes = ('person', 'bicycle', 'car')
-data = dict(
-    train=dict(classes=classes),
-    val=dict(classes=classes),
-    test=dict(classes=classes))
+metainfo = {
+    'CLASSES': ('person', 'bicycle', 'car'),
+    'PALETTE': [
+        (220, 20, 60),
+        (119, 11, 32),
+        (0, 0, 142),
+    ]
+}
+
+train_dataloader = dict(dataset=dict(metainfo=metainfo))
+val_dataloader = dict(dataset=dict(metainfo=metainfo))
+test_dataloader = dict(dataset=dict(metainfo=metainfo))
 
 load_from = 'https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_caffe_fpn_mstrain_3x_coco/faster_rcnn_r50_caffe_fpn_mstrain_3x_coco_bbox_mAP-0.398_20200504_163323-30042637.pth'  # noqa

--- a/configs/faster_rcnn/faster-rcnn_r50-caffe_fpn_ms-1x_coco-person.py
+++ b/configs/faster_rcnn/faster-rcnn_r50-caffe_fpn_ms-1x_coco-person.py
@@ -1,9 +1,14 @@
 _base_ = './faster-rcnn_r50-caffe_fpn_ms-1x_coco.py'
 model = dict(roi_head=dict(bbox_head=dict(num_classes=1)))
-classes = ('person', )
-data = dict(
-    train=dict(classes=classes),
-    val=dict(classes=classes),
-    test=dict(classes=classes))
+metainfo = {
+    'CLASSES': ('person', ),
+    'PALETTE': [
+        (220, 20, 60),
+    ]
+}
+
+train_dataloader = dict(dataset=dict(metainfo=metainfo))
+val_dataloader = dict(dataset=dict(metainfo=metainfo))
+test_dataloader = dict(dataset=dict(metainfo=metainfo))
 
 load_from = 'https://download.openmmlab.com/mmdetection/v2.0/faster_rcnn/faster_rcnn_r50_caffe_fpn_mstrain_3x_coco/faster_rcnn_r50_caffe_fpn_mstrain_3x_coco_bbox_mAP-0.398_20200504_163323-30042637.pth'  # noqa


### PR DESCRIPTION
When handling the coco subset on MMDet 3.x, should change the dataset configs in faster-rcnn

