### PR TITLE
[Enhance] tools/test.py: add options `--show-box-only` and `--show-mask-only`

### DIFF
--- a/docs/en/1_exist_data_model.md
+++ b/docs/en/1_exist_data_model.md
@@ -317,6 +317,8 @@ Optional arguments:
 - `EVAL_METRICS`: Items to be evaluated on the results. Allowed values depend on the dataset, e.g., `proposal_fast`, `proposal`, `bbox`, `segm` are available for COCO, `mAP`, `recall` for PASCAL VOC. Cityscapes could be evaluated by `cityscapes` as well as all COCO metrics.
 - `--show`: If specified, detection results will be plotted on the images and shown in a new window. It is only applicable to single GPU testing and used for debugging and visualization. Please make sure that GUI is available in your environment. Otherwise, you may encounter an error like `cannot connect to X server`.
 - `--show-dir`: If specified, detection results will be plotted on the images and saved to the specified directory. It is only applicable to single GPU testing and used for debugging and visualization. You do NOT need a GUI available in your environment for using this option.
+- `--show-box-only`: If specified, plot only `bbox` on the images if the model outputs both `bbox` and `mask`. It is invalid to specify both `--show-box-only` and `--show-mask-only`.
+- `--show-mask-only`: If specified, plot only `mask` on the images if the model outputs both `bbox` and `mask`. It is invalid to specify both `--show-box-only` and `--show-mask-only`.
 - `--show-score-thr`: If specified, detections with scores below this threshold will be removed.
 - `--cfg-options`:  if specified, the key-value pair optional cfg will be merged into config file
 - `--eval-options`: if specified, the key-value pair optional eval cfg will be kwargs for dataset.evaluate() function, it's only for evaluation

--- a/docs/zh_cn/1_exist_data_model.md
+++ b/docs/zh_cn/1_exist_data_model.md
@@ -311,6 +311,8 @@ bash tools/dist_test.sh \
 - `EVAL_METRICS`: 需要测试的度量指标。可选值是取决于数据集的，比如 `proposal_fast`，`proposal`，`bbox`，`segm` 是 COCO 数据集的可选值，`mAP`，`recall` 是 Pascal VOC 数据集的可选值。Cityscapes 数据集可以测试 `cityscapes` 和所有 COCO 数据集支持的度量指标。
 - `--show`: 如果开启，检测结果将被绘制在图像上，以一个新窗口的形式展示。它只适用于单 GPU 的测试，是用于调试和可视化的。请确保使用此功能时，你的 GUI 可以在环境中打开。否则，你可能会遇到这么一个错误 `cannot connect to X server`。
 - `--show-dir`: 如果指明，检测结果将会被绘制在图像上并保存到指定目录。它只适用于单 GPU 的测试，是用于调试和可视化的。即使你的环境中没有 GUI，这个选项也可使用。
+- `--show-box-only`: 如果开启，对于同时输出`bbox`和`mask`的模型，将只在图像上绘制`bbox`。此选项不能与`--show-mask-only`同时启用。
+- `--show-mask-only`: 如果开启，对于同时输出`bbox`和`mask`的模型，将只在图像上绘制`mask`。此选项不能与`--show-box-only`同时启用。
 - `--show-score-thr`: 如果指明，得分低于此阈值的检测结果将会被移除。
 - `--cfg-options`:  如果指明，这里的键值对将会被合并到配置文件中。
 - `--eval-options`: 如果指明，这里的键值对将会作为字典参数被传入 `dataset.evaluation()` 函数中，仅在测试阶段使用。

--- a/mmdet/apis/test.py
+++ b/mmdet/apis/test.py
@@ -18,7 +18,9 @@ def single_gpu_test(model,
                     data_loader,
                     show=False,
                     out_dir=None,
-                    show_score_thr=0.3):
+                    show_score_thr=0.3,
+                    show_box_only=False,
+                    show_mask_only=False):
     model.eval()
     results = []
     dataset = data_loader.dataset
@@ -58,7 +60,9 @@ def single_gpu_test(model,
                     mask_color=PALETTE,
                     show=show,
                     out_file=out_file,
-                    score_thr=show_score_thr)
+                    score_thr=show_score_thr,
+                    show_box_only=show_box_only,
+                    show_mask_only=show_mask_only)
 
         # encode mask results
         if isinstance(result[0], tuple):

