### PR TITLE
Fixed potential device mismatch

### DIFF
--- a/mmdet/core/bbox/assigners/point_assigner.py
+++ b/mmdet/core/bbox/assigners/point_assigner.py
@@ -83,7 +83,7 @@ class PointAssigner(BaseAssigner):
         assigned_gt_inds = points.new_zeros((num_points, ), dtype=torch.long)
         # stores the assigned gt dist (to this point) of each point
         assigned_gt_dist = points.new_full((num_points, ), float('inf'))
-        points_range = torch.arange(points.shape[0])
+        points_range = torch.arange(points.shape[0]).to(gt_bboxes_lvl.device)
 
         for idx in range(num_gts):
             gt_lvl = gt_bboxes_lvl[idx]


### PR DESCRIPTION
When training RepPoints, `points_range` will be on CPU and `lvl_idx` will be on GPU, while `points_range[lvl_idx]` is called.

## Modification

points_range.to(gt_bboxes_lvl.device)
