### PR TITLE
[Docs] Replace options with eval-options

### DIFF
--- a/docs/en/1_exist_data_model.md
+++ b/docs/en/1_exist_data_model.md
@@ -377,7 +377,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
        8 \
        --out results.pkl \
        --eval bbox segm \
-       --options "classwise=True"
+       --eval-options "classwise=True"
    ```
 
 6. Test Mask R-CNN on COCO test-dev with 8 GPUs, and generate JSON files for submitting to the official evaluation server.
@@ -389,7 +389,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
        checkpoints/mask_rcnn_r50_fpn_1x_coco_20200205-d4b0c5d6.pth \
        8 \
        --format-only \
-       --options "jsonfile_prefix=./mask_rcnn_test-dev_results"
+       --eval-options "jsonfile_prefix=./mask_rcnn_test-dev_results"
    ```
 
    This command generates two JSON files `mask_rcnn_test-dev_results.bbox.json` and `mask_rcnn_test-dev_results.segm.json`.
@@ -403,7 +403,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
        checkpoints/mask_rcnn_r50_fpn_1x_cityscapes_20200227-afe51d5a.pth \
        8 \
        --format-only \
-       --options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
+       --eval-options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
    ```
 
    The generated png and txt would be under `./mask_rcnn_cityscapes_test_results` directory.

--- a/docs/zh_cn/1_exist_data_model.md
+++ b/docs/zh_cn/1_exist_data_model.md
@@ -366,7 +366,7 @@ bash tools/dist_test.sh \
        8 \
        --out results.pkl \
        --eval bbox segm \
-       --options "classwise=True"
+       --eval-options "classwise=True"
    ```
 
 6. 在 COCO test-dev 数据集上，使用 8 块 GPU 测试 Mask R-CNN，并生成 JSON 文件提交到官方评测服务器。配置文件和 checkpoint 文件 [在此](https://github.com/open-mmlab/mmdetection/tree/master/configs/mask_rcnn) 。
@@ -377,7 +377,7 @@ bash tools/dist_test.sh \
        checkpoints/mask_rcnn_r50_fpn_1x_coco_20200205-d4b0c5d6.pth \
        8 \
        --format-only \
-       --options "jsonfile_prefix=./mask_rcnn_test-dev_results"
+       --eval-options "jsonfile_prefix=./mask_rcnn_test-dev_results"
    ```
 
 这行命令生成两个 JSON 文件 `mask_rcnn_test-dev_results.bbox.json` 和 `mask_rcnn_test-dev_results.segm.json`。
@@ -390,7 +390,7 @@ bash tools/dist_test.sh \
        checkpoints/mask_rcnn_r50_fpn_1x_cityscapes_20200227-afe51d5a.pth \
        8 \
        --format-only \
-       --options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
+       --eval-options "txtfile_prefix=./mask_rcnn_cityscapes_test_results"
    ```
 
 生成的 png 和 txt 文件在 `./mask_rcnn_cityscapes_test_results` 文件夹下。


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

To remove tools/test.py:116: UserWarning: --options is deprecated in favor of --eval-options warnings.warn('--options is deprecated in favor of --eval-options')

## Modification

Replace options with eval-options in docs/zh_cn/1_exist_data_model.md and docs/en/1_exist_data_model.md 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
