### PR TITLE
delete parrots-awared code of roi extractor

### DIFF
--- a/mmdet/models/roi_heads/roi_extractors/single_level_roi_extractor.py
+++ b/mmdet/models/roi_heads/roi_extractors/single_level_roi_extractor.py
@@ -69,9 +69,6 @@ class SingleRoIExtractor(BaseRoIExtractor):
         else:
             roi_feats = feats[0].new_zeros(
                 rois.size(0), self.out_channels, *out_size)
-        # TODO: remove this when parrots supports
-        if torch.__version__ == 'parrots':
-            roi_feats.requires_grad = True
 
         if num_levels == 1:
             if len(rois) == 0:


### PR DESCRIPTION
## Motivation

SenseParrots has already aligned some apis of autograd with pytorch so that requiring grad of "feats" is no longer needed by parrots, which will also cause an error.

## Modification

We deleted a bunch of parrots-awared code within roi extractor so that the parameter "feats" no longer requires grad.