### PR TITLE
[Feature] Support ConvNeXt-V2.

### DIFF
--- a/projects/ConvNeXt-V2/README.md
+++ b/projects/ConvNeXt-V2/README.md
@@ -1,0 +1,39 @@
+# ConvNeXt-V2
+
+> [ConvNeXt V2: Co-designing and Scaling ConvNets with Masked Autoencoders](http://arxiv.org/abs/2301.00808)
+
+## Abstract
+
+Driven by improved architectures and better representation learning frameworks, the field of visual recognition has enjoyed rapid modernization and performance boost in the early 2020s. For example, modern ConvNets, represented by ConvNeXt \[52\], have demonstrated strong performance in various scenarios. While these models were originally designed for supervised learning with ImageNet labels, they can also potentially benefit from self-supervised learning techniques such as masked autoencoders (MAE) . However, we found that simply combining these two approaches leads to subpar performance. In this paper, we propose a fully convolutional masked autoencoder framework and a new Global Response Normalization (GRN) layer that can be added to the ConvNeXt architecture to enhance inter-channel feature competition. This co-design of self-supervised learning techniques and architectural improvement results in a new model family called ConvNeXt V2, which significantly improves the performance of pure ConvNets on various recognition benchmarks, including ImageNet classification, COCO detection, and ADE20K segmentation. We also provide pre-trained ConvNeXt V2 models of various sizes, ranging from an efficient 3.7Mparameter Atto model with 76.7% top-1 accuracy on Im-ageNet, to a 650M Huge model that achieves a state-of-theart 88.9% accuracy using only public training data.
+
+<div align=center>
+<img src="https://user-images.githubusercontent.com/12907710/212588579-02d621d8-5796-4f0d-b4d2-758fe9c2f395.png" width="90%"/>
+</div>
+
+## Results and models
+
+|   Method   |   Backbone    | Pretrain | Lr schd | Augmentation | Mem (GB) | box AP | mask AP |                              Config                               |        Download         |
+| :--------: | :-----------: | :------: | :-----: | :----------: | :------: | :----: | :-----: | :---------------------------------------------------------------: | :---------------------: |
+| Mask R-CNN | ConvNeXt-V2-B |  FCMAE   |   3x    |     LSJ      |   22.5   |  52.9  |  46.4   | [config](./mask-rcnn_convnext-t-p4-w7_fpn_amp-ms-crop-3x_coco.py) | [model](-)  \| [log](-) |
+
+**Note**:
+
+- This is a pre-release version of ConvNeXt-V2 object detection. The official finetuning setting of ConvNeXt-V2 has not been released yet.
+- ConvNeXt backbone needs to install [MMClassification dev-1.x branch](https://github.com/open-mmlab/mmclassification/tree/dev-1.x) first, which has abundant backbones for downstream tasks.
+
+```shell
+git clone -b dev-1.x https://github.com/open-mmlab/mmclassification.git
+cd mmclassification
+pip install -U openmim && mim install -e .
+```
+
+## Citation
+
+```bibtex
+@article{Woo2023ConvNeXtV2,
+  title={ConvNeXt V2: Co-designing and Scaling ConvNets with Masked Autoencoders},
+  author={Sanghyun Woo, Shoubhik Debnath, Ronghang Hu, Xinlei Chen, Zhuang Liu, In So Kweon and Saining Xie},
+  year={2023},
+  journal={arXiv preprint arXiv:2301.00808},
+}
+```

--- a/projects/ConvNeXt-V2/README.md
+++ b/projects/ConvNeXt-V2/README.md
@@ -12,9 +12,9 @@ Driven by improved architectures and better representation learning frameworks, 
 
 ## Results and models
 
-|   Method   |   Backbone    | Pretrain | Lr schd | Augmentation | Mem (GB) | box AP | mask AP |                              Config                               |        Download         |
-| :--------: | :-----------: | :------: | :-----: | :----------: | :------: | :----: | :-----: | :---------------------------------------------------------------: | :---------------------: |
-| Mask R-CNN | ConvNeXt-V2-B |  FCMAE   |   3x    |     LSJ      |   22.5   |  52.9  |  46.4   | [config](./mask-rcnn_convnext-t-p4-w7_fpn_amp-ms-crop-3x_coco.py) | [model](-)  \| [log](-) |
+|   Method   |   Backbone    | Pretrain | Lr schd | Augmentation | Mem (GB) | box AP | mask AP |                            Config                            |                                                                                                                                                                                        Download                                                                                                                                                                                         |
+| :--------: | :-----------: | :------: | :-----: | :----------: | :------: | :----: | :-----: | :----------------------------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+| Mask R-CNN | ConvNeXt-V2-B |  FCMAE   |   3x    |     LSJ      |   22.5   |  52.9  |  46.4   | [config](./mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py) | [model](https://download.openmmlab.com/mmdetection/v3.0/convnextv2/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco_20230113_110947-757ee2dd.pth)  \| [log](https://download.openmmlab.com/mmdetection/v3.0/convnextv2/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco_20230113_110947.log.json) |
 
 **Note**:
 

--- a/projects/ConvNeXt-V2/README.md
+++ b/projects/ConvNeXt-V2/README.md
@@ -7,7 +7,7 @@
 Driven by improved architectures and better representation learning frameworks, the field of visual recognition has enjoyed rapid modernization and performance boost in the early 2020s. For example, modern ConvNets, represented by ConvNeXt \[52\], have demonstrated strong performance in various scenarios. While these models were originally designed for supervised learning with ImageNet labels, they can also potentially benefit from self-supervised learning techniques such as masked autoencoders (MAE) . However, we found that simply combining these two approaches leads to subpar performance. In this paper, we propose a fully convolutional masked autoencoder framework and a new Global Response Normalization (GRN) layer that can be added to the ConvNeXt architecture to enhance inter-channel feature competition. This co-design of self-supervised learning techniques and architectural improvement results in a new model family called ConvNeXt V2, which significantly improves the performance of pure ConvNets on various recognition benchmarks, including ImageNet classification, COCO detection, and ADE20K segmentation. We also provide pre-trained ConvNeXt V2 models of various sizes, ranging from an efficient 3.7Mparameter Atto model with 76.7% top-1 accuracy on Im-ageNet, to a 650M Huge model that achieves a state-of-theart 88.9% accuracy using only public training data.
 
 <div align=center>
-<img src="https://user-images.githubusercontent.com/12907710/212588579-02d621d8-5796-4f0d-b4d2-758fe9c2f395.png" width="90%"/>
+<img src="https://user-images.githubusercontent.com/12907710/212588579-02d621d8-5796-4f0d-b4d2-758fe9c2f395.png" width="50%"/>
 </div>
 
 ## Results and models

--- a/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
+++ b/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
@@ -1,7 +1,8 @@
 _base_ = [
-    '../_base_/models/mask-rcnn_r50_fpn.py',
-    '../_base_/datasets/coco_instance.py',
-    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+    'mmdet::_base_/models/mask-rcnn_r50_fpn.py',
+    'mmdet::_base_/datasets/coco_instance.py',
+    'mmdet::_base_/schedules/schedule_1x.py',
+    'mmdet::_base_/default_runtime.py'
 ]
 
 # please install mmcls>=1.0
@@ -19,9 +20,9 @@ model = dict(
         # TODO: verify stochastic depth rate {0.1, 0.2, 0.3, 0.4}
         # drop_path_rate=[0.1] * 3 + [0.2] * 3 + [0.3] * 27 + [0.4] * 3,
         drop_path_rate=0.4,
-        layer_scale_init_value=1.0,
+        layer_scale_init_value=0.,  # disable layer scale when using GRN
         gap_before_final_norm=False,
-        use_grn=True,
+        use_grn=True,  # V2 uses GRN
         init_cfg=dict(
             type='Pretrained', checkpoint=checkpoint_file,
             prefix='backbone.')),

--- a/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
+++ b/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
@@ -1,0 +1,91 @@
+_base_ = [
+    '../_base_/models/mask-rcnn_r50_fpn.py',
+    '../_base_/datasets/coco_instance.py',
+    '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
+]
+
+# please install mmcls>=1.0
+# import mmcls.models to trigger register_module in mmcls
+custom_imports = dict(imports=['mmcls.models'], allow_failed_imports=False)
+checkpoint_file = 'https://download.openmmlab.com/mmclassification/v0/convnext-v2/convnext-v2-base_3rdparty-fcmae_in1k_20230104-8a798eaf.pth'  # noqa
+image_size = (1024, 1024)
+
+model = dict(
+    backbone=dict(
+        _delete_=True,
+        type='mmcls.ConvNeXt',
+        arch='base',
+        out_indices=[0, 1, 2, 3],
+        # TODO: verify stochastic depth rate {0.1, 0.2, 0.3, 0.4}
+        # drop_path_rate=[0.1] * 3 + [0.2] * 3 + [0.3] * 27 + [0.4] * 3,
+        drop_path_rate=0.4,
+        layer_scale_init_value=1.0,
+        gap_before_final_norm=False,
+        use_grn=True,
+        init_cfg=dict(
+            type='Pretrained', checkpoint=checkpoint_file,
+            prefix='backbone.')),
+    neck=dict(in_channels=[128, 256, 512, 1024]),
+    test_cfg=dict(
+        rpn=dict(nms=dict(type='nms')),  # TODO: does RPN use soft_nms?
+        rcnn=dict(nms=dict(type='soft_nms'))))
+
+train_pipeline = [
+    dict(type='LoadImageFromFile', file_client_args=_base_.file_client_args),
+    dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
+    dict(
+        type='RandomResize',
+        scale=image_size,
+        ratio_range=(0.1, 2.0),
+        keep_ratio=True),
+    dict(
+        type='RandomCrop',
+        crop_type='absolute_range',
+        crop_size=image_size,
+        recompute_bbox=True,
+        allow_negative_crop=True),
+    dict(type='FilterAnnotations', min_gt_bbox_wh=(1e-2, 1e-2)),
+    dict(type='RandomFlip', prob=0.5),
+    dict(type='PackDetInputs')
+]
+
+train_dataloader = dict(
+    batch_size=4,  # total_batch_size 32 = 8 GPUS x 4 images
+    num_workers=8,
+    dataset=dict(pipeline=train_pipeline))
+
+max_epochs = 36
+train_cfg = dict(max_epochs=max_epochs)
+
+# learning rate
+param_scheduler = [
+    dict(
+        type='LinearLR', start_factor=0.001, by_epoch=False, begin=0,
+        end=1000),
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=max_epochs,
+        by_epoch=True,
+        milestones=[27, 33],
+        gamma=0.1)
+]
+
+# Enable automatic-mixed-precision training with AmpOptimWrapper.
+optim_wrapper = dict(
+    type='AmpOptimWrapper',
+    constructor='LearningRateDecayOptimizerConstructor',
+    paramwise_cfg={
+        'decay_rate': 0.95,
+        'decay_type': 'layer_wise',  # TODO: sweep layer-wise lr decay?
+        'num_layers': 12
+    },
+    optimizer=dict(
+        _delete_=True,
+        type='AdamW',
+        lr=0.0001,
+        betas=(0.9, 0.999),
+        weight_decay=0.05,
+    ))
+
+default_hooks = dict(checkpoint=dict(max_keep_ckpts=1))

--- a/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
+++ b/projects/ConvNeXt-V2/configs/mask-rcnn_convnext-v2-b_fpn_lsj-3x-fcmae_coco.py
@@ -5,7 +5,7 @@ _base_ = [
     'mmdet::_base_/default_runtime.py'
 ]
 
-# please install mmcls>=1.0
+# please install the mmclassification dev-1.x branch
 # import mmcls.models to trigger register_module in mmcls
 custom_imports = dict(imports=['mmcls.models'], allow_failed_imports=False)
 checkpoint_file = 'https://download.openmmlab.com/mmclassification/v0/convnext-v2/convnext-v2-base_3rdparty-fcmae_in1k_20230104-8a798eaf.pth'  # noqa
@@ -18,7 +18,6 @@ model = dict(
         arch='base',
         out_indices=[0, 1, 2, 3],
         # TODO: verify stochastic depth rate {0.1, 0.2, 0.3, 0.4}
-        # drop_path_rate=[0.1] * 3 + [0.2] * 3 + [0.3] * 27 + [0.4] * 3,
         drop_path_rate=0.4,
         layer_scale_init_value=0.,  # disable layer scale when using GRN
         gap_before_final_norm=False,


### PR DESCRIPTION
## Support ConvNeXt-V2

This PR gives an example of using ConvNeXt-V2 in mmdetection.

It requires the latest version of mmclassification-1.x.

## Notice

The **official finetuning setting of object detection is not released yet**. 

There are at least three settings unknown:

- [ ] What is stochastic depth rate {0.1, 0.2, 0.3, 0.4} mean?
- [ ] Does RPN use soft_nms?
- [ ] What is sweep layer-wise lr decay?

Training result:

```
01/14 20:43:26 - mmengine - [4m[37mINFO[0m - Evaluating bbox...
Loading and preparing results...
DONE (t=0.94s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *bbox*
DONE (t=39.44s).
Accumulating evaluation results...
DONE (t=6.56s).
Average Precision (AP) @[ IoU=0.50:0.95 | area= all | maxDets=100 ] = 0.529
Average Precision (AP) @[ IoU=0.50 | area= all | maxDets=1000 ] = 0.727
Average Precision (AP) @[ IoU=0.75 | area= all | maxDets=1000 ] = 0.587
Average Precision (AP) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.359
Average Precision (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.573
Average Precision (AP) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.670
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=100 ] = 0.694
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=300 ] = 0.694
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=1000 ] = 0.694
Average Recall (AR) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.523
Average Recall (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.742
Average Recall (AR) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.836
01/14 20:44:14 - mmengine - [4m[37mINFO[0m - bbox_mAP_copypaste: 0.529 0.727 0.587 0.359 0.573 0.670
01/14 20:44:14 - mmengine - [4m[37mINFO[0m - Evaluating segm...
Loading and preparing results...
DONE (t=2.69s)
creating index...
index created!
Running per image evaluation...
Evaluate annotation type *segm*
DONE (t=43.78s).
Accumulating evaluation results...
DONE (t=6.45s).
Average Precision (AP) @[ IoU=0.50:0.95 | area= all | maxDets=100 ] = 0.464
Average Precision (AP) @[ IoU=0.50 | area= all | maxDets=1000 ] = 0.699
Average Precision (AP) @[ IoU=0.75 | area= all | maxDets=1000 ] = 0.508
Average Precision (AP) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.273
Average Precision (AP) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.498
Average Precision (AP) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.649
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=100 ] = 0.601
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=300 ] = 0.601
Average Recall (AR) @[ IoU=0.50:0.95 | area= all | maxDets=1000 ] = 0.601
Average Recall (AR) @[ IoU=0.50:0.95 | area= small | maxDets=1000 ] = 0.436
Average Recall (AR) @[ IoU=0.50:0.95 | area=medium | maxDets=1000 ] = 0.639
Average Recall (AR) @[ IoU=0.50:0.95 | area= large | maxDets=1000 ] = 0.750
01/14 20:45:11 - mmengine - [4m[37mINFO[0m - segm_mAP_copypaste: 0.464 0.699 0.508 0.273 0.498 0.649
01/14 20:45:12 - mmengine - [4m[37mINFO[0m - Epoch(val) [36][625/625] coco/bbox_mAP: 0.5290 coco/bbox_mAP_50: 0.7270 coco/bbox_mAP_75: 0.5870 coco/bbox_mAP_s: 0.3590 coco/bbox_mAP_m: 0.5730 coco/bbox_mAP_l: 0.6700 coco/segm_mAP: 0.4640 coco/segm_mAP_50: 0.6990 coco/segm_mAP_75: 0.5080 coco/segm_mAP_s: 0.2730 coco/segm_mAP_m: 0.4980 coco/segm_mAP_l: 0.6490
```

The box AP is aligned with the paper, but the mask AP has a gap of 0.2%.