### PR TITLE
[Fix] Fix inconsistent float precision between mmdet and mmcv

### DIFF
--- a/mmdet/datasets/coco.py
+++ b/mmdet/datasets/coco.py
@@ -525,7 +525,7 @@ class CocoDataset(CustomDataset):
 
                 for item in metric_items:
                     val = float(
-                        f'{cocoEval.stats[coco_metric_names[item]]:.3f}')
+                        f'{cocoEval.stats[coco_metric_names[item]]:.4f}')
                     eval_results[item] = val
             else:
                 cocoEval.evaluate()
@@ -579,13 +579,13 @@ class CocoDataset(CustomDataset):
                 for metric_item in metric_items:
                     key = f'{metric}_{metric_item}'
                     val = float(
-                        f'{cocoEval.stats[coco_metric_names[metric_item]]:.3f}'
+                        f'{cocoEval.stats[coco_metric_names[metric_item]]:.4f}'
                     )
                     eval_results[key] = val
                 ap = cocoEval.stats[:6]
                 eval_results[f'{metric}_mAP_copypaste'] = (
-                    f'{ap[0]:.3f} {ap[1]:.3f} {ap[2]:.3f} {ap[3]:.3f} '
-                    f'{ap[4]:.3f} {ap[5]:.3f}')
+                    f'{ap[0]:.4f} {ap[1]:.4f} {ap[2]:.4f} {ap[3]:.4f} '
+                    f'{ap[4]:.4f} {ap[5]:.4f}')
 
         return eval_results
 

--- a/mmdet/datasets/lvis.py
+++ b/mmdet/datasets/lvis.py
@@ -408,7 +408,7 @@ class LVISV05Dataset(CocoDataset):
                 lvis_eval.summarize()
                 for k, v in lvis_eval.get_results().items():
                     if k.startswith('AR'):
-                        val = float('{:.3f}'.format(float(v)))
+                        val = float('{:.4f}'.format(float(v)))
                         eval_results[k] = val
             else:
                 lvis_eval.evaluate()
@@ -454,10 +454,10 @@ class LVISV05Dataset(CocoDataset):
                 for k, v in lvis_results.items():
                     if k.startswith('AP'):
                         key = '{}_{}'.format(metric, k)
-                        val = float('{:.3f}'.format(float(v)))
+                        val = float('{:.4f}'.format(float(v)))
                         eval_results[key] = val
                 ap_summary = ' '.join([
-                    '{}:{:.3f}'.format(k, float(v))
+                    '{}:{:.4f}'.format(k, float(v))
                     for k, v in lvis_results.items() if k.startswith('AP')
                 ])
                 eval_results['{}_mAP_copypaste'.format(metric)] = ap_summary

--- a/tests/test_data/test_datasets/test_panoptic_dataset.py
+++ b/tests/test_data/test_datasets/test_panoptic_dataset.py
@@ -444,13 +444,13 @@ def test_instance_segmentation_evaluation():
 
     # Here is the results for instance segmentation:
     # {
-    #     'segm_mAP': 0.5, 'segm_mAP_50': 0.626, 'segm_mAP_75': 0.5,
+    #     'segm_mAP': 0.5005, 'segm_mAP_50': 0.626, 'segm_mAP_75': 0.5,
     #     'segm_mAP_s': 0.5, 'segm_mAP_m': -1.0, 'segm_mAP_l': -1.0,
     #     'segm_mAP_copypaste': '0.500 0.626 0.500 0.500 -1.000 -1.000',
-    #     'bbox_mAP': 0.564, 'bbox_mAP_50': 0.626, 'bbox_mAP_75': 0.626,
+    #     'bbox_mAP': 0.5636, 'bbox_mAP_50': 0.626, 'bbox_mAP_75': 0.626,
     #     'bbox_mAP_s': 0.564, 'bbox_mAP_m': -1.0, 'bbox_mAP_l': -1.0,
     #     'bbox_mAP_copypaste': '0.564 0.626 0.626 0.564 -1.000 -1.000'
     # }
 
-    assert np.isclose(parsed_results['segm_mAP'], 0.5)
-    assert np.isclose(parsed_results['bbox_mAP'], 0.564)
+    assert np.isclose(parsed_results['segm_mAP'], 0.5005)
+    assert np.isclose(parsed_results['bbox_mAP'], 0.5636)


### PR DESCRIPTION
In coco.py and lvis.py, the float precision of bbox mAP of eval_result of evaluate() function is .3f,
However, in the float precision when printing log in mmcv is .4f, 
see:
https://github.com/open-mmlab/mmcv/blob/ea173c9f07f0abf6873d2b7d786fb6411843cf00/mmcv/runner/hooks/logger/text.py#L178-L179

This PR suggests using the same .4f float precision. Another solution is not to limit the float precision in eval_result.

Fix #9569