### PR TITLE
Fixed deadlock issue related with MMDetWandbHook

### DIFF
--- a/mmdet/core/hook/wandblogger_hook.py
+++ b/mmdet/core/hook/wandblogger_hook.py
@@ -202,10 +202,14 @@ class MMDetWandbHook(WandbLoggerHook):
             # Log ground truth data
             self._log_data_table()
 
-    @master_only
+    # for the reason of this double-layered structure, refer to
+    # https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076
     def after_train_epoch(self, runner):
         super(MMDetWandbHook, self).after_train_epoch(runner)
+        self._after_train_epoch(runner)
 
+    @master_only
+    def _after_train_epoch(self, runner):
         if not self.by_epoch:
             return
 
@@ -235,7 +239,8 @@ class MMDetWandbHook(WandbLoggerHook):
             # Log the table
             self._log_eval_table(runner.epoch + 1)
 
-    @master_only
+    # for the reason of this double-layered structure, refer to
+    # https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076
     def after_train_iter(self, runner):
         if self.get_mode(runner) == 'train':
             # An ugly patch. The iter-based eval hook will call the
@@ -245,7 +250,10 @@ class MMDetWandbHook(WandbLoggerHook):
             return super(MMDetWandbHook, self).after_train_iter(runner)
         else:
             super(MMDetWandbHook, self).after_train_iter(runner)
+        self._after_train_iter(runner)
 
+    @master_only
+    def _after_train_iter(self, runner):
         if self.by_epoch:
             return
 


### PR DESCRIPTION
Co-authored-by: WangYudong <yudong.wang@akane.waseda.jp>

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

https://github.com/open-mmlab/mmdetection/issues/8145
To summarize problem, when we use `MMDetWandbHook` after `TextLoggerHook`, problem such as deadlock or `AssertionError: loss log variables are different across GPUs!` occurs. These are because of same reason and I summarized the reason in https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076 here.

## Modification

Made MMDetWandbHook to clear `runner.log_buffer` on every process, including process for GPU 1,2,3...

I'm wondering if I should consider `after_val_epoch` of `MMDetWandbHook`, because since there is not `after_val_epoch` on `MMDetWandbHook`, I didn't deal with this method. If someone implement `after_val_epoch` in `MMDetWandbHook` with `@master_only`, same error can occurs.

I guess it is sufficient to mention above lines in `MMDetWandbHook` as I did, but it may be a potential threat.
```
    # for the reason of this double-layered structure, refer to
    # https://github.com/open-mmlab/mmdetection/issues/8145#issuecomment-1345343076
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
