### PR TITLE
update img_shape after Expand

### DIFF
--- a/mmdet/datasets/pipelines/transforms.py
+++ b/mmdet/datasets/pipelines/transforms.py
@@ -1112,6 +1112,7 @@ class Expand:
         expand_img[top:top + h, left:left + w] = img
 
         results['img'] = expand_img
+        results['img_shape'] = expand_img.shape
         # expand bboxes
         for key in results.get('bbox_fields', []):
             results[key] = results[key] + np.tile(


### PR DESCRIPTION

## Motivation

Updating img_shape after `Expand`, otherwise if there's a `RandomFlip` after `Expand` the result will be incorrect, because `RandomFlip` maintains flipped gt_bboxes using `result['img_shape']`.

## Modification

updating img_shape after `Expand`

## BC-breaking (Optional)

None

## Use cases (Optional)

```
train_pipeline = [
    dict(type='LoadImageFromFile', to_float32=True),
    dict(type='LoadAnnotations', with_bbox=True),
    dict( 
        type='Resize', 
        img_scale=[(480 // 2 - 20, 768 // 2 - 20), (480 // 2 + 20, 768 // 2 + 20)],
        multiscale_mode='range', 
        keep_ratio=True),  
    # Using RandomFlip after an Expand directly will course incorrect result before this commit, now it is fixed.
    dict( 
        type='Expand',
        mean=(0,),
        prob=0.5,
        ratio_range=(1.2, 1.5)),
    dict(type='RandomFlip', flip_ratio=0.5, direction=['horizontal']),
    dict(type='Normalize', **img_norm_cfg),
    dict(type='Pad', size_divisor=32),
    dict(type='DefaultFormatBundle'),
    dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels']),
]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
