### PR TITLE
fix a bug of random flip in MixUp

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -2366,7 +2366,7 @@ class MixUp:
         retrieve_img = retrieve_results['img']
 
         jit_factor = random.uniform(*self.ratio_range)
-        is_filp = random.uniform(0, 1) > self.flip_ratio
+        is_filp = random.uniform(0, 1) < self.flip_ratio
 
         if len(retrieve_img.shape) == 3:
             out_img = np.ones(


### PR DESCRIPTION
> Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

> Please describe the motivation of this PR and the goal you want to achieve through this PR.

Random flip in MixUp augmentation seems to have a bug.

In current implementation, when `flip_ratio` is set to 0, mixup image is always flipped.

## Modification

> Please briefly describe what modification is made in this PR.

Fixed the above behavior.

## BC-breaking (Optional)

> Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

> If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

> 1. Pre-commit or other linting tools are used to fix the potential lint issues.
> 2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
> 3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
> 4. The documentation has been modified accordingly, like docstring or example tutorials.
