### PR TITLE
make sure conv2 of CSPNeXtBlock controlled by use_depthwise

### DIFF
--- a/mmdet/models/layers/csp_layer.py
+++ b/mmdet/models/layers/csp_layer.py
@@ -126,7 +126,7 @@ class CSPNeXtBlock(BaseModule):
             padding=1,
             norm_cfg=norm_cfg,
             act_cfg=act_cfg)
-        self.conv2 = DepthwiseSeparableConvModule(
+        self.conv2 = conv(
             hidden_channels,
             out_channels,
             kernel_size,


### PR DESCRIPTION
## Motivation

Whether use_depthwise=False/True, self.conv2 of CSPNeXtBlock is depthwise conv, it's not controlled by this argument.

## Modification
```        
conv = DepthwiseSeparableConvModule if use_depthwise else ConvModule

self.conv2 = DepthwiseSeparableConvModule(
=>
self.conv2 = conv(
```