### PR TITLE
[Fix] Unifying metafile.yml

### DIFF
--- a/configs/fsaf/metafile.yml
+++ b/configs/fsaf/metafile.yml
@@ -56,7 +56,7 @@ Models:
       - Task: Object Detection
         Dataset: COCO
         Metrics:
-          box AP: 39.3 (37.9)
+          box AP: 39.3
     Weights: https://download.openmmlab.com/mmdetection/v2.0/fsaf/fsaf_r101_fpn_1x_coco/fsaf_r101_fpn_1x_coco-9e71098f.pth
 
   - Name: fsaf_x101-64x4d_fpn_1x_coco
@@ -76,5 +76,5 @@ Models:
       - Task: Object Detection
         Dataset: COCO
         Metrics:
-          box AP: 42.4 (41.0)
+          box AP: 42.4
     Weights: https://download.openmmlab.com/mmdetection/v2.0/fsaf/fsaf_x101_64x4d_fpn_1x_coco/fsaf_x101_64x4d_fpn_1x_coco-e3f6e6fd.pth

--- a/configs/paa/metafile.yml
+++ b/configs/paa/metafile.yml
@@ -24,6 +24,7 @@ Models:
     Config: configs/paa/paa_r50_fpn_1x_coco.py
     Metadata:
       Training Memory (GB): 3.7
+      Epochs: 12
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -36,6 +37,7 @@ Models:
     Config: configs/paa/paa_r50_fpn_1.5x_coco.py
     Metadata:
       Training Memory (GB): 3.7
+      Epochs: 18
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -48,6 +50,7 @@ Models:
     Config: configs/paa/paa_r50_fpn_2x_coco.py
     Metadata:
       Training Memory (GB): 3.7
+      Epochs: 24
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -60,6 +63,7 @@ Models:
     Config: configs/paa/paa_r50_fpn_ms-3x_coco.py
     Metadata:
       Training Memory (GB): 3.7
+      Epochs: 36
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -72,6 +76,7 @@ Models:
     Config: configs/paa/paa_r101_fpn_1x_coco.py
     Metadata:
       Training Memory (GB): 6.2
+      Epochs: 12
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -84,6 +89,7 @@ Models:
     Config: configs/paa/paa_r101_fpn_2x_coco.py
     Metadata:
       Training Memory (GB): 6.2
+      Epochs: 24
     Results:
       - Task: Object Detection
         Dataset: COCO
@@ -96,6 +102,7 @@ Models:
     Config: configs/paa/paa_r101_fpn_ms-3x_coco.py
     Metadata:
       Training Memory (GB): 6.2
+      Epochs: 36
     Results:
       - Task: Object Detection
         Dataset: COCO

--- a/configs/yolact/metafile.yml
+++ b/configs/yolact/metafile.yml
@@ -24,6 +24,7 @@ Models:
     Metadata:
       Training Resources: 1x V100 GPU
       Batch Size: 8
+      Epochs: 55
       inference time (ms/im):
         - value: 23.53
           hardware: V100
@@ -43,6 +44,7 @@ Models:
     Config: configs/yolact/yolact_r50_8xb8-55e_coco.py
     Metadata:
       Batch Size: 64
+      Epochs: 55
       inference time (ms/im):
         - value: 23.53
           hardware: V100
@@ -63,6 +65,7 @@ Models:
     Metadata:
       Training Resources: 1x V100 GPU
       Batch Size: 8
+      Epochs: 55
       inference time (ms/im):
         - value: 29.85
           hardware: V100


### PR DESCRIPTION
## Motivation

Unifying metafile.yml

## Modification

1. Delete the brackets in `box_ap` to make the command, `mim search mmdet --dataset COCO --sort coco/box_ap --descending`, run successfully. Or it would raise an error, `TypeError: '>' not supported between instances of 'str' and 'int'`.
2. Add missing information on the training epochs in `paa/metafile.yml` and `yolact/metafile.yml`