### PR TITLE
[Fix] Metafile.yml: Fix typo of all config file path.

### DIFF
--- a/configs/dcnv2/metafile.yml
+++ b/configs/dcnv2/metafile.yml
@@ -19,7 +19,7 @@ Collections:
 Models:
   - Name: faster_rcnn_r50_fpn_mdconv_c3-c5_1x_coco
     In Collection: Deformable Convolutional Networks v2
-    Config: configs/dcn/faster_rcnn_r50_fpn_mdconv_c3-c5_1x_coco.py
+    Config: configs/dcnv2/faster_rcnn_r50_fpn_mdconv_c3-c5_1x_coco.py
     Metadata:
       Training Memory (GB): 4.1
       inference time (ms/im):
@@ -39,7 +39,7 @@ Models:
 
   - Name: faster_rcnn_r50_fpn_mdconv_c3-c5_group4_1x_coco
     In Collection: Deformable Convolutional Networks v2
-    Config: configs/dcn/faster_rcnn_r50_fpn_mdconv_c3-c5_group4_1x_coco.py
+    Config: configs/dcnv2/faster_rcnn_r50_fpn_mdconv_c3-c5_group4_1x_coco.py
     Metadata:
       Training Memory (GB): 4.2
       inference time (ms/im):
@@ -59,7 +59,7 @@ Models:
 
   - Name: faster_rcnn_r50_fpn_mdpool_1x_coco
     In Collection: Deformable Convolutional Networks v2
-    Config: configs/dcn/faster_rcnn_r50_fpn_mdpool_1x_coco.py
+    Config: configs/dcnv2/faster_rcnn_r50_fpn_mdpool_1x_coco.py
     Metadata:
       Training Memory (GB): 5.8
       inference time (ms/im):
@@ -79,7 +79,7 @@ Models:
 
   - Name: mask_rcnn_r50_fpn_mdconv_c3-c5_1x_coco
     In Collection: Deformable Convolutional Networks v2
-    Config: configs/dcn/mask_rcnn_r50_fpn_mdconv_c3-c5_1x_coco.py
+    Config: configs/dcnv2/mask_rcnn_r50_fpn_mdconv_c3-c5_1x_coco.py
     Metadata:
       Training Memory (GB): 4.5
       inference time (ms/im):
@@ -103,7 +103,7 @@ Models:
 
   - Name: mask_rcnn_r50_fpn_fp16_mdconv_c3-c5_1x_coco
     In Collection: Deformable Convolutional Networks v2
-    Config: configs/dcn/mask_rcnn_r50_fpn_fp16_mdconv_c3-c5_1x_coco.py
+    Config: configs/dcnv2/mask_rcnn_r50_fpn_fp16_mdconv_c3-c5_1x_coco.py
     Metadata:
       Training Memory (GB): 3.1
       Training Techniques:

--- a/configs/gn+ws/metafile.yml
+++ b/configs/gn+ws/metafile.yml
@@ -14,13 +14,13 @@ Collections:
       Title: 'Weight Standardization'
     README: configs/gn+ws/README.md
     Code:
-      URL: https://github.com/open-mmlab/mmdetection/blob/v2.0.0/configs/gn%2Bws/mask_rcnn_r50_fpn_gn_ws-all_2x_coco.py
+      URL: https://github.com/open-mmlab/mmdetection/blob/v2.0.0/configs/gn+ws/mask_rcnn_r50_fpn_gn_ws-all_2x_coco.py
       Version: v2.0.0
 
 Models:
   - Name: faster_rcnn_r50_fpn_gn_ws-all_1x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/faster_rcnn_r50_fpn_gn_ws-all_1x_coco.py
+    Config: configs/gn+ws/faster_rcnn_r50_fpn_gn_ws-all_1x_coco.py
     Metadata:
       Training Memory (GB): 5.9
       inference time (ms/im):
@@ -40,7 +40,7 @@ Models:
 
   - Name: faster_rcnn_r101_fpn_gn_ws-all_1x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/faster_rcnn_r101_fpn_gn_ws-all_1x_coco.py
+    Config: configs/gn+ws/faster_rcnn_r101_fpn_gn_ws-all_1x_coco.py
     Metadata:
       Training Memory (GB): 8.9
       inference time (ms/im):
