### PR TITLE
namespaced validation logs to prevent overwriting

### DIFF
--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -263,8 +263,13 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
         losses = self(**data)
         loss, log_vars = self._parse_losses(losses)
 
+        log_vars_ = dict()
+        for loss_name, loss_value in log_vars.items():
+            k = loss_name + '_val'
+            log_vars_[k] = loss_value
+
         outputs = dict(
-            loss=loss, log_vars=log_vars, num_samples=len(data['img_metas']))
+            loss=loss, log_vars=log_vars_, num_samples=len(data['img_metas']))
 
         return outputs
 


### PR DESCRIPTION
## Motivation
The validation loss is currently not logged in the setting of both train and val workflow modes.

The problem is described in this issue:
https://github.com/open-mmlab/mmsegmentation/issues/1396
This PR replicates the changes made in this PR to the mmsegmentation library: https://github.com/open-mmlab/mmsegmentation/pull/1494

## Modification

val_step is modified to add _val suffix to all validation losses, to distinguish those losses from those in the training step. This enables both training and validation loss logging.