### PR TITLE
[Fix] docker build for ampere gpus and cuda11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,10 @@ ARG CUDNN="7"
 
 FROM pytorch/pytorch:${PYTORCH}-cuda${CUDA}-cudnn${CUDNN}-devel
 
+# ARG will be removed after FROM. Therefore, the following shall be defined after FROM
+ARG MMCV_VERSION="1.3.17"
+ARG MMCV_URL="https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html"
+
 ENV TORCH_CUDA_ARCH_LIST="6.0 6.1 7.0+PTX"
 ENV TORCH_NVCC_FLAGS="-Xfatbin -compress-all"
 ENV CMAKE_PREFIX_PATH="$(dirname $(which conda))/../"
@@ -18,7 +22,7 @@ RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build 
 
 # Install MMCV
 RUN pip install --no-cache-dir --upgrade pip wheel setuptools
-RUN pip install --no-cache-dir mmcv-full==1.3.17 -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
+RUN pip install --no-cache-dir mmcv-full==${MMCV_VERSION} -f ${MMCV_URL}
 
 # Install MMDetection
 RUN conda clean --all

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -196,6 +196,18 @@ We provide a [Dockerfile](https://github.com/open-mmlab/mmdetection/blob/master/
 docker build -t mmdetection docker/
 ```
 
+It should be noted that more recent GPU versions such as 3070, with Ampere architecture may require CUDA 11 as the minimum.
+In this case, you can pass the corresponding versions into the docker build:
+
+```
+docker build -t mmdetection -f docker/Dockerfile \
+--build-arg PYTORCH=1.9.0  \
+--build-arg CUDA=11.1  \
+--build-arg CUDNN=8 \
+--build-arg MMCV_VERSION=1.7.0 \
+--build-arg MMCV_URL="https://download.openmmlab.com/mmcv/dist/cu111/torch1.9/index.html" .
+```
+
 Run it with
 
 ```shell

--- a/docs/zh_cn/get_started.md
+++ b/docs/zh_cn/get_started.md
@@ -227,6 +227,17 @@ MIM 能够自动地安装 OpenMMLab 的项目以及对应的依赖包。
 docker build -t mmdetection docker/
 ```
 
+应该注意的是，较新的 GPU 版本（例如 3070）具有 Ampere 架构，可能至少需要 CUDA 11。 在这种情况下，您可以将相应的版本传递到 docker build 中：
+
+```
+docker build -t mmdetection -f docker/Dockerfile \
+--build-arg PYTORCH=1.9.0  \
+--build-arg CUDA=11.1  \
+--build-arg CUDNN=8 \
+--build-arg MMCV_VERSION=1.7.0 \
+--build-arg MMCV_URL="https://download.openmmlab.com/mmcv/dist/cu111/torch1.9/index.html" .
+```
+
 运行命令：
 
 ```shell


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1. the Dockerfile has hard coded mmcv-full and url which is bind to lower version of CUDA and Pytorch
2. it lacks document of how to pass arguments to docker to use newer version of CUDA and Pytorch

As a consequence, there is no way to run the docker on any more recent GPUs with Ampere arch, which requires CUDA 11.

## Modification

- added 2 ARGs to be passed to the Dockerfile to indicate the mmcv-full version and url
- added the documentation in both English and Chinese to provide an example of the docker build command

It has been tested on the following machine:
- Ubuntu 22.04
- GPU RTX 3070
- Docker version 20.10.22, build 3a2c30b
- Driver Version: 525.85.12


## BC-breaking (Optional)

No. Even though two new ARGS are added, the default value remains the same, which is backwards compatible.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
5. The documentation has been modified accordingly, like docstring or example tutorials.
