### PR TITLE
fix config import links in model converters

### DIFF
--- a/tools/model_converters/upgrade_model_version.py
+++ b/tools/model_converters/upgrade_model_version.py
@@ -5,7 +5,7 @@ import tempfile
 from collections import OrderedDict
 
 import torch
-from mmcv import Config
+from mmengine import Config, DictAction
 
 
 def is_head(key):

--- a/tools/model_converters/upgrade_model_version.py
+++ b/tools/model_converters/upgrade_model_version.py
@@ -5,7 +5,7 @@ import tempfile
 from collections import OrderedDict
 
 import torch
-from mmengine import Config, DictAction
+from mmengine import Config
 
 
 def is_head(key):

--- a/tools/model_converters/upgrade_ssd_version.py
+++ b/tools/model_converters/upgrade_ssd_version.py
@@ -4,7 +4,7 @@ import tempfile
 from collections import OrderedDict
 
 import torch
-from mmcv import Config
+from mmengine import Config, DictAction
 
 
 def parse_config(config_strings):

--- a/tools/model_converters/upgrade_ssd_version.py
+++ b/tools/model_converters/upgrade_ssd_version.py
@@ -4,7 +4,7 @@ import tempfile
 from collections import OrderedDict
 
 import torch
-from mmengine import Config, DictAction
+from mmengine import Config
 
 
 def parse_config(config_strings):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
`import Config` has been changed in openmmlab-2.0, update the import code in the `./tools/model_converters`
## Modification
Replace `from mmcv import Config, DictAction` with `from mmengine import Config, DictAction`

Two files are changed, including  `./tools/model_converters/upgrade_ssd_version.py` and `./tools/model_converters/upgrade_model_version.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
