### PR TITLE
[Fix Bug] record img_shape: x.shape -> x.shape[:2]

### DIFF
--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -722,7 +722,7 @@ class RandomCrop(BaseTransform):
         img = img[crop_y1:crop_y2, crop_x1:crop_x2, ...]
         img_shape = img.shape
         results['img'] = img
-        results['img_shape'] = img_shape
+        results['img_shape'] = img_shape.shape[:2]
 
         # crop bboxes accordingly and clip to the image boundary
         if results.get('gt_bboxes', None) is not None:
@@ -1510,7 +1510,7 @@ class Albu(BaseTransform):
             return None
         # back to the original format
         results = self.mapper(results, self.keymap_back)
-        results['img_shape'] = results['img'].shape
+        results['img_shape'] = results['img'].shape[:2]
         return results
 
     def _preprocess_results(self, results: dict) -> tuple:
@@ -1862,7 +1862,7 @@ class RandomCenterCropPad(BaseTransform):
 
                 if len(gt_bboxes) == 0:
                     results['img'] = cropped_img
-                    results['img_shape'] = cropped_img.shape
+                    results['img_shape'] = cropped_img.shape[:2]
                     return results
 
                 # if image do not have valid bbox, any crop patch is valid.
@@ -1871,7 +1871,7 @@ class RandomCenterCropPad(BaseTransform):
                     continue
 
                 results['img'] = cropped_img
-                results['img_shape'] = cropped_img.shape
+                results['img_shape'] = cropped_img.shape[:2]
 
                 x0, y0, x1, y1 = patch
 
@@ -1937,7 +1937,7 @@ class RandomCenterCropPad(BaseTransform):
         cropped_img, border, _ = self._crop_image_and_paste(
             img, [h // 2, w // 2], [target_h, target_w])
         results['img'] = cropped_img
-        results['img_shape'] = cropped_img.shape
+        results['img_shape'] = cropped_img.shape[:2]
         results['border'] = border
         return results
 
@@ -2241,7 +2241,7 @@ class Mosaic(BaseTransform):
         mosaic_ignore_flags = mosaic_ignore_flags[inside_inds]
 
         results['img'] = mosaic_img
-        results['img_shape'] = mosaic_img.shape
+        results['img_shape'] = mosaic_img.shape[:2]
         results['gt_bboxes'] = mosaic_bboxes
         results['gt_bboxes_labels'] = mosaic_bboxes_labels
         results['gt_ignore_flags'] = mosaic_ignore_flags
@@ -2523,7 +2523,7 @@ class MixUp(BaseTransform):
         mixup_gt_ignore_flags = mixup_gt_ignore_flags[inside_inds]
 
         results['img'] = mixup_img.astype(np.uint8)
-        results['img_shape'] = mixup_img.shape
+        results['img_shape'] = mixup_img.shape[:2]
         results['gt_bboxes'] = mixup_gt_bboxes
         results['gt_bboxes_labels'] = mixup_gt_bboxes_labels
         results['gt_ignore_flags'] = mixup_gt_ignore_flags
@@ -2646,7 +2646,7 @@ class RandomAffine(BaseTransform):
             dsize=(width, height),
             borderValue=self.border_val)
         results['img'] = img
-        results['img_shape'] = img.shape
+        results['img_shape'] = img.shape[:2]
 
         bboxes = results['gt_bboxes']
         num_bboxes = len(bboxes)
@@ -3335,7 +3335,7 @@ class CachedMosaic(Mosaic):
         mosaic_ignore_flags = mosaic_ignore_flags[inside_inds]
 
         results['img'] = mosaic_img
-        results['img_shape'] = mosaic_img.shape
+        results['img_shape'] = mosaic_img.shape[:2]
         results['gt_bboxes'] = mosaic_bboxes
         results['gt_bboxes_labels'] = mosaic_bboxes_labels
         results['gt_ignore_flags'] = mosaic_ignore_flags
@@ -3615,7 +3615,7 @@ class CachedMixUp(BaseTransform):
             mixup_gt_masks = mixup_gt_masks[inside_inds]
 
         results['img'] = mixup_img.astype(np.uint8)
-        results['img_shape'] = mixup_img.shape
+        results['img_shape'] = mixup_img.shape[:2]
         results['gt_bboxes'] = mixup_gt_bboxes
         results['gt_bboxes_labels'] = mixup_gt_bboxes_labels
         results['gt_ignore_flags'] = mixup_gt_ignore_flags


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Some transforms record image shape as `x.shape`, which is inconsistent with others (`x.shape[:2]`). Most code prefer the latter one.

## Modification

Changing `x.shape` to `x.shape[:2]` in file `mmdet/datasets/transforms/transforms.py` in branch 3.x.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
