### PR TITLE
[Fix] Deprecating old type alias due to new version of numpy

### DIFF
--- a/mmdet/datasets/transforms/augment_wrappers.py
+++ b/mmdet/datasets/transforms/augment_wrappers.py
@@ -97,7 +97,7 @@ class AutoAugment(RandomChoice):
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
     - gt_masks (BitmapMasks | PolygonMasks) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_seg_map (np.uint8) (optional)
 
     Modified Keys:
@@ -178,7 +178,7 @@ class RandAugment(RandomChoice):
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
     - gt_masks (BitmapMasks | PolygonMasks) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_seg_map (np.uint8) (optional)
 
     Modified Keys:

--- a/mmdet/datasets/transforms/loading.py
+++ b/mmdet/datasets/transforms/loading.py
@@ -218,7 +218,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
     - gt_bboxes_labels (np.int64)
     - gt_masks (BitmapMasks | PolygonMasks)
     - gt_seg_map (np.uint8)
-    - gt_ignore_flags (np.bool)
+    - gt_ignore_flags (bool)
 
     Args:
         with_bbox (bool): Whether to parse and load the bbox annotation.
@@ -270,7 +270,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
         else:
             _, box_type_cls = get_box_type(self.box_type)
             results['gt_bboxes'] = box_type_cls(gt_bboxes, dtype=torch.float32)
