### PR TITLE
CodeCamp #34 add type hints for bfp and channel_mapper

### DIFF
--- a/mmdet/models/necks/bfp.py
+++ b/mmdet/models/necks/bfp.py
@@ -1,10 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Tuple
+
 import torch.nn.functional as F
 from mmcv.cnn import ConvModule
 from mmcv.cnn.bricks import NonLocal2d
 from mmengine.model import BaseModule
+from torch import Tensor
 
 from mmdet.registry import MODELS
+from mmdet.utils import OptConfigType, OptMultiConfig
 
 
 @MODELS.register_module()
@@ -21,25 +25,30 @@ class BFP(BaseModule):
         in_channels (int): Number of input channels (feature maps of all levels
             should have the same channels).
         num_levels (int): Number of input feature levels.
-        conv_cfg (dict): The config dict for convolution layers.
-        norm_cfg (dict): The config dict for normalization layers.
         refine_level (int): Index of integration and refine level of BSF in
             multi-level features from bottom to top.
         refine_type (str): Type of the refine op, currently support
             [None, 'conv', 'non_local'].
-        init_cfg (dict or list[dict], optional): Initialization config dict.
+        conv_cfg (:obj:`ConfigDict` or dict, optional): The config dict for
+            convolution layers.
+        norm_cfg (:obj:`ConfigDict` or dict, optional): The config dict for
+            normalization layers.
+        init_cfg (:obj:`ConfigDict` or dict or list[:obj:`ConfigDict` or
+            dict], optional): Initialization config dict.
     """
 
-    def __init__(self,
-                 in_channels,
-                 num_levels,
-                 refine_level=2,
-                 refine_type=None,
-                 conv_cfg=None,
-                 norm_cfg=None,
-                 init_cfg=dict(
-                     type='Xavier', layer='Conv2d', distribution='uniform')):
-        super(BFP, self).__init__(init_cfg)
+    def __init__(
+        self,
+        in_channels: int,
+        num_levels: int,
+        refine_level: int = 2,
+        refine_type: str = None,
+        conv_cfg: OptConfigType = None,
+        norm_cfg: OptConfigType = None,
+        init_cfg: OptMultiConfig = dict(
+            type='Xavier', layer='Conv2d', distribution='uniform')
+    ) -> None:
+        super().__init__(init_cfg=init_cfg)
         assert refine_type in [None, 'conv', 'non_local']
 
         self.in_channels = in_channels
@@ -67,7 +76,7 @@ class BFP(BaseModule):
                 conv_cfg=self.conv_cfg,
                 norm_cfg=self.norm_cfg)
 
-    def forward(self, inputs):
+    def forward(self, inputs: Tuple[Tensor]) -> Tuple[Tensor]:
         """Forward function."""
         assert len(inputs) == self.num_levels
 

--- a/mmdet/models/necks/channel_mapper.py
+++ b/mmdet/models/necks/channel_mapper.py
@@ -1,14 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Tuple
+
 import torch.nn as nn
 from mmcv.cnn import ConvModule
 from mmengine.model import BaseModule
+from torch import Tensor
 
 from mmdet.registry import MODELS
+from mmdet.utils import OptConfigType, OptMultiConfig
 
 
 @MODELS.register_module()
 class ChannelMapper(BaseModule):
-    r"""Channel Mapper to reduce/increase channels of backbone features.
+    """Channel Mapper to reduce/increase channels of backbone features.
 
     This is used to reduce/increase channels of backbone features.
 
@@ -17,16 +21,16 @@ class ChannelMapper(BaseModule):
         out_channels (int): Number of output channels (used at each scale).
         kernel_size (int, optional): kernel_size for reducing channels (used
             at each scale). Default: 3.
-        conv_cfg (dict, optional): Config dict for convolution layer.
-            Default: None.
-        norm_cfg (dict, optional): Config dict for normalization layer.
-            Default: None.
-        act_cfg (dict, optional): Config dict for activation layer in
-            ConvModule. Default: dict(type='ReLU').
-        num_outs (int, optional): Number of output feature maps. There
-            would be extra_convs when num_outs larger than the length
-            of in_channels.
-        init_cfg (dict or list[dict], optional): Initialization config dict.
+        conv_cfg (:obj:`ConfigDict` or dict, optional): Config dict for
+            convolution layer. Default: None.
+        norm_cfg (:obj:`ConfigDict` or dict, optional): Config dict for
+            normalization layer. Default: None.
+        act_cfg (:obj:`ConfigDict` or dict, optional): Config dict for
+            activation layer in ConvModule. Default: dict(type='ReLU').
+        num_outs (int, optional): Number of output feature maps. There would
+            be extra_convs when num_outs larger than the length of in_channels.
+        init_cfg (:obj:`ConfigDict` or dict or list[:obj:`ConfigDict` or dict],
+            optional): Initialization config dict.
     Example:
         >>> import torch
         >>> in_channels = [2, 3, 5, 7]
@@ -43,17 +47,19 @@ class ChannelMapper(BaseModule):
         outputs[3].shape = torch.Size([1, 11, 43, 43])
     """
 
-    def __init__(self,
-                 in_channels,
-                 out_channels,
-                 kernel_size=3,
-                 conv_cfg=None,
-                 norm_cfg=None,
-                 act_cfg=dict(type='ReLU'),
-                 num_outs=None,
-                 init_cfg=dict(
-                     type='Xavier', layer='Conv2d', distribution='uniform')):
-        super(ChannelMapper, self).__init__(init_cfg)
+    def __init__(
+        self,
+        in_channels: List[int],
+        out_channels: int,
+        kernel_size: int = 3,
+        conv_cfg: OptConfigType = None,
+        norm_cfg: OptConfigType = None,
+        act_cfg: OptConfigType = dict(type='ReLU'),
+        num_outs: int = None,
+        init_cfg: OptMultiConfig = dict(
+            type='Xavier', layer='Conv2d', distribution='uniform')
+    ) -> None:
+        super().__init__(init_cfg=init_cfg)
         assert isinstance(in_channels, list)
         self.extra_convs = None
         if num_outs is None:
@@ -87,7 +93,7 @@ class ChannelMapper(BaseModule):
                         norm_cfg=norm_cfg,
                         act_cfg=act_cfg))
 
-    def forward(self, inputs):
+    def forward(self, inputs: Tuple[Tensor]) -> Tuple[Tensor]:
         """Forward function."""
         assert len(inputs) == len(self.convs)
         outs = [self.convs[i](inputs[i]) for i in range(len(inputs))]


### PR DESCRIPTION
## Motivation

超级视客营 mmdet 基础任务，为part-9的 `bfp.py` 和 `channel_mapper.py` 添加 type hints

## Modification

1. 昨天修改好了 `bfp.py` 并提交PR且已经过审，但不太熟悉PR操作，没有签署 commit sign 导致无法合并
2. 为 `channel_mapper.py` 中相关函数添加 type hints

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.