### PR TITLE
[Fix] type of "counts" in COCO’s compressed RLE

### DIFF
--- a/mmdet/datasets/transforms/loading.py
+++ b/mmdet/datasets/transforms/loading.py
@@ -348,7 +348,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
             elif isinstance(gt_mask, dict) and \
                     not (gt_mask.get('counts') is not None and
                          gt_mask.get('size') is not None and
-                         isinstance(gt_mask['counts'], list)):
+                         isinstance(gt_mask['counts'], (list, str))):
                 # if gt_mask is a dict, it should include `counts` and `size`,
                 # so that `BitmapMasks` can uncompressed RLE
                 instance['ignore_flag'] = 1

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -2464,9 +2464,9 @@ class MixUp(BaseTransform):
         ori_img = results['img']
         origin_h, origin_w = out_img.shape[:2]
         target_h, target_w = ori_img.shape[:2]
-        padded_img = np.zeros(
-            (max(origin_h, target_h), max(origin_w,
-                                          target_w), 3)).astype(np.uint8)
+        padded_img = np.ones((max(origin_h, target_h), max(
+            origin_w, target_w), 3)) * self.pad_val
+        padded_img = padded_img.astype(np.uint8)
         padded_img[:origin_h, :origin_w] = out_img
 
         x_offset, y_offset = 0, 0
@@ -3512,9 +3512,9 @@ class CachedMixUp(BaseTransform):
         ori_img = results['img']
         origin_h, origin_w = out_img.shape[:2]
         target_h, target_w = ori_img.shape[:2]
-        padded_img = np.zeros(
-            (max(origin_h, target_h), max(origin_w,
-                                          target_w), 3)).astype(np.uint8)
+        padded_img = np.ones((max(origin_h, target_h), max(
+            origin_w, target_w), 3)) * self.pad_val
+        padded_img = padded_img.astype(np.uint8)
         padded_img[:origin_h, :origin_w] = out_img
 
         x_offset, y_offset = 0, 0


### PR DESCRIPTION
## Motivation

"counts" in COCO’s compressed RLE format has type of 'str' or 'list'.
![ea6e2d0d707f54058f5ecc31b0b2385](https://user-images.githubusercontent.com/45008718/200510901-756dda61-b066-4c0e-bae9-464b38087254.png)

## Modification