-        results['gt_ignore_flags'] = np.array(gt_ignore_flags, dtype=np.bool)
+        results['gt_ignore_flags'] = np.array(gt_ignore_flags, dtype=bool)
 
     def _load_labels(self, results: dict) -> None:
         """Private function to load label annotations.
@@ -356,7 +356,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
             gt_masks.append(gt_mask)
             # re-process gt_ignore_flags
             gt_ignore_flags.append(instance['ignore_flag'])
-        results['gt_ignore_flags'] = np.array(gt_ignore_flags, dtype=np.bool)
+        results['gt_ignore_flags'] = np.array(gt_ignore_flags, dtype=bool)
         return gt_masks
 
     def _load_masks(self, results: dict) -> None:
@@ -485,7 +485,7 @@ class LoadPanopticAnnotations(LoadAnnotations):
     - gt_bboxes_labels (np.int64)
     - gt_masks (BitmapMasks | PolygonMasks)
     - gt_seg_map (np.uint8)
-    - gt_ignore_flags (np.bool)
+    - gt_ignore_flags (bool)
 
     Args:
         with_bbox (bool): Whether to parse and load the bbox annotation.
@@ -667,7 +667,7 @@ class FilterAnnotations(BaseTransform):
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
     - gt_masks (BitmapMasks | PolygonMasks) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 
@@ -758,7 +758,7 @@ class LoadEmptyAnnotations(BaseTransform):
     - gt_bboxes_labels (np.int64)
     - gt_masks (BitmapMasks | PolygonMasks)
     - gt_seg_map (np.uint8)
-    - gt_ignore_flags (np.bool)
+    - gt_ignore_flags (bool)
 
     Args:
         with_bbox (bool): Whether to load the pseudo bbox annotation.

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -419,14 +419,14 @@ class RandomShift(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32])
     - gt_bboxes_labels (np.int64)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 
     - img
     - gt_bboxes
     - gt_bboxes_labels
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Args:
         prob (float): Probability of shifts. Defaults to 0.5.
@@ -611,7 +611,7 @@ class RandomCrop(BaseTransform):
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
     - gt_masks (BitmapMasks | PolygonMasks) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_seg_map (np.uint8) (optional)
 
     Modified Keys:
@@ -1157,7 +1157,7 @@ class MinIoURandomCrop(BaseTransform):
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
     - gt_masks (BitmapMasks | PolygonMasks) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_seg_map (np.uint8) (optional)
 
     Modified Keys:
@@ -1554,7 +1554,7 @@ class Albu(BaseTransform):
         if 'gt_ignore_flags' in results and isinstance(
                 results['gt_ignore_flags'], list):
             results['gt_ignore_flags'] = np.array(
-                results['gt_ignore_flags'], dtype=np.bool)
+                results['gt_ignore_flags'], dtype=bool)
 
         if 'bboxes' in results:
             if isinstance(results['bboxes'], list):
@@ -1656,7 +1656,7 @@ class RandomCenterCropPad(BaseTransform):
     - img_shape (tuple)
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 
@@ -1664,7 +1664,7 @@ class RandomCenterCropPad(BaseTransform):
     - img_shape (tuple)
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Args:
         crop_size (tuple, optional): expected size after crop, final size will
@@ -2094,7 +2094,7 @@ class Mosaic(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
     Modified Keys:
@@ -2347,7 +2347,7 @@ class MixUp(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
 
@@ -2549,7 +2549,7 @@ class RandomAffine(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 
@@ -2791,7 +2791,7 @@ class CopyPaste(BaseTransform):
     - img
     - gt_bboxes (BaseBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_masks (BitmapMasks) (optional)
 
     Modified Keys:
@@ -2971,7 +2971,7 @@ class RandomErasing(BaseTransform):
     - img
     - gt_bboxes (HorizontalBoxes[torch.float32]) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - gt_masks (BitmapMasks) (optional)
 
     Modified Keys:
@@ -3156,7 +3156,7 @@ class CachedMosaic(Mosaic):
     - img
     - gt_bboxes (np.float32) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
 
     Modified Keys:
 
@@ -3385,7 +3385,7 @@ class CachedMixUp(BaseTransform):
     - img
     - gt_bboxes (np.float32) (optional)
     - gt_bboxes_labels (np.int64) (optional)
-    - gt_ignore_flags (np.bool) (optional)
+    - gt_ignore_flags (bool) (optional)
     - mix_results (List[dict])
 
 

--- a/mmdet/evaluation/functional/mean_ap.py
+++ b/mmdet/evaluation/functional/mean_ap.py
@@ -93,8 +93,8 @@ def tpfp_imagenet(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -202,8 +202,8 @@ def tpfp_default(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -317,8 +317,8 @@ def tpfp_openimages(det_bboxes,
 
     # an indicator of ignored gts
     gt_ignore_inds = np.concatenate(
-        (np.zeros(gt_bboxes.shape[0], dtype=np.bool),
-         np.ones(gt_bboxes_ignore.shape[0], dtype=np.bool)))
+        (np.zeros(gt_bboxes.shape[0],
+                  dtype=bool), np.ones(gt_bboxes_ignore.shape[0], dtype=bool)))
     # stack gt_bboxes and gt_bboxes_ignore for convenience
     gt_bboxes = np.vstack((gt_bboxes, gt_bboxes_ignore))
 
@@ -517,7 +517,7 @@ def get_cls_group_ofs(annotations, class_id):
         if ann.get('gt_is_group_ofs', None) is not None:
             gt_group_ofs.append(ann['gt_is_group_ofs'][gt_inds])
         else:
-            gt_group_ofs.append(np.empty((0, 1), dtype=np.bool))
+            gt_group_ofs.append(np.empty((0, 1), dtype=bool))
 
     return gt_group_ofs
 

--- a/mmdet/models/task_modules/samplers/iou_balanced_neg_sampler.py
+++ b/mmdet/models/task_modules/samplers/iou_balanced_neg_sampler.py
@@ -73,7 +73,7 @@ class IoUBalancedNegSampler(RandomSampler):
                 tmp_sampled_set = self.random_choice(tmp_inds,
                                                      per_num_expected)
             else:
-                tmp_sampled_set = np.array(tmp_inds, dtype=np.int)
+                tmp_sampled_set = np.array(tmp_inds, dtype=np.int64)
             sampled_inds.append(tmp_sampled_set)
 
         sampled_inds = np.concatenate(sampled_inds)
@@ -138,13 +138,13 @@ class IoUBalancedNegSampler(RandomSampler):
                         iou_sampling_neg_inds, num_expected_iou_sampling)
             else:
                 iou_sampled_inds = np.array(
-                    iou_sampling_neg_inds, dtype=np.int)
+                    iou_sampling_neg_inds, dtype=np.int64)
             num_expected_floor = num_expected - len(iou_sampled_inds)
             if len(floor_neg_inds) > num_expected_floor:
                 sampled_floor_inds = self.random_choice(
                     floor_neg_inds, num_expected_floor)
             else:
-                sampled_floor_inds = np.array(floor_neg_inds, dtype=np.int)
+                sampled_floor_inds = np.array(floor_neg_inds, dtype=np.int64)
             sampled_inds = np.concatenate(
                 (sampled_floor_inds, iou_sampled_inds))
             if len(sampled_inds) < num_expected:

--- a/mmdet/structures/mask/structures.py
+++ b/mmdet/structures/mask/structures.py
@@ -235,7 +235,7 @@ class BitmapMasks(BaseInstanceMasks):
         >>> from mmdet.data_elements.mask.structures import *  # NOQA
         >>> num_masks, H, W = 3, 32, 32
         >>> rng = np.random.RandomState(0)
-        >>> masks = (rng.rand(num_masks, H, W) > 0.1).astype(np.int)
+        >>> masks = (rng.rand(num_masks, H, W) > 0.1).astype(np.int64)
         >>> self = BitmapMasks(masks, height=H, width=W)
 
         >>> # demo crop_and_resize
@@ -824,7 +824,7 @@ class PolygonMasks(BaseInstanceMasks):
         """Translate the PolygonMasks.
 
         Example:
