### PR TITLE
Replace numpy transpose with torch permute to speed-up

### DIFF
--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -226,9 +226,11 @@ class DefaultFormatBundle:
             results = self._add_default_meta_keys(results)
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-            # To lower the computational time, if image is not contiguous,
-            # use `numpy.transpose()`` before `numpy.ascontiguousarray()`,
-            # otherwise, use `torch.permute()` before `torch.contiguous()`.
+            # To improve the computational speed by by 3-5 times, apply:
+            # If image is not contiguous, use
+            # `numpy.transpose()` followed by `numpy.ascontiguousarray()`
+            # If image is already contiguous, use
+            # `torch.permute()` followed by `torch.contiguous()`
             if not img.flags.c_contiguous:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1))
                 img = to_tensor(img)

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from collections.abc import Sequence
 
+import mmcv
 import numpy as np
 import torch
-
-import mmcv
 from mmcv.parallel import DataContainer as DC
 
 from ..builder import PIPELINES
@@ -79,21 +78,21 @@ class ImageToTensor:
     def __init__(self, keys):
         self.keys = keys
 
-    def __call__(self, results):
-        """Call function to convert image in results to :obj:`torch.Tensor` and
+        permute the channel order.
+        permute the channel order.
         permute the channel order.
 
         Args:
             results (dict): Result dict contains the image data to convert.
 
-        Returns:
-            dict: The result dict contains the image converted
+                to :obj:`torch.Tensor` and permuted to (C, H, W) order.
+                to :obj:`torch.Tensor` and permuted to (C, H, W) order.
                 to :obj:`torch.Tensor` and permuted to (C, H, W) order.
         """
         for key in self.keys:
             img = results[key]
-            if len(img.shape) < 3:
-                img = np.expand_dims(img, -1)
+            results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
+            results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
             results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
         return results
 
@@ -178,8 +177,8 @@ class DefaultFormatBundle:
 
     It simplifies the pipeline of formatting common fields, including "img",
     "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
-    These fields are formatted as follows.
-
+    - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
+    - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
     - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
     - proposals: (1)to tensor, (2)to DataContainer
     - gt_bboxes: (1)to tensor, (2)to DataContainer
@@ -225,10 +224,12 @@ class DefaultFormatBundle:
                 img = img.astype(np.float32)
             # add default meta keys
             results = self._add_default_meta_keys(results)
-            if len(img.shape) < 3:
-                img = np.expand_dims(img, -1)
             results['img'] = DC(
                 to_tensor(img).permute(2, 0, 1).contiguous(),
+                padding_value=self.pad_val['img'],
+                stack=True)
+                padding_value=self.pad_val['img'],
+                stack=True)
                 padding_value=self.pad_val['img'],
                 stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -78,21 +78,21 @@ class ImageToTensor:
     def __init__(self, keys):
         self.keys = keys
 
-        permute the channel order.
-        permute the channel order.
+    def __call__(self, results):
+        """Call function to convert image in results to :obj:`torch.Tensor` and
         permute the channel order.
 
         Args:
             results (dict): Result dict contains the image data to convert.
 
-                to :obj:`torch.Tensor` and permuted to (C, H, W) order.
-                to :obj:`torch.Tensor` and permuted to (C, H, W) order.
+        Returns:
+            dict: The result dict contains the image converted
                 to :obj:`torch.Tensor` and permuted to (C, H, W) order.
         """
         for key in self.keys:
             img = results[key]
-            results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
-            results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
+            if len(img.shape) < 3:
+                img = np.expand_dims(img, -1)
             results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
         return results
 
@@ -177,8 +177,8 @@ class DefaultFormatBundle:
 
     It simplifies the pipeline of formatting common fields, including "img",
     "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
-    - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
-    - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
+    These fields are formatted as follows.
+
     - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
     - proposals: (1)to tensor, (2)to DataContainer
     - gt_bboxes: (1)to tensor, (2)to DataContainer
