### PR TITLE
fix: warning msg floordiv is deprecated

### DIFF
--- a/mmdet/models/utils/positional_encoding.py
+++ b/mmdet/models/utils/positional_encoding.py
@@ -78,7 +78,7 @@ class SinePositionalEncoding(BaseModule):
                       (x_embed[:, :, -1:] + self.eps) * self.scale
         dim_t = torch.arange(
             self.num_feats, dtype=torch.float32, device=mask.device)
-        dim_t = self.temperature**(2 * (dim_t // 2) / self.num_feats)
+        dim_t = self.temperature**(2 * torch.div(dim_t, 2, rounding_mode='floor') / self.num_feats)
         pos_x = x_embed[:, :, :, None] / dim_t
         pos_y = y_embed[:, :, :, None] / dim_t
         # use `view` instead of `flatten` for dynamically exporting to ONNX


### PR DESCRIPTION
Remove the warning message due to using
## Motivation

Removing the annoying Warning message making it unable to view the prints of my program

## Modification

replaced floordiv  (// l.81) which is deprecated by torch.div() with rounding_mode='floor'

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
