### PR TITLE
[WIP] [Feature] Refactor assigner and sampler

### DIFF
--- a/mmdet/models/task_modules/assigners/iou2d_calculator.py
+++ b/mmdet/models/task_modules/assigners/iou2d_calculator.py
@@ -1,11 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Union
+
 import torch
+from mmengine.structures import InstanceData
+from torch import Tensor
 
 from mmdet.registry import TASK_UTILS
-from mmdet.structures.bbox import bbox_overlaps, get_box_tensor
+from mmdet.structures.bbox import BaseBoxes, bbox_overlaps, get_box_tensor
 
 
-def cast_tensor_type(x, scale=1., dtype=None):
+def cast_tensor_type(x: Tensor,
+                     scale: float = 1.,
+                     dtype: Optional[torch.dtype] = None) -> Tensor:
+    """Convert Tensor to float16."""
     if dtype == 'fp16':
         # scale is for preventing overflows
         x = (x / scale).half()
@@ -16,30 +23,49 @@ def cast_tensor_type(x, scale=1., dtype=None):
 class BboxOverlaps2D:
     """2D Overlaps (e.g. IoUs, GIoUs) Calculator."""
 
-    def __init__(self, scale=1., dtype=None):
+    def __init__(self,
+                 scale: float = 1.,
+                 dtype: Optional[torch.dtype] = None) -> None:
         self.scale = scale
         self.dtype = dtype
 
-    def __call__(self, bboxes1, bboxes2, mode='iou', is_aligned=False):
+    def __call__(self,
+                 bboxes1: Union[Tensor, BaseBoxes, InstanceData],
+                 bboxes2: Union[Tensor, BaseBoxes, InstanceData],
+                 mode: str = 'iou',
+                 is_aligned: bool = False,
+                 key1: Optional[str] = None,
+                 key2: Optional[str] = None) -> Tensor:
         """Calculate IoU between 2D bboxes.
 
         Args:
-            bboxes1 (Tensor or :obj:`BaseBoxes`): bboxes have shape (m, 4)
-                in <x1, y1, x2, y2> format, or shape (m, 5) in <x1, y1, x2,
-                y2, score> format.
-            bboxes2 (Tensor or :obj:`BaseBoxes`): bboxes have shape (m, 4)
-                in <x1, y1, x2, y2> format, shape (m, 5) in <x1, y1, x2, y2,
-                score> format, or be empty. If ``is_aligned `` is ``True``,
-                then m and n must be equal.
+            bboxes1 (Tensor or :obj:`BaseBoxes` or :obj:`InstanceData`): bboxes
+                have shape (m, 4) in <x1, y1, x2, y2> format, or shape (m, 5)
+                in <x1, y1, x2, y2, score> format.
+            bboxes2 (Tensor or :obj:`BaseBoxes` or :obj:`InstanceData`): bboxes
+                have shape (m, 4) in <x1, y1, x2, y2> format, or shape (m, 5)
+                in <x1, y1, x2, y2, score> format, or be empty.
+                If ``is_aligned `` is ``True``, then m and n must be equal.
             mode (str): "iou" (intersection over union), "iof" (intersection
                 over foreground), or "giou" (generalized intersection over
-                union).
+                union). Defaults to 'iou'.
             is_aligned (bool, optional): If True, then m and n must be equal.
-                Default False.
+                Defaults to False.
+            key1 (str, optional): The key to get bboxes1, is necessary when
+                bboxes1 is :obj:`InstanceData`. Defaults to None.
+            key2 (str, optional): The key to get bboxes2, is necessary when
+                bboxes2 is :obj:`InstanceData`. Defaults to None.
 
         Returns:
             Tensor: shape (m, n) if ``is_aligned `` is False else shape (m,)
         """
+        if isinstance(bboxes1, InstanceData):
+            assert key1 is not None
+            bboxes1 = bboxes1.get(key1)
+        if isinstance(bboxes2, InstanceData):
+            assert key2 is not None
+            bboxes2 = bboxes2.get(key2)
+
         bboxes1 = get_box_tensor(bboxes1)
         bboxes2 = get_box_tensor(bboxes2)
         assert bboxes1.size(-1) in [0, 4, 5]