-            >>> self = PolygonMasks.random(dtype=np.int)
+            >>> self = PolygonMasks.random(dtype=np.int64)
             >>> out_shape = (self.height, self.width)
             >>> new = self.translate(out_shape, 4., direction='horizontal')
             >>> assert np.all(new.masks[0][0][1::2] == self.masks[0][0][1::2])

--- a/mmdet/testing/_utils.py
+++ b/mmdet/testing/_utils.py
@@ -81,7 +81,7 @@ def _rand_masks(rng, num_boxes, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int64)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/mmdet/visualization/local_visualizer.py
+++ b/mmdet/visualization/local_visualizer.py
@@ -168,7 +168,7 @@ class DetLocalVisualizer(Visualizer):
             elif isinstance(masks, (PolygonMasks, BitmapMasks)):
                 masks = masks.to_ndarray()
 
-            masks = masks.astype(np.bool)
+            masks = masks.astype(bool)
 
             max_label = int(max(labels) if len(labels) > 0 else 0)
             mask_color = palette if self.mask_color is None \

--- a/tests/test_datasets/test_transforms/test_formatting.py
+++ b/tests/test_datasets/test_transforms/test_formatting.py
@@ -35,7 +35,7 @@ class TestPackDetInputs(unittest.TestCase):
             'gt_masks':
             BitmapMasks(rng.rand(3, 300, 400), height=300, width=400),
             'gt_bboxes_labels': rng.rand(3, ),
-            'gt_ignore_flags': np.array([0, 0, 1], dtype=np.bool),
+            'gt_ignore_flags': np.array([0, 0, 1], dtype=bool),
             'proposals': rng.rand(2, 4),
             'proposals_scores': rng.rand(2, )
         }

--- a/tests/test_datasets/test_transforms/test_loading.py
+++ b/tests/test_datasets/test_transforms/test_loading.py
@@ -71,7 +71,7 @@ class TestLoadAnnotations(unittest.TestCase):
         self.assertEqual(results['gt_bboxes'].dtype, np.float32)
         self.assertTrue((results['gt_ignore_flags'] == np.array([0, 0,
                                                                  1])).all())
