### PR TITLE
[Fix] Fix cropping polygon mask.

### DIFF
--- a/mmdet/structures/mask/structures.py
+++ b/mmdet/structures/mask/structures.py
@@ -7,6 +7,7 @@ import cv2
 import mmcv
 import numpy as np
 import pycocotools.mask as maskUtils
+import shapely.geometry as geometry
 import torch
 from mmcv.ops.roi_align import roi_align
 
@@ -753,15 +754,40 @@ class PolygonMasks(BaseInstanceMasks):
         if len(self.masks) == 0:
             cropped_masks = PolygonMasks([], h, w)
         else:
+            # reference: https://github.com/facebookresearch/fvcore/blob/main/fvcore/transforms/transform.py  # noqa
+            crop_box = geometry.box(x1, y1, x2, y2).buffer(0.0)
             cropped_masks = []
             for poly_per_obj in self.masks:
                 cropped_poly_per_obj = []
                 for p in poly_per_obj:
-                    # pycocotools will clip the boundary
                     p = p.copy()
-                    p[0::2] = p[0::2] - bbox[0]
-                    p[1::2] = p[1::2] - bbox[1]
-                    cropped_poly_per_obj.append(p)
+                    p = geometry.Polygon(p.reshape(-1, 2)).buffer(0.0)
+                    # polygon must be valid to perform intersection.
+                    if not p.is_valid:
+                        continue
+                    cropped = p.intersection(crop_box)
+                    if cropped.is_empty:
+                        continue
+                    if isinstance(cropped,
+                                  geometry.collection.BaseMultipartGeometry):
+                        cropped = cropped.geoms
+                    else:
+                        cropped = [cropped]
+                    # one polygon may be cropped to multiple ones
+                    for poly in cropped:
+                        # ignore lines or points
+                        if not isinstance(
+                                poly, geometry.Polygon) or not poly.is_valid:
+                            continue
+                        coords = np.asarray(poly.exterior.coords)
+                        # remove an extra identical vertex at the end
+                        coords = coords[:-1]
+                        coords[:, 0] -= x1
+                        coords[:, 1] -= y1
+                        cropped_poly_per_obj.append(coords.reshape(-1))
+
+                if len(cropped_poly_per_obj) == 0:
+                    cropped_poly_per_obj = [np.array([0, 0, 0, 0, 0, 0])]
                 cropped_masks.append(cropped_poly_per_obj)
             cropped_masks = PolygonMasks(cropped_masks, h, w)
         return cropped_masks

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,5 +2,6 @@ matplotlib
 numpy
 pycocotools
 scipy
+shapely
 six
 terminaltables


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The crop method of PolygonMasks is actually translating the coordinates, not actually clipping the polygon.
Fix this bug by applying geometrical intersection.
This solution refers to https://github.com/facebookresearch/fvcore/blob/main/fvcore/transforms/transform.py.

## Modification

Fix the `crop` method of `PolygonMasks` with `shapely.geometry.intersection`.
The geometry intersection is a little bit slower than shifting coordinates after interpolating boundary. But interpolating will generate 1000x more points which will slow down other transforms.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
