### PR TITLE
[Fix]: fix checking masks on MMDetWandbHook (open-mmlab#8455)

### DIFF
--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -376,6 +376,7 @@ class MMDetWandbHook(WandbLoggerHook):
             wandb_boxes = self._get_wandb_bboxes(bboxes, labels)
 
             # Get dict of masks to be logged.
+            masks = None if set(masks) == {None} else masks
             if masks is not None:
                 wandb_masks = self._get_wandb_masks(
                     masks,


### PR DESCRIPTION
## Motivation

To fix errors described on #8455.

```
IndexError: list index out of range
Exception: input type is not supported.
```

## Modification

Before checking `masks is not None`, if `masks` is the list of `None`, then change to `None`.

```python
masks = [None, None, ..., None]
masks = None if set(masks) == {None} else masks
```


```python
masks = None if set(masks) == {None} else masks     # 👈 new lines
if masks is not None:
    wandb_masks = self._get_wandb_masks(
        masks,
        labels,
        is_poly_mask=True,
        height=img_height,
        width=img_width)
else:
    wandb_masks = None
```