--- a/mmdet/core/visualization/image.py
+++ b/mmdet/core/visualization/image.py
@@ -219,7 +219,9 @@ def imshow_det_bboxes(img,
                       win_name='',
                       show=True,
                       wait_time=0,
-                      out_file=None):
+                      out_file=None,
+                      show_box_only=False,
+                      show_mask_only=False):
     """Draw bboxes and class labels (with scores) on an image.
 
     Args:
@@ -297,7 +299,7 @@ def imshow_det_bboxes(img,
     text_colors = [text_palette[label] for label in labels]
 
     num_bboxes = 0
-    if bboxes is not None:
+    if bboxes is not None and not show_mask_only:
         num_bboxes = bboxes.shape[0]
         bbox_palette = palette_val(get_palette(bbox_color, max_label + 1))
         colors = [bbox_palette[label] for label in labels[:num_bboxes]]
@@ -319,7 +321,7 @@ def imshow_det_bboxes(img,
             scales=scales,
             horizontal_alignment=horizontal_alignment)
 
-    if segms is not None:
+    if segms is not None and not show_box_only:
         mask_palette = get_palette(mask_color, max_label + 1)
         colors = [mask_palette[label] for label in labels]
         colors = np.array(colors, dtype=np.uint8)

--- a/mmdet/models/detectors/base.py
+++ b/mmdet/models/detectors/base.py
@@ -285,7 +285,9 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
                     win_name='',
                     show=False,
                     wait_time=0,
-                    out_file=None):
+                    out_file=None,
+                    show_box_only=False,
+                    show_mask_only=False):
         """Draw `result` over `img`.
 
         Args:
@@ -355,7 +357,9 @@ class BaseDetector(BaseModule, metaclass=ABCMeta):
             win_name=win_name,
             show=show,
             wait_time=wait_time,
-            out_file=out_file)
+            out_file=out_file,
+            show_box_only=show_box_only,
+            show_mask_only=show_mask_only)
 
         if not (show or out_file):
             return img

--- a/tools/test.py
+++ b/tools/test.py
@@ -104,6 +104,16 @@ def parse_args():
         default='none',
         help='job launcher')
     parser.add_argument('--local_rank', type=int, default=0)
+    parser.add_argument(
+        '--show-box-only',
+        action='store_true',
+        help='paint only bounding boxes on the images to be saved. This is '
+        'only effective with --show-dir.')
+    parser.add_argument(
+        '--show-mask-only',
+        action='store_true',
+        help='paint only segmentation masks on the images to be saved. This '
+        'is only effective with --show-dir.')
     args = parser.parse_args()
     if 'LOCAL_RANK' not in os.environ:
         os.environ['LOCAL_RANK'] = str(args.local_rank)
@@ -239,8 +249,11 @@ def main():
 
     if not distributed:
         model = build_dp(model, cfg.device, device_ids=cfg.gpu_ids)
+        assert not (args.show_box_only and args.show_mask_only), \
+            '"--show-box-only" and "--show-mask-only" cannot be both specified'
         outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
-                                  args.show_score_thr)
+                                  args.show_score_thr, args.show_box_only,
+                                  args.show_mask_only)
     else:
         model = build_ddp(
             model,


### PR DESCRIPTION
## Motivation

Currently to visualize results, '--show-dir' plots both bounding boxes and instance masks if the network outputs them both. But bbox and masks can be compared independently in practice (e.g. in an academic paper). This PR provides two options `--box-only` and `--mask-only` for tools/test.py to control the output style.

## Modification

In `tools/test.py`, options `--box-only` and `--mask-only` are added to argparser. And they are finally applied to `mmdet\core\visualization\image.py`.

```python
if bboxes is not None and not mask_only:
	...
# and
if segms is not None and not box_only:
	...
```

## Use cases (Optional)

Neithor `--show-mask-only` nor `--show-box-only`

```bash
python .\tools\test.py .\configs\mask2former\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco.py .\ckpt\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco_20220508_091649-4a943037.pth --show-dir .\vis\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco
```

output image:
![000000000785](https://user-images.githubusercontent.com/51251025/221753897-dc5a93cc-01c2-479f-bfd2-13af38657e30.jpg)

--show-mask-only:

```bash
python .\tools\test.py .\configs\mask2former\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco.py .\ckpt\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco_20220508_091649-4a943037.pth --show-mask-only --show-dir .\vis\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco_mask
```

output image:
![000000000785](https://user-images.githubusercontent.com/51251025/221753980-a7960a1d-16c7-452c-b1c5-9376f105cf8d.jpg)

--show-box-only:

```bash
python .\tools\test.py .\configs\mask2former\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco.py .\ckpt\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco_20220508_091649-4a943037.pth --show-box-only --show-dir .\vis\mask2former_swin-t-p4-w7-224_lsj_8x2_50e_coco_box
```

output image:
![000000000785](https://user-images.githubusercontent.com/51251025/221754044-40a71ae1-553f-4165-a826-08dd020d2792.jpg)

both --box-only and --mask-only:

```bash
AssertionError: "--show-box-only" and "--show-mask-only" cannot be both specified
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
