### PR TITLE
[Fix] fix only cuda device bug in datasets sampler

### DIFF
--- a/mmdet/datasets/samplers/infinite_sampler.py
+++ b/mmdet/datasets/samplers/infinite_sampler.py
@@ -7,6 +7,7 @@ from mmcv.runner import get_dist_info
 from torch.utils.data.sampler import Sampler
 
 from mmdet.core.utils import sync_random_seed
+from mmdet.utils import get_device
 
 
 class InfiniteGroupBatchSampler(Sampler):
@@ -56,7 +57,8 @@ class InfiniteGroupBatchSampler(Sampler):
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
         # same data list.
-        self.seed = sync_random_seed(seed)
+        device = get_device()
+        self.seed = sync_random_seed(seed, device)
         self.shuffle = shuffle
 
         assert hasattr(self.dataset, 'flag')
@@ -147,7 +149,8 @@ class InfiniteBatchSampler(Sampler):
         # in the same order based on the same seed. Then different ranks
         # could use different indices to select non-overlapped data from the
         # same data list.
-        self.seed = sync_random_seed(seed)
+        device = get_device()
+        self.seed = sync_random_seed(seed, device)
         self.shuffle = shuffle
         self.size = len(dataset)
         self.indices = self._indices_of_rank()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The code raise error when i am running mmdet3d pgd network on MLU device:

![image](https://user-images.githubusercontent.com/70051089/222683338-0d4608f6-53d1-4073-a2b7-a62957c17298.png)

## Modification

Add utils function to get current device and pass it to `sync_random_seed` function.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
