### PR TITLE
[Fix] Fix Condinst predict error when val batch_size>1

### DIFF
--- a/mmdet/models/dense_heads/condinst_head.py
+++ b/mmdet/models/dense_heads/condinst_head.py
@@ -1158,8 +1158,8 @@ class CondInstMaskHead(BaseMaskHead):
             img_meta = batch_img_metas[img_id]
             results = results_list[img_id]
             bboxes = results.bboxes
-            mask_preds = mask_preds[img_id]
-            if bboxes.shape[0] == 0 or mask_preds.shape[0] == 0:
+            mask_pred = mask_preds[img_id]
+            if bboxes.shape[0] == 0 or mask_pred.shape[0] == 0:
                 results_list[img_id] = empty_instances(
                     [img_meta],
                     bboxes.device,
@@ -1167,7 +1167,7 @@ class CondInstMaskHead(BaseMaskHead):
                     instance_results=[results])[0]
             else:
                 im_mask = self._predict_by_feat_single(
-                    mask_preds=mask_preds,
+                    mask_preds=mask_pred,
                     bboxes=bboxes,
                     img_meta=img_meta,
                     rescale=rescale)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When set batch_size>1 in val_dataloader, got an error like this:

```
  File "/workspace/mmdetection/mmdet/models/detectors/single_stage_instance_seg.py", line 175, in predict
    results_list = self.mask_head.predict(
  File "/workspace/mmdetection/mmdet/models/dense_heads/base_mask_head.py", line 121, in predict
    results_list = self.predict_by_feat(
  File "/workspace/mmdetection/mmdet/models/dense_heads/condinst_head.py", line 1191, in predict_by_feat
    im_mask = self._predict_by_feat_single(
  File "/workspace/mmdetection/mmdet/models/dense_heads/condinst_head.py", line 1234, in _predict_by_feat_single
    mask_preds = aligned_bilinear(mask_preds, self.mask_out_stride)
  File "/workspace/mmdetection/mmdet/models/utils/misc.py", line 611, in aligned_bilinear
    assert tensor.dim() == 4
AssertionError
```

I found the loop in `predict_by_feat` overrides the `mask_feats` so the second batch will got the error because the dim is wrong.


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
