### PR TITLE
[Fix] Fix VOC metrics

### DIFF
--- a/mmdet/evaluation/metrics/dump_det_results.py
+++ b/mmdet/evaluation/metrics/dump_det_results.py
@@ -17,11 +17,6 @@ class DumpDetResults(DumpResults):
     segmentation masks into RLE format.
 
     Args:
-        keep_gt (bool): Whether to dump `gt_instances` simultaneously. It
-            should be True if offline VOCMetric is used. Defaults to False.
-        keep_gt_ignore (bool): Whether to dump `ignored_instances`
-            simultaneously. It should be True if offline VOCMetric is used.
-            Defaults to False.
         out_file_path (str): Path of the dumped file. Must end with '.pkl'
             or '.pickle'.
         collect_device (str): Device name used for collecting results from
@@ -29,23 +24,13 @@ class DumpDetResults(DumpResults):
             'gpu'. Defaults to 'cpu'.
     """
 
-    def __init__(self,
-                 keep_gt: bool = False,
-                 keep_gt_ignore: bool = False,
-                 **kwargs) -> None:
-        super().__init__(**kwargs)
-        self.keep_gt = keep_gt
-        self.keep_gt_ignore = keep_gt_ignore
-
     def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
         """transfer tensors in predictions to CPU."""
         data_samples = _to_cpu(data_samples)
         for data_sample in data_samples:
             # remove gt
-            if not self.keep_gt:
-                data_sample.pop('gt_instances', None)
-            if not self.keep_gt_ignore:
-                data_sample.pop('ignored_instances', None)
+            data_sample.pop('gt_instances', None)
+            data_sample.pop('ignored_instances', None)
             data_sample.pop('gt_panoptic_seg', None)
 
             if 'pred_instances' in data_sample:

--- a/mmdet/evaluation/metrics/dump_det_results.py
+++ b/mmdet/evaluation/metrics/dump_det_results.py
@@ -17,6 +17,11 @@ class DumpDetResults(DumpResults):
     segmentation masks into RLE format.
 
     Args:
+        keep_gt (bool): Whether dumped `gt_instances` simultaneously. It
+            should be True if offline VOCMetric is used. Defaults to False.
+        keep_gt_ignore (bool): Whether dumped `ignored_instances`
+            simultaneously. It should be True if offline VOCMetric is used.
+            Defaults to False.
         out_file_path (str): Path of the dumped file. Must end with '.pkl'
             or '.pickle'.
         collect_device (str): Device name used for collecting results from
@@ -24,13 +29,23 @@ class DumpDetResults(DumpResults):
             'gpu'. Defaults to 'cpu'.
     """
 
+    def __init__(self,
+                 keep_gt: bool = False,
+                 keep_gt_ignore: bool = False,
+                 **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.keep_gt = keep_gt
+        self.keep_gt_ignore = keep_gt_ignore
+
     def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
         """transfer tensors in predictions to CPU."""
         data_samples = _to_cpu(data_samples)
         for data_sample in data_samples:
             # remove gt
-            data_sample.pop('gt_instances', None)
-            data_sample.pop('ignored_instances', None)
+            if not self.keep_gt:
+                data_sample.pop('gt_instances', None)
+            if not self.keep_gt_ignore:
+                data_sample.pop('ignored_instances', None)
             data_sample.pop('gt_panoptic_seg', None)
 
             if 'pred_instances' in data_sample:

--- a/mmdet/evaluation/metrics/dump_det_results.py
+++ b/mmdet/evaluation/metrics/dump_det_results.py
@@ -19,7 +19,7 @@ class DumpDetResults(DumpResults):
     Args:
         keep_gt (bool): Whether to dump `gt_instances` simultaneously. It
             should be True if offline VOCMetric is used. Defaults to False.
-        keep_gt_ignore (bool): Whether dumped `ignored_instances`
+        keep_gt_ignore (bool): Whether to dump `ignored_instances`
             simultaneously. It should be True if offline VOCMetric is used.
             Defaults to False.
         out_file_path (str): Path of the dumped file. Must end with '.pkl'

--- a/mmdet/evaluation/metrics/dump_det_results.py
+++ b/mmdet/evaluation/metrics/dump_det_results.py
@@ -17,7 +17,7 @@ class DumpDetResults(DumpResults):
     segmentation masks into RLE format.
 
     Args:
-        keep_gt (bool): Whether dumped `gt_instances` simultaneously. It
+        keep_gt (bool): Whether to dump `gt_instances` simultaneously. It
             should be True if offline VOCMetric is used. Defaults to False.
         keep_gt_ignore (bool): Whether dumped `ignored_instances`
             simultaneously. It should be True if offline VOCMetric is used.

--- a/mmdet/evaluation/metrics/voc_metric.py
+++ b/mmdet/evaluation/metrics/voc_metric.py
@@ -150,6 +150,7 @@ class VOCMetric(BaseMetric):
                     iou_thr=iou_thr,
                     dataset=dataset_name,
                     logger=logger,
+                    eval_mode=self.eval_mode,
                     use_legacy_coordinate=True)
                 mean_aps.append(mean_ap)
                 eval_results[f'AP{int(iou_thr * 100):02d}'] = round(mean_ap, 3)


### PR DESCRIPTION
1. Fixed VOC metrics, add `eval_mode` in `eval_map`, or it will used `area` when calculating VOC2007, which is wrong.