### PR TITLE
[Feature] Support mmdet with NPU backend

### DIFF
--- a/configs/fcos/fcos_r50_caffe_fpn_gn-head_fp16_1x_bs8x8_coco.py
+++ b/configs/fcos/fcos_r50_caffe_fpn_gn-head_fp16_1x_bs8x8_coco.py
@@ -1,0 +1,13 @@
+_base_ = ['./fcos_r50_caffe_fpn_gn-head_1x_coco.py']
+
+data = dict(samples_per_gpu=8, workers_per_gpu=8)
+
+# optimizer
+optimizer = dict(lr=0.04)
+fp16 = dict(loss_scale='dynamic')
+
+# learning policy
+# In order to avoid non-convergence in the early stage of
+# mixed-precision training, the warmup in the lr_config is set to linear,
+# warmup_iters increases and warmup_ratio decreases.
+lr_config = dict(warmup='linear', warmup_iters=1000, warmup_ratio=1.0 / 10)

--- a/configs/ssd/ssd300_fp16_coco.py
+++ b/configs/ssd/ssd300_fp16_coco.py
@@ -1,0 +1,9 @@
+_base_ = ['./ssd300_coco.py']
+
+fp16 = dict(loss_scale='dynamic')
+
+# learning policy
+# In order to avoid non-convergence in the early stage of
+# mixed-precision training, the warmup in the lr_config is set to linear,
+# warmup_iters increases and warmup_ratio decreases.
+lr_config = dict(warmup='linear', warmup_iters=1000, warmup_ratio=1.0 / 10)

--- a/mmdet/apis/inference.py
+++ b/mmdet/apis/inference.py
@@ -54,6 +54,12 @@ def init_detector(config, checkpoint=None, device='cuda:0', cfg_options=None):
     model.cfg = config  # save the config in the model for convenience
     model.to(device)
     model.eval()
+
+    if device == 'npu':
+        from mmcv.device.npu import NPUDataParallel
+        model = NPUDataParallel(model)
+        model.cfg = config
+
     return model
 
 

--- a/mmdet/apis/train.py
+++ b/mmdet/apis/train.py
@@ -180,6 +180,8 @@ def train_detector(model,
 
     # fp16 setting
     fp16_cfg = cfg.get('fp16', None)
+    if fp16_cfg is None and cfg.get('device', None) == 'npu':
+        fp16_cfg = dict(loss_scale='dynamic')
     if fp16_cfg is not None:
         optimizer_config = Fp16OptimizerHook(
             **cfg.optimizer_config, **fp16_cfg, distributed=distributed)

--- a/mmdet/core/data_structures/general_data.py
+++ b/mmdet/core/data_structures/general_data.py
@@ -274,6 +274,16 @@ class GeneralData(NiceRepr):
         return new_data
 
     # Tensor-like methods
+    def npu(self):
+        """Apply same name function to all tensors in data_fields."""
+        new_data = self.new()
+        for k, v in self.items():
+            if isinstance(v, torch.Tensor):
+                v = v.npu()
+            new_data[k] = v
+        return new_data
+
+    # Tensor-like methods
     def mlu(self):
         """Apply same name function to all tensors in data_fields."""
         new_data = self.new()


### PR DESCRIPTION
## Motivation

Added NPU(ascending device) support in mmdet

## Modification

The main modification points are:
1. add NPUDataParallel、NPUDistributedDataParallel

## BC-breaking (Optional)

None

## Use cases (Optional)

Provides configuration information that can be worked on the NPU

| config |  map | map_gpu |
| ----------- | ----------- | ----------- |
| configs/fcos/fcos_r50_caffe_fpn_gn-head_1x_bs8x8_coco.py | 36.2 | 36.1 |
| configs/ssd/ssd300_coco_fp16.py | 25.6 | 25.5 |




## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
5. The documentation has been modified accordingly, like docstring or example tutorials.