@@ -60,7 +60,7 @@ Models:
 
   - Name: faster_rcnn_x50_32x4d_fpn_gn_ws-all_1x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/faster_rcnn_x50_32x4d_fpn_gn_ws-all_1x_coco.py
+    Config: configs/gn+ws/faster_rcnn_x50_32x4d_fpn_gn_ws-all_1x_coco.py
     Metadata:
       Training Memory (GB): 7.0
       inference time (ms/im):
@@ -80,7 +80,7 @@ Models:
 
   - Name: faster_rcnn_x101_32x4d_fpn_gn_ws-all_1x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/faster_rcnn_x101_32x4d_fpn_gn_ws-all_1x_coco.py
+    Config: configs/gn+ws/faster_rcnn_x101_32x4d_fpn_gn_ws-all_1x_coco.py
     Metadata:
       Training Memory (GB): 10.8
       inference time (ms/im):
@@ -100,7 +100,7 @@ Models:
 
   - Name: mask_rcnn_r50_fpn_gn_ws-all_2x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_r50_fpn_gn_ws-all_2x_coco.py
+    Config: configs/gn+ws/mask_rcnn_r50_fpn_gn_ws-all_2x_coco.py
     Metadata:
       Training Memory (GB): 7.3
       inference time (ms/im):
@@ -124,7 +124,7 @@ Models:
 
   - Name: mask_rcnn_r101_fpn_gn_ws-all_2x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_r101_fpn_gn_ws-all_2x_coco.py
+    Config: configs/gn+ws/mask_rcnn_r101_fpn_gn_ws-all_2x_coco.py
     Metadata:
       Training Memory (GB): 10.3
       inference time (ms/im):
@@ -148,7 +148,7 @@ Models:
 
   - Name: mask_rcnn_x50_32x4d_fpn_gn_ws-all_2x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_x50_32x4d_fpn_gn_ws-all_2x_coco.py
+    Config: configs/gn+ws/mask_rcnn_x50_32x4d_fpn_gn_ws-all_2x_coco.py
     Metadata:
       Training Memory (GB): 8.4
       inference time (ms/im):
@@ -172,7 +172,7 @@ Models:
 
   - Name: mask_rcnn_x101_32x4d_fpn_gn_ws-all_2x_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_x101_32x4d_fpn_gn_ws-all_2x_coco.py
+    Config: configs/gn+ws/mask_rcnn_x101_32x4d_fpn_gn_ws-all_2x_coco.py
     Metadata:
       Training Memory (GB): 12.2
       inference time (ms/im):
@@ -196,7 +196,7 @@ Models:
 
   - Name: mask_rcnn_r50_fpn_gn_ws-all_20_23_24e_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_r50_fpn_gn_ws-all_20_23_24e_coco.py
+    Config: configs/gn+ws/mask_rcnn_r50_fpn_gn_ws-all_20_23_24e_coco.py
     Metadata:
       Training Memory (GB): 7.3
       Epochs: 24
@@ -213,7 +213,7 @@ Models:
 
   - Name: mask_rcnn_r101_fpn_gn_ws-all_20_23_24e_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_r101_fpn_gn_ws-all_20_23_24e_coco.py
+    Config: configs/gn+ws/mask_rcnn_r101_fpn_gn_ws-all_20_23_24e_coco.py
     Metadata:
       Training Memory (GB): 10.3
       Epochs: 24
@@ -230,7 +230,7 @@ Models:
 
   - Name: mask_rcnn_x50_32x4d_fpn_gn_ws-all_20_23_24e_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_x50_32x4d_fpn_gn_ws-all_20_23_24e_coco.py
+    Config: configs/gn+ws/mask_rcnn_x50_32x4d_fpn_gn_ws-all_20_23_24e_coco.py
     Metadata:
       Training Memory (GB): 8.4
       Epochs: 24
@@ -247,7 +247,7 @@ Models:
 
   - Name: mask_rcnn_x101_32x4d_fpn_gn_ws-all_20_23_24e_coco
     In Collection: Weight Standardization
-    Config: configs/gn%2Bws/mask_rcnn_x101_32x4d_fpn_gn_ws-all_20_23_24e_coco.py
+    Config: configs/gn+ws/mask_rcnn_x101_32x4d_fpn_gn_ws-all_20_23_24e_coco.py
     Metadata:
       Training Memory (GB): 12.2
       Epochs: 24

