### PR TITLE
[dev-3.x][Fix] Fix duplicate param error in DAB-DETR

### DIFF
--- a/configs/dab_detr/dab-detr_r50_8xb2-50e_coco.py
+++ b/configs/dab_detr/dab-detr_r50_8xb2-50e_coco.py
@@ -136,7 +136,8 @@ optim_wrapper = dict(
     optimizer=dict(type='AdamW', lr=0.0001, weight_decay=0.0001),
     clip_grad=dict(max_norm=0.1, norm_type=2),
     paramwise_cfg=dict(
-        custom_keys={'backbone': dict(lr_mult=0.1, decay_mult=1.0)}))
+        custom_keys={'backbone': dict(lr_mult=0.1, decay_mult=1.0)},
+        bypass_duplicate=True))
 
 # learning policy
 max_epochs = 50


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Using `torch==1.9.1`, `mmcv==2.0.0rc2` and `mmengine==0.5.0`,
When running `python3 tools/train.py configs/dab_detr/dab-detr_r50_8xb2-50e_coco.py`
```
File "tools/train.py", line 130, in <module>
    main()
  File "tools/train.py", line 126, in main
    runner.train()
  File "/usr/local/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1661, in train
    self.optim_wrapper = self.build_optim_wrapper(self.optim_wrapper)
  File "/usr/local/lib/python3.8/site-packages/mmengine/runner/runner.py", line 1077, in build_optim_wrapper
    return build_optim_wrapper(self.model, optim_wrapper)
  File "/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/builder.py", line 69, in build_optim_wrapper
    optim_wrapper = optim_wrapper_constructor(model)
  File "/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py", line 301, in __call__
    optimizer = OPTIMIZERS.build(optimizer_cfg)
  File "/usr/local/lib/python3.8/site-packages/mmengine/registry/registry.py", line 521, in build
    return self.build_func(cfg, *args, **kwargs, registry=self)
  File "/usr/local/lib/python3.8/site-packages/mmengine/registry/build_functions.py", line 135, in build_from_cfg
    raise type(e)(
ValueError: class `AdamW` in torch/optim/adamw.py: some parameters appear in more than one parameter group
```

## Modification
Added `bypass_duplicate=True` to `paramwise_cfg` as in https://github.com/open-mmlab/mmdetection/blob/130a620396850baab90bae8d89b992bb00dfcc2d/configs/resnet_strikes_back/faster-rcnn_r50-rsb-pre_fpn_1x_coco.py#L15

Printed log
```
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.0.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.1.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.2.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.3.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.4.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: encoder.layers.5.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.0.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.1.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.2.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.3.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.4.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
/usr/local/lib/python3.8/site-packages/mmengine/optim/optimizer/default_constructor.py:211: UserWarning: decoder.layers.5.ffn.layers.0.1 is duplicate. It is skipped since bypass_duplicate=True
  warnings.warn(f'{prefix} is duplicate. It is skipped since '
```