### PR TITLE
Deprecating `np.bool` Type Alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.8.3
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/PyCQA/isort

--- a/mmdet/core/evaluation/mean_ap.py
+++ b/mmdet/core/evaluation/mean_ap.py
@@ -93,8 +93,8 @@ def tpfp_imagenet(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -202,8 +202,8 @@ def tpfp_default(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -317,8 +317,8 @@ def tpfp_openimages(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -517,7 +517,7 @@ def get_cls_group_ofs(annotations, class_id):
         if ann.get('gt_is_group_ofs', None) is not None:
             gt_group_ofs.append(ann['gt_is_group_ofs'][gt_inds])
         else:
-            gt_group_ofs.append(np.empty((0, 1), dtype=np.bool))
+            gt_group_ofs.append(np.empty((0, 1), dtype=bool))
 
     return gt_group_ofs
 

--- a/mmdet/core/export/model_wrappers.py
+++ b/mmdet/core/export/model_wrappers.py
@@ -82,7 +82,7 @@ class DeployBaseDetector(BaseDetector):
                     masks = torch.nn.functional.interpolate(
                         masks.unsqueeze(0), size=(ori_h, ori_w))
                     masks = masks.squeeze(0).detach().numpy()
-                if masks.dtype != np.bool:
+                if masks.dtype != bool:
                     masks = masks >= 0.5
                 segms_results = [[] for _ in range(len(self.CLASSES))]
                 for j in range(len(dets)):

--- a/mmdet/core/mask/structures.py
+++ b/mmdet/core/mask/structures.py
@@ -1068,7 +1068,7 @@ def polygon_to_bitmap(polygons, height, width):
     """
     rles = maskUtils.frPyObjects(polygons, height, width)
     rle = maskUtils.merge(rles)
-    bitmap_mask = maskUtils.decode(rle).astype(np.bool)
+    bitmap_mask = maskUtils.decode(rle).astype(bool)
     return bitmap_mask
 
 

--- a/mmdet/datasets/openimages.py
+++ b/mmdet/datasets/openimages.py
@@ -267,13 +267,13 @@ class OpenImagesDataset(CustomDataset):
             labels_ignore = np.array(labels_ignore)
 
         assert len(is_group_ofs) == len(labels) == len(bboxes)
-        gt_is_group_ofs = np.array(is_group_ofs, dtype=np.bool)
+        gt_is_group_ofs = np.array(is_group_ofs, dtype=bool)
 
         # These parameters is not used yet.
-        is_occludeds = np.array(is_occludeds, dtype=np.bool)
-        is_truncateds = np.array(is_truncateds, dtype=np.bool)
-        is_depictions = np.array(is_depictions, dtype=np.bool)
-        is_insides = np.array(is_insides, dtype=np.bool)
+        is_occludeds = np.array(is_occludeds, dtype=bool)
+        is_truncateds = np.array(is_truncateds, dtype=bool)
+        is_depictions = np.array(is_depictions, dtype=bool)
+        is_insides = np.array(is_insides, dtype=bool)
 
         ann = dict(
             bboxes=bboxes.astype(np.float32),
@@ -450,7 +450,7 @@ class OpenImagesDataset(CustomDataset):
                 bboxes=np.array(gt_bboxes).astype(np.float32),
                 labels=np.array(gt_labels).astype(np.int64),
                 bboxes_ignore=ann['bboxes_ignore'],
-                gt_is_group_ofs=np.array(gt_is_group_ofs).astype(np.bool))
+                gt_is_group_ofs=np.array(gt_is_group_ofs).astype(bool))
 
         return annotations
 
@@ -790,7 +790,7 @@ class OpenImagesChallengeDataset(OpenImagesDataset):
             gt_bboxes = np.array(bboxes, dtype=np.float32)
             gt_labels = np.array(labels, dtype=np.int64)
             gt_bboxes_ignore = np.zeros((0, 4), dtype=np.float32)
-            gt_is_group_ofs = np.array(is_group_ofs, dtype=np.bool)
+            gt_is_group_ofs = np.array(is_group_ofs, dtype=bool)
 
             img_info = dict(filename=filename)
             ann_info = dict(

--- a/tests/test_metrics/test_mean_ap.py
+++ b/tests/test_metrics/test_mean_ap.py
@@ -114,7 +114,7 @@ def test_tpfp_openimages():
                            [10, 10, 25, 25, 0.98], [28, 28, 35, 35, 0.97],
                            [30, 30, 51, 51, 0.96], [100, 110, 120, 130, 0.15]])
     gt_bboxes = np.array([[10., 10., 30., 30.], [30., 30., 50., 50.]])
-    gt_groups_of = np.array([True, False], dtype=np.bool)
+    gt_groups_of = np.array([True, False], dtype=bool)
     gt_ignore = np.zeros((0, 4))
 
     # Open Images evaluation using group of.
@@ -158,7 +158,7 @@ def test_tpfp_openimages():
     assert cls_dets.shape == (6, 5)
 
     # Open Images evaluation using group of, and gt is all group of bboxes.
-    gt_groups_of = np.array([True, True], dtype=np.bool)
+    gt_groups_of = np.array([True, True], dtype=bool)
     result = tpfp_openimages(
         det_bboxes,
         gt_bboxes,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Gets rid of instances of `np.bool` to increase compatibility with newer versions of `numpy`. For more details see: https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations. 

_Note: `np.bool` has just been an alias for `bool`_ 

## Modification

Replaces all `np.bool` instances w/ `bool`.

## BC-breaking (Optional)

Not applicable

## Use cases (Optional)

Not applicable

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
