### PR TITLE
Add fix for albu channel order

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -1484,7 +1484,13 @@ class Albu:
             else:
                 results['masks'] = [mask for mask in results['masks'].masks]
 
+        # Convert to RGB since Albumentations works with RGB images
+        results['image'] = cv2.cvtColor(results['image'], cv2.COLOR_BGR2RGB)
+
         results = self.aug(**results)
+
+        # Convert back to BGR
+        results['image'] = cv2.cvtColor(results['image'], cv2.COLOR_RGB2BGR)
 
         if 'bboxes' in results:
             if isinstance(results['bboxes'], list):


### PR DESCRIPTION
## Motivation

Albumentations uses RGB channel order. MMLab is based on BGR. It is necessary to sort channels properly before calling albu methods.

see https://github.com/open-mmlab/mmdetection/issues/9891

## Modification

Change channel order and add regression test.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
