### PR TITLE
[Fix] benchmark in windows.

### DIFF
--- a/mmdet/utils/benchmark.py
+++ b/mmdet/utils/benchmark.py
@@ -58,7 +58,7 @@ def print_process_memory(p: psutil.Process,
         uss_mem += gb_round(child_mem_info.uss)
         if hasattr(child_mem_info, 'pss'):
             pss_mem += gb_round(child_mem_info.pss)
-            
+
     process_count = 1 + len(p.children())
 
     log_msg = f'(GB) mem_used: {mem_used:.2f} | uss: {uss_mem:.2f} | '
@@ -66,7 +66,6 @@ def print_process_memory(p: psutil.Process,
         log_msg += f'pss: {pss_mem:.2f} | '
     log_msg += f'total_proc: {process_count}'
     print_log(log_msg, logger)
-
 
 
 class BaseBenchmark:

--- a/mmdet/utils/benchmark.py
+++ b/mmdet/utils/benchmark.py
@@ -50,15 +50,23 @@ def print_process_memory(p: psutil.Process,
     mem_used = gb_round(psutil.virtual_memory().used)
     memory_full_info = p.memory_full_info()
     uss_mem = gb_round(memory_full_info.uss)
-    pss_mem = gb_round(memory_full_info.pss)
+    if hasattr(memory_full_info, 'pss'):
+        pss_mem = gb_round(memory_full_info.pss)
+
     for children in p.children():
         child_mem_info = children.memory_full_info()
         uss_mem += gb_round(child_mem_info.uss)
-        pss_mem += gb_round(child_mem_info.pss)
+        if hasattr(child_mem_info, 'pss'):
+            pss_mem += gb_round(child_mem_info.pss)
+            
     process_count = 1 + len(p.children())
-    print_log(
-        f'(GB) mem_used: {mem_used:.2f} | uss: {uss_mem:.2f} | '
-        f'pss: {pss_mem:.2f} | total_proc: {process_count}', logger)
+
+    log_msg = f'(GB) mem_used: {mem_used:.2f} | uss: {uss_mem:.2f} | '
+    if hasattr(memory_full_info, 'pss'):
+        log_msg += f'pss: {pss_mem:.2f} | '
+    log_msg += f'total_proc: {process_count}'
+    print_log(log_msg, logger)
+
 
 
 class BaseBenchmark:


### PR DESCRIPTION
Fix the issue that `benchmark.py` cannot be used on Windows due to the inability to obtain Proportional Set Size on Windows.

## Motivation

The error occurs when running [tools/analysis_tools/benchmark.py](https://github.com/open-mmlab/mmdetection/blob/ecac3a77becc63f23d9f6980b2a36f86acd00a8a/tools/analysis_tools/benchmark.py) on Windows environment because memory_full_info.pss [**cannot** be obtained on Windows](https://psutil.readthedocs.io/en/latest/#psutil.Process.memory_info:~:text=terminated%20right%20now.-,pss,-(Linux)%3A%20aka).
https://github.com/open-mmlab/mmdetection/blob/ecac3a77becc63f23d9f6980b2a36f86acd00a8a/mmdet/utils/benchmark.py#L53-L61

## Modification

Added a check for the existence of `memory_full_info.pss`, and if it does not exist, Proportional Set Size will not be obtained and displayed.

## etc. 

As far as I know, the concept of Proportional Set Size is related to Linux Page Cache, which makes it impossible to find a strict replacement indicator for Windows. I have tried to find alternatives for Windows, but according to an [old article](https://superuser.com/questions/413900/is-there-a-tool-that-measures-proportional-set-size-pss-on-windows-7), there does not seem to be a strictly consistent replacement.

Rather than using a compromised substitute that causes implicit inconsistencies in the metric, I think it should be removed on Windows.
