### PR TITLE
Support installation on Windows

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,6 +1,7 @@
 matplotlib
 numpy
-pycocotools
+pycocotools ; sys_platform != 'win32'
+pycocotools-windows ; sys_platform == 'win32'
 scipy
 six
 terminaltables


### PR DESCRIPTION
## Motivation

Fix Windows Installation Issue

## Modification

Replace ﻿`pycocotools` with `pycocotools-windows` for Windows OS in pip list.