### PR TITLE
[Fix] Fix resume arg conflict.

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -100,8 +100,8 @@ def main():
                                '"auto_scale_lr.enable" or '
                                '"auto_scale_lr.base_batch_size" in your'
                                ' configuration file.')
-
-    cfg.resume = args.resume
+    if args.resume:
+        cfg.resume = args.resume
 
     # build the runner from config
     if 'runner_type' not in cfg:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

If `args.resume` is None, `cfg.resume = args.resume` will always set `resume` to `None` even if you set `resume=True` in config or through `--cfg-options`.

## Modification

Only overwrite the cfg.resume when args.resume is not None.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
