### PR TITLE
[Speed Up ] `BaseBoxes` supports `pin_memory`

### DIFF
--- a/mmdet/structures/bbox/base_boxes.py
+++ b/mmdet/structures/bbox/base_boxes.py
@@ -128,6 +128,11 @@ class BaseBoxes(metaclass=ABCMeta):
             sizes, fill, dtype=dtype, device=device)
         return type(self)(fake_boxes, clone=False)
 
+    def pin_memory(self):
+        """BaseBoxes supports pin_memory function to speed up training."""
+        self.tensor = self.tensor.pin_memory()
+        return self
+
     def __getitem__(self: T, index: IndexType) -> T:
         """Rewrite getitem to protect the last dimension shape."""
         boxes = self.tensor

--- a/tests/test_structures/test_bbox/test_base_boxes.py
+++ b/tests/test_structures/test_bbox/test_base_boxes.py
@@ -274,3 +274,9 @@ class TestBaseBoxes(TestCase):
         if torch.cuda.is_available():
             new_boxes = boxes.fake_boxes((3, 4, 4), device='cuda')
             self.assertTrue(new_boxes.tensor.is_cuda)
+
+    def test_pin_memory(self):
+        boxes = ToyBaseBoxes(torch.rand(3, 4, 4))
+        self.assertEqual(boxes.tensor.is_pinned(), False)
+        boxes = boxes.pin_memory()
+        self.assertEqual(boxes.tensor.is_pinned(), True)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Custom object `BaseBoxes` supports `pin_memory` function to speed up training. I have tested it on rtmdet-s, it can be accelerated by about 3~4 hours.

Waiting for https://github.com/open-mmlab/mmengine/pull/910


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
