### PR TITLE
[DOCS] import  `register_all_modules` and call it 

### DIFF
--- a/docs/en/user_guides/inference.md
+++ b/docs/en/user_guides/inference.md
@@ -17,8 +17,11 @@ import mmcv
 from mmcv.transforms import Compose
 from mmengine.utils import track_iter_progress
 from mmdet.registry import VISUALIZERS
+from mmdet.utils import register_all_modules
 from mmdet.apis import init_detector, inference_detector
 
+# Register all modules in mmdet into the registries
+register_all_modules()
 
 # Specify the path to model config and checkpoint file
 config_file = 'configs/faster_rcnn/faster-rcnn_r50-fpn_1x_coco.py'


### PR DESCRIPTION
## Motivation

We should register all modules in mmdet into the registries before runing the rest codes

I have seen similar pull in another notebook, but this problem doesn't exist in [3.x](https://github.com/open-mmlab/mmdetection/edit/3.x/docs/en/user_guides/inference.md)


## Modification
import  `register_all_modules` and call `register_all_modules()` before runing the rest codes

```
from mmdet.utils import register_all_modules

# Register all modules in mmdet into the registries
register_all_modules()
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
