### PR TITLE
[Fix]: Change MMCV minimum version to 2.0.0rc4 for dev-3.x branch

### DIFF
--- a/docs/en/notes/faq.md
+++ b/docs/en/notes/faq.md
@@ -11,6 +11,7 @@ We list some common troubles faced by many users and their corresponding solutio
   | MMDetection version |      MMCV version       |     MMEngine version     |
   | :-----------------: | :---------------------: | :----------------------: |
   |         3.x         | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
+  |      3.0.0rc6       | mmcv>=2.0.0rc4, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
   |      3.0.0rc5       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
   |      3.0.0rc4       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |
   |      3.0.0rc3       | mmcv>=2.0.0rc1, \<2.1.0 | mmengine>=0.3.0, \<1.0.0 |

--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -5,7 +5,7 @@ from mmengine.utils import digit_version
 
 from .version import __version__, version_info
 
-mmcv_minimum_version = '2.0.0rc0'
+mmcv_minimum_version = '2.0.0rc4'
 mmcv_maximum_version = '2.1.0'
 mmcv_version = digit_version(mmcv.__version__)
 


### PR DESCRIPTION
## Motivation
According to #9692 and [#2444](https://github.com/open-mmlab/mmcv/pull/2444), tackling the _value error_ of optimizer requires the **minimum** version of **MMCV** to be **2.0.0rc4** for supporting dev-3.x branch.