### PR TITLE
[Fix] Fix docstring about noise in DINO

### DIFF
--- a/mmdet/models/layers/transformer/dino_layers.py
+++ b/mmdet/models/layers/transformer/dino_layers.py
@@ -410,7 +410,7 @@ class CdnQueryGenerator(BaseModule):
         # calculate the random part of the added noise
         rand_part = torch.rand_like(gt_bboxes_expand)  # [0, 1)
         rand_part[negative_idx] += 1.0  # pos: [0, 1); neg: [1, 2)
-        rand_part *= rand_sign  # pos: (-1, 1); neg: (-2, 1] U [1, 2)
+        rand_part *= rand_sign  # pos: (-1, 1); neg: (-2, -1] U [1, 2)
 
         # add noise to the bboxes
         bboxes_whwh = bbox_xyxy_to_cxcywh(gt_bboxes_expand)[:, 2:].repeat(1, 2)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

```python
rand_sign # [low, high), 1 or -1, randomly
```
https://github.com/open-mmlab/mmdetection/blob/78030a65608819080f6d9c5b1bfad95f0a36ac97/mmdet/models/layers/transformer/dino_layers.py#L410-L413

Current code is written as `neg: (-2, 1] U [1, 2)`, but it is actually `neg: (-2, -1] U [1, 2)`.

<img width="224" alt="image" src="https://user-images.githubusercontent.com/25769408/217731307-58d67e02-5d54-4738-bf95-94be29f46e7b.png">
(Fig.3. of the original paper)

## Modification
Fix `neg: (-2, 1] U [1, 2)` to `neg: (-2, -1] U [1, 2)`.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
