### PR TITLE
[Fix] Fix the teacher_model is not automatically placed on the right device

### DIFF
--- a/mmdet/models/detectors/lad.py
+++ b/mmdet/models/detectors/lad.py
@@ -37,6 +37,8 @@ class LAD(KnowledgeDistillationSingleStageDetector):
         if teacher_ckpt is not None:
             load_checkpoint(
                 self.teacher_model, teacher_ckpt, map_location='cpu')
+        self.teacher_model_list = nn.ModuleList()
+        self.teacher_model_list.append(self.teacher_model)
 
     @property
     def with_teacher_neck(self):


### PR DESCRIPTION
## Motivation

In the model LAD, self.teacher_model is not placed in nn.ModuleList, which makes the module cannot automatically run on the Ascend NPU.

## Modification

Add self.teacher_model to nn.ModuleList so that it can be automatically placed on the correct device.
This may seem redundant, if there is a better way please let me know.

## BC-breaking (Optional)

Not affected.

## Use cases (Optional)

Not affected.
