### PR TITLE
fix amp pooling overflow

### DIFF
--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -115,7 +115,11 @@ class SPPBottleneck(BaseModule):
 
     def forward(self, x):
         x = self.conv1(x)
-        x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1)
+        if x.dtype == torch.float16:
+            x = x.float()
+            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1).half()
+        else:
+            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1)
         x = self.conv2(x)
         return x
 

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -116,7 +116,7 @@ class SPPBottleneck(BaseModule):
     def forward(self, x):
         x = self.conv1(x)
         with torch.autocast(enabled=False):
-            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], 
+            x = torch.cat([x] + [pooling(x) for pooling in self.poolings],
                           dim=1)
         x = self.conv2(x)
         return x

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -117,7 +117,7 @@ class SPPBottleneck(BaseModule):
         x = self.conv1(x)
         with torch.autocast(enabled=False):
             x = torch.cat(
-+                [x] + [pooling(x) for pooling in self.poolings], dim=1)
+                [x] + [pooling(x) for pooling in self.poolings], dim=1)
         x = self.conv2(x)
         return x
 

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -115,10 +115,7 @@ class SPPBottleneck(BaseModule):
 
     def forward(self, x):
         x = self.conv1(x)
-        if x.dtype == torch.float16:
-            x = x.float()
-            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1).half()
-        else:
+        with torch.autocast(enabled=False):
             x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1)
         x = self.conv2(x)
         return x

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -115,7 +115,7 @@ class SPPBottleneck(BaseModule):
 
     def forward(self, x):
         x = self.conv1(x)
-        with torch.autocast(enabled=False):
+        with torch.cuda.amp.autocast(enabled=False):
             x = torch.cat(
                 [x] + [pooling(x) for pooling in self.poolings], dim=1)
         x = self.conv2(x)

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -116,8 +116,8 @@ class SPPBottleneck(BaseModule):
     def forward(self, x):
         x = self.conv1(x)
         with torch.autocast(enabled=False):
-            x = torch.cat([x] + [pooling(x) for pooling in self.poolings],
-                          dim=1)
+            x = torch.cat(
++                [x] + [pooling(x) for pooling in self.poolings], dim=1)
         x = self.conv2(x)
         return x
 

--- a/mmdet/models/backbones/csp_darknet.py
+++ b/mmdet/models/backbones/csp_darknet.py
@@ -116,7 +116,8 @@ class SPPBottleneck(BaseModule):
     def forward(self, x):
         x = self.conv1(x)
         with torch.autocast(enabled=False):
-            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], dim=1)
+            x = torch.cat([x] + [pooling(x) for pooling in self.poolings], 
+                          dim=1)
         x = self.conv2(x)
         return x
 

--- a/mmdet/models/layers/se_layer.py
+++ b/mmdet/models/layers/se_layer.py
@@ -152,7 +152,7 @@ class ChannelAttention(BaseModule):
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward function for ChannelAttention."""
-        with torch.autocast(enabled=False):
+        with torch.cuda.amp.autocast(enabled=False):
             out = self.global_avgpool(x)
         out = self.fc(out)
         out = self.act(out)

--- a/mmdet/models/layers/se_layer.py
+++ b/mmdet/models/layers/se_layer.py
@@ -152,7 +152,10 @@ class ChannelAttention(BaseModule):
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward function for ChannelAttention."""
-        out = self.global_avgpool(x)
+        if x.dtype == torch.float16:
+            out = self.global_avgpool(x.float()).half()
+        else:
+            out = self.global_avgpool(x)
         out = self.fc(out)
         out = self.act(out)
         return x * out

--- a/mmdet/models/layers/se_layer.py
+++ b/mmdet/models/layers/se_layer.py
@@ -152,9 +152,7 @@ class ChannelAttention(BaseModule):
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward function for ChannelAttention."""
-        if x.dtype == torch.float16:
-            out = self.global_avgpool(x.float()).half()
-        else:
+        with torch.autocast(enabled=False):
             out = self.global_avgpool(x)
         out = self.fc(out)
         out = self.act(out)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Pooling, mostly avg pooling and max pooling, in amp(float16) mode may overflow, because when every element in one channel sums up, it might be greater than the upper limit of float16, which is only 65536, then it overflows and starts from the lower limit. This is very common when the weights are not converged.

I trained coco with rtmdet from scratch in amp mode, I encounter nan loss issue. I thought this may be overflowing. And when I turn off amp mode, no more nan issue. So I confirmed this is pooling overflow issue, I know it because I have fixed it in another repo before.

## Modification

Detect whether input tensor dtype in pooling is float16 or float32, if float16, force casting it to float32 and do pooling, then cast the result back to float16.

I tested by training rtmdet on coco from scratch, no more nan. But in other network, this issue may still exist.