--- a/configs/rfnext/metafile.yml
+++ b/configs/rfnext/metafile.yml
@@ -18,7 +18,7 @@ Collections:
 Models:
   - Name: rfnext_search_cascade_mask_rcnn_convnext_tiny_patch4_window7_mstrain_480-800_giou_4conv1f_adamw_3x_coco_in1k
     In Collection: RF-Next
-    Config: configs/rfnext/rfnext_search_cascade_mask_rcnn_convnext_tiny_patch4_window7_mstrain_480-800_giou_4conv1f_adamw_3x_coco_in1k.py
+    Config: configs/rfnext/rfnext_search_cascade_mask_rcnn_convnext-t_p4_w7_fpn_giou_4conv1f_fp16_ms-crop_3x_coco.py
     Metadata:
       Training Memory (GB): 11.9
       Epochs: 36
@@ -42,7 +42,7 @@ Models:
 
   - Name: rfnext_fixed_single_branch_cascade_mask_rcnn_convnext_tiny_patch4_window7_mstrain_480-800_giou_4conv1f_adamw_3x_coco_in1k
     In Collection: RF-Next
-    Config: configs/rfnext/rfnext_fixed_single_branch_cascade_mask_rcnn_convnext_tiny_patch4_window7_mstrain_480-800_giou_4conv1f_adamw_3x_coco_in1k.py
+    Config: configs/rfnext/rfnext_fixed_single_branch_cascade_mask_rcnn_convnext-t_p4_w7_fpn_giou_4conv1f_fp16_ms-crop_3x_coco.py
     Metadata:
       Training Memory (GB): 9.4
       Epochs: 36

--- a/configs/seesaw_loss/metafile.yml
+++ b/configs/seesaw_loss/metafile.yml
@@ -23,7 +23,7 @@ Collections:
 Models:
   - Name: mask_rcnn_r50_fpn_random_seesaw_loss_mstrain_2x_lvis_v1
     In Collection: Seesaw Loss
-    Config: seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_mstrain_2x_lvis_v1.py
+    Config: configs/seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_mstrain_2x_lvis_v1.py
     Metadata:
       Epochs: 24
     Results:
@@ -38,7 +38,7 @@ Models:
     Weights: https://download.openmmlab.com/mmdetection/v2.0/seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_mstrain_2x_lvis_v1-a698dd3d.pth
   - Name: mask_rcnn_r50_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1
     In Collection: Seesaw Loss
-    Config: seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1.py
+    Config: configs/seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1.py
     Metadata:
       Epochs: 24
     Results:
@@ -53,7 +53,7 @@ Models:
     Weights: https://download.openmmlab.com/mmdetection/v2.0/seesaw_loss/mask_rcnn_r50_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1-a1c11314.pth
   - Name: mask_rcnn_r101_fpn_random_seesaw_loss_mstrain_2x_lvis_v1
     In Collection: Seesaw Loss
-    Config: seesaw_loss/mask_rcnn_r101_fpn_random_seesaw_loss_mstrain_2x_lvis_v1.py
+    Config: configs/seesaw_loss/mask_rcnn_r101_fpn_random_seesaw_loss_mstrain_2x_lvis_v1.py
     Metadata:
       Epochs: 24
     Results:
@@ -68,7 +68,7 @@ Models:
     Weights: https://download.openmmlab.com/mmdetection/v2.0/seesaw_loss/mask_rcnn_r101_fpn_random_seesaw_loss_mstrain_2x_lvis_v1-8e6e6dd5.pth
   - Name: mask_rcnn_r101_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1
     In Collection: Seesaw Loss
-    Config: seesaw_loss/mask_rcnn_r101_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1.py
+    Config: configs/seesaw_loss/mask_rcnn_r101_fpn_random_seesaw_loss_normed_mask_mstrain_2x_lvis_v1.py
     Metadata:
       Epochs: 24
     Results:


### PR DESCRIPTION
## Motivation

While I look thorough the model zoo using mim, I found that there are some models failed to download because of the wrong config file path in metafile.yml (all weights links are OK btw.)

Related: https://github.com/open-mmlab/mim/pull/192

## Modification

Fix all possible typos in metafile.yml. Now mim should be able to download all model configs without error!

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