@@ -224,12 +224,10 @@ class DefaultFormatBundle:
                 img = img.astype(np.float32)
             # add default meta keys
             results = self._add_default_meta_keys(results)
+            if len(img.shape) < 3:
+                img = np.expand_dims(img, -1)
             results['img'] = DC(
                 to_tensor(img).permute(2, 0, 1).contiguous(),
-                padding_value=self.pad_val['img'],
-                stack=True)
-                padding_value=self.pad_val['img'],
-                stack=True)
                 padding_value=self.pad_val['img'],
                 stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -237,9 +237,7 @@ class DefaultFormatBundle:
             else:
                 img = to_tensor(img).permute(2, 0, 1).contiguous()
             results['img'] = DC(
-                img,
-                padding_value=self.pad_val['img'],
-                stack=True)
+                img, padding_value=self.pad_val['img'], stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:
             if key not in results:
                 continue

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -231,6 +231,8 @@ class DefaultFormatBundle:
             # `numpy.transpose()` followed by `numpy.ascontiguousarray()`
             # If image is already contiguous, use
             # `torch.permute()` followed by `torch.contiguous()`
+            # Refer to https://github.com/open-mmlab/mmdetection/pull/9533
+            # for more details
             if not img.flags.c_contiguous:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1))
                 img = to_tensor(img)

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -179,7 +179,7 @@ class DefaultFormatBundle:
     "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
     These fields are formatted as follows.
 
-    - img: (1)transpose (or permute) & to tensor, (2)to DataContainer (stack=True)
+    - img: (1)transpose & to tensor, (2)to DataContainer (stack=True)
     - proposals: (1)to tensor, (2)to DataContainer
     - gt_bboxes: (1)to tensor, (2)to DataContainer
     - gt_bboxes_ignore: (1)to tensor, (2)to DataContainer
@@ -232,7 +232,9 @@ class DefaultFormatBundle:
             if not img.flags.c_contiguous:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1))
                 results['img'] = DC(
-                    to_tensor(img), padding_value=self.pad_val['img'], stack=True)
+                    to_tensor(img),
+                    padding_value=self.pad_val['img'],
+                    stack=True)
             else:
                 results['img'] = DC(
                     to_tensor(img).permute(2, 0, 1).contiguous(),

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -231,15 +231,13 @@ class DefaultFormatBundle:
             # otherwise, use `torch.permute()` before `torch.contiguous()`.
             if not img.flags.c_contiguous:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1))
-                img = to_tensor(img),
-            
+                img = to_tensor(img)
             else:
-               img =  to_tensor(img).permute(2, 0, 1).contiguous()
-                   
+                img = to_tensor(img).permute(2, 0, 1).contiguous()
             results['img'] = DC(
-                    img,
-                    padding_value=self.pad_val['img'],
-                    stack=True)
+                img,
+                padding_value=self.pad_val['img'],
+                stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:
             if key not in results:
                 continue

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -1,9 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from collections.abc import Sequence
 
-import mmcv
 import numpy as np
 import torch
+
+import mmcv
 from mmcv.parallel import DataContainer as DC
 
 from ..builder import PIPELINES
@@ -80,20 +81,20 @@ class ImageToTensor:
 
     def __call__(self, results):
         """Call function to convert image in results to :obj:`torch.Tensor` and
-        transpose the channel order.
+        permute the channel order.
 
         Args:
             results (dict): Result dict contains the image data to convert.
 
         Returns:
             dict: The result dict contains the image converted
-                to :obj:`torch.Tensor` and transposed to (C, H, W) order.
+                to :obj:`torch.Tensor` and permuted to (C, H, W) order.
         """
         for key in self.keys:
             img = results[key]
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-            results[key] = (to_tensor(img.transpose(2, 0, 1))).contiguous()
+            results[key] = to_tensor(img).permute(2, 0, 1).contiguous()
         return results
 
     def __repr__(self):
