### PR TITLE
[WIP][Fix] Solve the problem of lvis AP degradation in 3.x

### DIFF
--- a/mmdet/datasets/lvis.py
+++ b/mmdet/datasets/lvis.py
@@ -633,6 +633,21 @@ class LVISV1Dataset(LVISDataset):
                 total_ann_ids
             ), f"Annotation ids in '{self.ann_file}' are not unique!"
 
-        del self.lvis
+        # del self.lvis
 
         return data_list
+
+    def get_cat_ids(self, idx):
+        """Get COCO category ids by index.
+
+        Args:
+            idx (int): Index of data.
+
+        Returns:
+            list[int]: All categories in the image of specified index.
+        """
+
+        img_id = self.get_data_info(idx)['img_id']
+        ann_ids = self.lvis.get_ann_ids(img_ids=[img_id])
+        ann_info = self.lvis.load_anns(ann_ids)
+        return [ann['category_id'] for ann in ann_info]

--- a/tools/misc/download_dataset.py
+++ b/tools/misc/download_dataset.py
@@ -148,7 +148,7 @@ def main():
         ],
         lvis=[
             'https://s3-us-west-2.amazonaws.com/dl.fbaipublicfiles.com/LVIS/lvis_v1_train.json.zip',  # noqa
-            'https://s3-us-west-2.amazonaws.com/dl.fbaipublicfiles.com/LVIS/lvis_v1_train.json.zip',  # noqa
+            'https://s3-us-west-2.amazonaws.com/dl.fbaipublicfiles.com/LVIS/lvis_v1_val.json.zip',  # noqa
         ],
         voc2007=[
             'http://host.robots.ox.ac.uk/pascal/VOC/voc2007/VOCtrainval_06-Nov-2007.tar',  # noqa


### PR DESCRIPTION
After refactoring to MMDet 3.x, the AP of `lvis` is reduced. This PR is going to fix this bug.

## Description of the problem
In MMDet 2.x, `get_cat_ids` is directly obtained from `self.coco` (which means `self.lvis` in MMDet 3.x):

https://github.com/open-mmlab/mmdetection/blob/e9cae2d0787cd5c2fc6165a6061f92fa09e48fb1/mmdet/datasets/coco.py#L106-L119

While, in 3.x, it is obtained from `self.data_info`:

https://github.com/open-mmlab/mmdetection/blob/05f42355edb901e41264e680b7f225f6a4a23689/mmdet/datasets/base_det_dataset.py#L110-L120

Some instances will be filtered when loading annotation. Hence, in `ClassBalancedDataset`, `cat_ids` may empty. (This is the core problem that AP reduced in 3.x)
```python
for idx in range(num_images):
    cat_ids = set(self.dataset.get_cat_ids(idx))
    if len(cat_ids) != 0:
         repeat_factor = max(
            {category_repeat[cat_id]
             for cat_id in cat_ids})
          repeat_factors.append(repeat_factor)
```
![image](https://user-images.githubusercontent.com/48282753/228163509-9c4992e0-21d1-490b-9e6f-189d1136a782.png)

If the cat_ids is empty, the operation will be skipped. And the length of the `repeat_factors` will not equal to `len(self.dataset)`. The index of the image without any label will be replaced by the next image, and this will cause error.

```python
repeat_indices = []
for dataset_index, repeat_factor in enumerate(repeat_factors):
    repeat_indices.extend([dataset_index] * math.ceil(repeat_factor))
```

### Results

Released results in mmdet2.x:
```
{"mode": "val", "epoch": 12, "iter": 7674, "lr": 0.0002, "bbox_AP": 0.225, "bbox_AP50": 0.369, "bbox_AP75": 0.238, "bbox_APs": 0.168, "bbox_APm": 0.297, "bbox_APl": 0.35, "bbox_APr": 0.091, "bbox_APc": 0.211, "bbox_APf": 0.301, 
 "bbox_mAP_copypaste": "AP:0.225 AP50:0.369 AP75:0.238 APs:0.168 APm:0.297 APl:0.350 APr:0.091 APc:0.211 APf:0.301", 
 "segm_AP": 0.217, "segm_AP50": 0.343, "segm_AP75": 0.23, "segm_APs": 0.152, "segm_APm": 0.294, "segm_APl": 0.351, "segm_APr": 0.096, "segm_APc": 0.21, "segm_APf": 0.278, 
 "segm_mAP_copypaste": "AP:0.217 AP50:0.343 AP75:0.230 APs:0.152 APm:0.294 APl:0.351 APr:0.096 APc:0.210 APf:0.278"}
```

After fixing this error:
```shell
03/28 15:12:01 - mmengine - INFO - Evaluating bbox...
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=all] = 0.229
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=300 catIds=all] = 0.376
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=300 catIds=all] = 0.239
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     s | maxDets=300 catIds=all] = 0.173
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     m | maxDets=300 catIds=all] = 0.300
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     l | maxDets=300 catIds=all] = 0.350
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  r] = 0.105
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  c] = 0.213 
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  f] = 0.300 
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=all] = 0.313
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     s | maxDets=300 catIds=all] = 0.219
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     m | maxDets=300 catIds=all] = 0.402
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     l | maxDets=300 catIds=all] = 0.480
03/28 15:22:23 - mmengine - INFO - Evaluating segm...
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=all] = 0.223
 Average Precision  (AP) @[ IoU=0.50      | area=   all | maxDets=300 catIds=all] = 0.350
 Average Precision  (AP) @[ IoU=0.75      | area=   all | maxDets=300 catIds=all] = 0.238
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     s | maxDets=300 catIds=all] = 0.158
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     m | maxDets=300 catIds=all] = 0.297
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=     l | maxDets=300 catIds=all] = 0.354
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  r] = 0.117
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  c] = 0.214
 Average Precision  (AP) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=  f] = 0.279
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=   all | maxDets=300 catIds=all] = 0.303
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     s | maxDets=300 catIds=all] = 0.202
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     m | maxDets=300 catIds=all] = 0.396
 Average Recall     (AR) @[ IoU=0.50:0.95 | area=     l | maxDets=300 catIds=all] = 0.479
03/28 15:34:31 - mmengine - INFO - Epoch(val) [12][2477/2477]  lvis/bbox_AP: 0.2290  lvis/bbox_AP50: 0.3760  lvis/bbox_AP75: 0.2390  lvis/bbox_APs: 0.1730  lvis/bbox_APm: 0.3000  lvis/bbox_APl: 0.3500  lvis/bbox_APr: 0.1050  lvis/bbox_APc: 0.2130  lvis/bbox_APf: 0.3000  lvis/segm_AP: 0.2230  lvis/segm_AP50: 0.3500  lvis/segm_AP75: 0.2380  lvis/segm_APs: 0.1580  lvis/segm_APm: 0.2970  lvis/segm_APl: 0.3540  lvis/segm_APr: 0.1170  lvis/segm_APc: 0.2140  lvis/segm_APf: 0.2790
```

### Way to fix this problem

Right now, we have temporarily solved this problem using the original solution, i.e. use 2.x `get_cat_ids` way (obtained from `self.lvis`.

We need to find a more elegant way to solve this error.

