### PR TITLE
Seems to correct #8208

### DIFF
--- a/mmdet/models/backbones/cspnext.py
+++ b/mmdet/models/backbones/cspnext.py
@@ -169,6 +169,8 @@ class CSPNeXt(BaseModule):
             self.add_module(f'stage{i + 1}', nn.Sequential(*stage))
             self.layers.append(f'stage{i + 1}')
 
+        self._freeze_stages()
+
     def _freeze_stages(self) -> None:
         if self.frozen_stages >= 0:
             for i in range(self.frozen_stages + 1):

--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -641,6 +641,8 @@ class SwinTransformer(BaseModule):
             layer_name = f'norm{i}'
             self.add_module(layer_name, layer)
 
+        self._freeze_stages()
+
     def train(self, mode=True):
         """Convert the model into training mode while keep layers freezed."""
         super(SwinTransformer, self).train(mode)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This appears to fix #8208 for me, but correct me if I'm wrong (if there's any unintended consequences to this modification)

## Modification

Fix the error when using frozen stages in swin and cspnext:

> RuntimeError: Expected to have finished reduction in the prior iteration before starting a new one.

I believe this can be fixed by adding `self._freeze_stages()` at the end of the backbone `__init__` methods

## BC-breaking (Optional)

Not that I'm aware of

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