-        self.assertEqual(results['gt_ignore_flags'].dtype, np.bool)
+        self.assertEqual(results['gt_ignore_flags'].dtype, bool)
 
     def test_load_labels(self):
         transform = LoadAnnotations(

--- a/tests/test_datasets/test_transforms/test_transforms.py
+++ b/tests/test_datasets/test_transforms/test_transforms.py
@@ -922,7 +922,7 @@ class TestMosaic(unittest.TestCase):
     def test_transform_with_no_gt(self):
         self.results['gt_bboxes'] = np.empty((0, 4), dtype=np.float32)
         self.results['gt_bboxes_labels'] = np.empty((0, ), dtype=np.int64)
-        self.results['gt_ignore_flags'] = np.empty((0, ), dtype=np.bool)
+        self.results['gt_ignore_flags'] = np.empty((0, ), dtype=bool)
         transform = Mosaic(img_scale=(12, 10))
         self.results['mix_results'] = [copy.deepcopy(self.results)] * 3
         results = transform(copy.deepcopy(self.results))
@@ -1532,7 +1532,7 @@ class TestAlbu(unittest.TestCase):
         results = albu_transform(results)
         self.assertEqual(results['img'].dtype, np.float64)
         self.assertEqual(results['gt_bboxes'].dtype, np.float32)
-        self.assertEqual(results['gt_ignore_flags'].dtype, np.bool)
+        self.assertEqual(results['gt_ignore_flags'].dtype, bool)
         self.assertEqual(results['gt_bboxes_labels'].dtype, np.int64)
 
     @unittest.skipIf(albumentations is None, 'albumentations is not installed')

--- a/tests/test_models/test_dense_heads/test_boxinst_head.py
+++ b/tests/test_models/test_dense_heads/test_boxinst_head.py
@@ -17,7 +17,7 @@ def _rand_masks(num_items, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int64)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/tests/test_models/test_dense_heads/test_condinst_head.py
+++ b/tests/test_models/test_dense_heads/test_condinst_head.py
@@ -16,7 +16,7 @@ def _rand_masks(num_items, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int64)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/tests/test_models/test_dense_heads/test_solo_head.py
+++ b/tests/test_models/test_dense_heads/test_solo_head.py
@@ -19,7 +19,7 @@ def _rand_masks(num_items, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int64)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/tests/test_models/test_dense_heads/test_solov2_head.py
+++ b/tests/test_models/test_dense_heads/test_solov2_head.py
@@ -17,7 +17,7 @@ def _rand_masks(num_items, bboxes, img_w, img_h):
     for i, bbox in enumerate(bboxes):
         bbox = bbox.astype(np.int32)
         mask = (rng.rand(1, bbox[3] - bbox[1], bbox[2] - bbox[0]) >
-                0.3).astype(np.int)
+                0.3).astype(np.int64)
         masks[i:i + 1, bbox[1]:bbox[3], bbox[0]:bbox[2]] = mask
     return BitmapMasks(masks, height=img_h, width=img_w)
 

--- a/tools/analysis_tools/browse_dataset.py
+++ b/tools/analysis_tools/browse_dataset.py
@@ -2,7 +2,6 @@
 import argparse
 import os.path as osp
 
-import numpy as np
 from mmengine.config import Config, DictAction
 from mmengine.utils import ProgressBar
 
@@ -71,7 +70,7 @@ def main():
         gt_masks = gt_instances.get('masks', None)
         if gt_masks is not None:
             masks = mask2ndarray(gt_masks)
-            gt_instances.masks = masks.astype(np.bool)
+            gt_instances.masks = masks.astype(bool)
         data_sample.gt_instances = gt_instances
 
         visualizer.add_datasample(


### PR DESCRIPTION
## Motivation

Deprecating old type alias due to new version of numpy.

## Modification

1. Replace all `np.int` with `np.int64`.
2. Replace all `np.bool` with `bool`.