@@ -61,7 +87,7 @@ class BboxOverlaps2D:
 
         return bbox_overlaps(bboxes1, bboxes2, mode, is_aligned)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """str: a string describing the module"""
         repr_str = self.__class__.__name__ + f'(' \
             f'scale={self.scale}, dtype={self.dtype})'

--- a/mmdet/models/task_modules/samplers/mask_pseudo_sampler.py
+++ b/mmdet/models/task_modules/samplers/mask_pseudo_sampler.py
@@ -6,7 +6,7 @@ import torch
 from mmengine.structures import InstanceData
 
 from mmdet.registry import TASK_UTILS
-from ..assigners import AssignResult
+from ..assigners.assign_result import AssignResult
 from .base_sampler import BaseSampler
 from .mask_sampling_result import MaskSamplingResult
 

--- a/mmdet/models/task_modules/samplers/mask_sampling_result.py
+++ b/mmdet/models/task_modules/samplers/mask_sampling_result.py
@@ -5,7 +5,7 @@ https://github.com/ZwwWayne/K-Net/blob/main/knet/det/mask_pseudo_sampler.py."""
 import torch
 from torch import Tensor
 
-from ..assigners import AssignResult
+from ..assigners.assign_result import AssignResult
 from .sampling_result import SamplingResult
 
 

--- a/mmdet/models/task_modules/samplers/multi_instance_random_sampler.py
+++ b/mmdet/models/task_modules/samplers/multi_instance_random_sampler.py
@@ -7,7 +7,7 @@ from numpy import ndarray
 from torch import Tensor
 
 from mmdet.registry import TASK_UTILS
-from ..assigners import AssignResult
+from ..assigners.assign_result import AssignResult
 from .multi_instance_sampling_result import MultiInstanceSamplingResult
 from .random_sampler import RandomSampler
 

--- a/mmdet/models/task_modules/samplers/multi_instance_sampling_result.py
+++ b/mmdet/models/task_modules/samplers/multi_instance_sampling_result.py
@@ -2,7 +2,7 @@
 import torch
 from torch import Tensor
 
-from ..assigners import AssignResult
+from ..assigners.assign_result import AssignResult
 from .sampling_result import SamplingResult
 
 

--- a/mmdet/models/task_modules/samplers/pseudo_sampler.py
+++ b/mmdet/models/task_modules/samplers/pseudo_sampler.py
@@ -1,9 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import torch
-from mmengine.structures import InstanceData
-
 from mmdet.registry import TASK_UTILS
-from ..assigners import AssignResult
 from .base_sampler import BaseSampler
 from .sampling_result import SamplingResult
 
@@ -23,38 +19,13 @@ class PseudoSampler(BaseSampler):
         """Sample negative samples."""
         raise NotImplementedError
 
-    def sample(self, assign_result: AssignResult, pred_instances: InstanceData,
-               gt_instances: InstanceData, *args, **kwargs):
+    def sample(self, assign_result: SamplingResult, *args, **kwargs):
         """Directly returns the positive and negative indices  of samples.
 
         Args:
-            assign_result (:obj:`AssignResult`): Bbox assigning results.
-            pred_instances (:obj:`InstanceData`): Instances of model
-                predictions. It includes ``priors``, and the priors can
-                be anchors, points, or bboxes predicted by the model,
-                shape(n, 4).
-            gt_instances (:obj:`InstanceData`): Ground truth of instance
-                annotations. It usually includes ``bboxes`` and ``labels``
-                attributes.
+            assign_result (:obj:`SamplingResult`): Bbox assigning results.
 
         Returns:
             :obj:`SamplingResult`: sampler results
         """
-        gt_bboxes = gt_instances.bboxes
-        priors = pred_instances.priors
-
-        pos_inds = torch.nonzero(
-            assign_result.gt_inds > 0, as_tuple=False).squeeze(-1).unique()
-        neg_inds = torch.nonzero(
-            assign_result.gt_inds == 0, as_tuple=False).squeeze(-1).unique()
-
-        gt_flags = priors.new_zeros(priors.shape[0], dtype=torch.uint8)
-        sampling_result = SamplingResult(
-            pos_inds=pos_inds,
-            neg_inds=neg_inds,
-            priors=priors,
-            gt_bboxes=gt_bboxes,
-            assign_result=assign_result,
-            gt_flags=gt_flags,
-            avg_factor_with_neg=False)
-        return sampling_result
+        return assign_result