@@ -179,7 +180,7 @@ class DefaultFormatBundle:
     "proposals", "gt_bboxes", "gt_labels", "gt_masks" and "gt_semantic_seg".
     These fields are formatted as follows.
 
-    - img: (1)transpose, (2)to tensor, (3)to DataContainer (stack=True)
+    - img: (1)to tensor, (2)permute, (3)to DataContainer (stack=True)
     - proposals: (1)to tensor, (2)to DataContainer
     - gt_bboxes: (1)to tensor, (2)to DataContainer
     - gt_bboxes_ignore: (1)to tensor, (2)to DataContainer
@@ -226,9 +227,10 @@ class DefaultFormatBundle:
             results = self._add_default_meta_keys(results)
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
-            img = np.ascontiguousarray(img.transpose(2, 0, 1))
             results['img'] = DC(
-                to_tensor(img), padding_value=self.pad_val['img'], stack=True)
+                to_tensor(img).permute(2, 0, 1).contiguous(),
+                padding_value=self.pad_val['img'],
+                stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:
             if key not in results:
                 continue

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -226,6 +226,7 @@ class DefaultFormatBundle:
             results = self._add_default_meta_keys(results)
             if len(img.shape) < 3:
                 img = np.expand_dims(img, -1)
+            img = np.ascontiguousarray(img)
             results['img'] = DC(
                 to_tensor(img).permute(2, 0, 1).contiguous(),
                 padding_value=self.pad_val['img'],

--- a/mmdet/datasets/pipelines/formatting.py
+++ b/mmdet/datasets/pipelines/formatting.py
@@ -231,13 +231,13 @@ class DefaultFormatBundle:
             # otherwise, use `torch.permute()` before `torch.contiguous()`.
             if not img.flags.c_contiguous:
                 img = np.ascontiguousarray(img.transpose(2, 0, 1))
-                results['img'] = DC(
-                    to_tensor(img),
-                    padding_value=self.pad_val['img'],
-                    stack=True)
+                img = to_tensor(img),
+            
             else:
-                results['img'] = DC(
-                    to_tensor(img).permute(2, 0, 1).contiguous(),
+               img =  to_tensor(img).permute(2, 0, 1).contiguous()
+                   
+            results['img'] = DC(
+                    img,
                     padding_value=self.pad_val['img'],
                     stack=True)
         for key in ['proposals', 'gt_bboxes', 'gt_bboxes_ignore', 'gt_labels']:

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,3 +1,3 @@
 cityscapesscripts
 imagecorruptions
-sklearn
+scikit-learn


### PR DESCRIPTION
## Motivation

`numpy.transpose()` is mush more slow than `torch.permute()` according to my benchmarks on a jupyter notebook:

1. If the input image size (1366, 800, 3) is the size of COCO dataset image

```
import numpy as np
import torch
img = np.random.randn(1366, 800, 3)
```

```
%%timeit
img_np = np.ascontiguousarray(img.transpose(2, 0, 1))
input = torch.from_numpy(img_np)
```
Output: 7.69 ms ± 314 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

```
%%timeit
input = torch.from_numpy(img).permute(2, 0, 1).contiguous()
```
Output: 1.65 ms ± 123 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

2. If the input image size is large, especially when inferencing a large image ((3648, 5472, 3) in my case)

```
img = np.random.randn(3648, 5472, 3)
```

```
%%timeit
img_np = np.ascontiguousarray(img.transpose(2, 0, 1))
input = torch.from_numpy(img_np)
```
Output: 327 ms ± 1.13 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```
%%timeit
input = torch.from_numpy(img).permute(2, 0, 1).contiguous()
```
Output: 93.8 ms ± 4.77 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

## Modification

Replace the transpose operation`numpy.transpose(2, 0, 1)` with `torch.permute(2, 0, 1)` to in [ImageToTensor](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/pipelines/formatting.py#L96) and [DefaultFormatBundle](https://github.com/open-mmlab/mmdetection/blob/master/mmdet/datasets/pipelines/formatting.py#L229-L230) to speed-up the process.
