### PR TITLE
Only keep meta and state_dict when publish model.

### DIFF
--- a/tools/model_converters/publish_model.py
+++ b/tools/model_converters/publish_model.py
@@ -16,9 +16,13 @@ def parse_args():
 
 def process_checkpoint(in_file, out_file):
     checkpoint = torch.load(in_file, map_location='cpu')
-    # remove optimizer for smaller file size
-    if 'optimizer' in checkpoint:
-        del checkpoint['optimizer']
+
+    # only keep `meta` and `state_dict` for smaller file size
+    ckpt_keys = list(checkpoint.keys())
+    for k in ckpt_keys:
+        if k not in ['meta', 'state_dict']:
+            checkpoint.pop(k, None)
+
     # if it is necessary to remove some sensitive data in checkpoint['meta'],
     # add the code here.
     if torch.__version__ >= '1.6':

--- a/tools/model_converters/publish_model.py
+++ b/tools/model_converters/publish_model.py
@@ -12,7 +12,7 @@ def parse_args():
     parser.add_argument('in_file', help='input checkpoint filename')
     parser.add_argument('out_file', help='output checkpoint filename')
     parser.add_argument(
-        '--saved-keys',
+        '--save-keys',
         nargs='+',
         type=str,
         default=['meta', 'state_dict'],
@@ -21,17 +21,17 @@ def parse_args():
     return args
 
 
-def process_checkpoint(in_file, out_file, saved_keys=['meta', 'state_dict']):
+def process_checkpoint(in_file, out_file, save_keys=['meta', 'state_dict']):
     checkpoint = torch.load(in_file, map_location='cpu')
 
     # only keep `meta` and `state_dict` for smaller file size
     ckpt_keys = list(checkpoint.keys())
     for k in ckpt_keys:
-        if k not in saved_keys:
+        if k not in save_keys:
             print_log(
                 f'Key `{k}` will be removed because it is not in '
-                f'saved_keys. If you want to keep it, '
-                f'please set --saved-keys.',
+                f'save_keys. If you want to keep it, '
+                f'please set --save-keys.',
                 logger='current')
             checkpoint.pop(k, None)
 
@@ -54,7 +54,7 @@ def process_checkpoint(in_file, out_file, saved_keys=['meta', 'state_dict']):
 
 def main():
     args = parse_args()
-    process_checkpoint(args.in_file, args.out_file, args.saved_keys)
+    process_checkpoint(args.in_file, args.out_file, args.save_keys)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

The checkpoint saved by mmengine contains more keys (e.g. message_hub, param_scheduler). These parts are very large and may take dozens or even hundreds of MB.

## Modification

Pop the keys except for meta and state_dict.