--- a/mmdet/models/task_modules/samplers/random_sampler.py
+++ b/mmdet/models/task_modules/samplers/random_sampler.py
@@ -6,8 +6,8 @@ from numpy import ndarray
 from torch import Tensor
 
 from mmdet.registry import TASK_UTILS
-from ..assigners import AssignResult
 from .base_sampler import BaseSampler
+from .sampling_result import SamplingResult
 
 
 @TASK_UTILS.register_module()
@@ -70,7 +70,7 @@ class RandomSampler(BaseSampler):
             rand_inds = rand_inds.cpu().numpy()
         return rand_inds
 
-    def _sample_pos(self, assign_result: AssignResult, num_expected: int,
+    def _sample_pos(self, assign_result: SamplingResult, num_expected: int,
                     **kwargs) -> Union[Tensor, ndarray]:
         """Randomly sample some positive samples.
 
@@ -89,7 +89,7 @@ class RandomSampler(BaseSampler):
         else:
             return self.random_choice(pos_inds, num_expected)
 
-    def _sample_neg(self, assign_result: AssignResult, num_expected: int,
+    def _sample_neg(self, assign_result: SamplingResult, num_expected: int,
                     **kwargs) -> Union[Tensor, ndarray]:
         """Randomly sample some negative samples.
 

--- a/mmdet/models/task_modules/samplers/score_hlr_sampler.py
+++ b/mmdet/models/task_modules/samplers/score_hlr_sampler.py
@@ -9,7 +9,7 @@ from torch import Tensor
 
 from mmdet.registry import TASK_UTILS
 from mmdet.structures.bbox import bbox2roi
-from ..assigners import AssignResult
+from ..assigners.assign_result import AssignResult
 from .base_sampler import BaseSampler
 from .sampling_result import SamplingResult
 

--- a/mmdet/structures/bbox/bbox_overlaps.py
+++ b/mmdet/structures/bbox/bbox_overlaps.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 
+from mmdet.utils.memory import AvoidCUDAOOM
+
 
 def fp16_clamp(x, min=None, max=None):
     if not x.is_cuda and x.dtype == torch.float16:
@@ -10,6 +12,7 @@ def fp16_clamp(x, min=None, max=None):
     return x.clamp(min, max)
 
 
+@AvoidCUDAOOM.retry_if_cuda_oom
 def bbox_overlaps(bboxes1, bboxes2, mode='iou', is_aligned=False, eps=1e-6):
     """Calculate overlap between two set of bboxes.
 

--- a/mmdet/utils/memory.py
+++ b/mmdet/utils/memory.py
@@ -6,6 +6,7 @@ from functools import wraps
 
 import torch
 from mmengine.logging import MMLogger
+from mmengine.structures import BaseDataElement
 
 
 def cast_tensor_type(inputs, src_type=None, dst_type=None):
@@ -39,6 +40,8 @@ def cast_tensor_type(inputs, src_type=None, dst_type=None):
                 return inputs
         # we need to ensure that the type of inputs to be casted are the same
         # as the argument `src_type`.
+    elif isinstance(inputs, str):
+        return inputs
     elif isinstance(inputs, abc.Mapping):
         return type(inputs)({
             k: cast_tensor_type(v, src_type=src_type, dst_type=dst_type)
@@ -48,12 +51,9 @@ def cast_tensor_type(inputs, src_type=None, dst_type=None):
         return type(inputs)(
             cast_tensor_type(item, src_type=src_type, dst_type=dst_type)
             for item in inputs)
-    # TODO: Currently not supported
-    # elif isinstance(inputs, InstanceData):
-    #     for key, value in inputs.items():
-    #         inputs[key] = cast_tensor_type(
-    #             value, src_type=src_type, dst_type=dst_type)
-    #     return inputs
+    elif isinstance(inputs, BaseDataElement):
+        inputs = inputs.to(dst_type)
+        return inputs
     else:
         return inputs
 


### PR DESCRIPTION
Refactor AssignerResult and SamplingResult. 

- keep AssignerResult and SamplingResult have the same logic, which means can deprecate `pseudo sampler`
- the input of SamplingResult changed to InstanceData, which can have better scalability, (can deprecate MaskSamplingResult)
- Use AvoidCUDAOOM instead of `assign_on_cpu` in assigner