### PR TITLE
[datasets] cityscapes.py: complement necessary arg seg_suffix

### DIFF
--- a/mmdet/datasets/cityscapes.py
+++ b/mmdet/datasets/cityscapes.py
@@ -263,8 +263,9 @@ class CityscapesDataset(CocoDataset):
             # create CocoDataset with CityscapesDataset annotation
             self_coco = CocoDataset(self.ann_file, self.pipeline.transforms,
                                     None, self.data_root, self.img_prefix,
-                                    self.seg_prefix, self.proposal_file,
-                                    self.test_mode, self.filter_empty_gt)
+                                    self.seg_prefix, self.seg_suffix,
+                                    self.proposal_file, self.test_mode,
+                                    self.filter_empty_gt)
             # TODO: remove this in the future
             # reload annotations of correct class
             self_coco.CLASSES = self.CLASSES


### PR DESCRIPTION
Issue: #9329
A new entry `seg_suffix` is added for CustomDataset.__init__() but missing in `self_coco = CocoDataset` in function `evaluate()`, `mmdet/datasets/cityscapes.py`.

Signed-off-by: Shengjiang QUAN <qsj287068067@126.com>

## Motivation

Issue: #9329
A new entry `seg_suffix` is added for CustomDataset.__init__() but missing in `self_coco = CocoDataset` in function `evaluate()`, `mmdet/datasets/cityscapes.py`.
There is an arguments mismatch between the arguments of `self_coco = CocoDataset` in `mmdet/datasets/cityscapes.py` with the new `__init__` in `mmdet/datasets/custom.py`. `self.proposal_file` in `CocoDataset` class in `mmdet/datasets/cityscapes.py` is assigned to `seg_suffix` in `CustomDataset.__init__()` in `mmdet/datasets/custom.py`.

## Modification

Complement the missing argument `seg_suffix: str = '.png'` in `self_coco = CocoDataset()`.

## BC-breaking (Optional)

Not applicable

## Use cases (Optional)

Not applicable

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
