### PR TITLE
[Feature] add SIoULoss implementation

### DIFF
--- a/mmdet/models/losses/__init__.py
+++ b/mmdet/models/losses/__init__.py
@@ -34,6 +34,6 @@ __all__ = [
     'weight_reduce_loss', 'weighted_loss', 'L1Loss', 'l1_loss', 'isr_p',
     'carl_loss', 'AssociativeEmbeddingLoss', 'GaussianFocalLoss',
     'QualityFocalLoss', 'DistributionFocalLoss', 'VarifocalLoss',
-    'KnowledgeDistillationKLDivLoss', 'SeesawLoss', 'DiceLoss', 'EQLV2Loss', 'MarginL2Loss',
-    'MultiPosCrossEntropyLoss', 'L2Loss', 'TripletLoss'
+    'KnowledgeDistillationKLDivLoss', 'SeesawLoss', 'DiceLoss', 'EQLV2Loss',
+    'MarginL2Loss', 'MultiPosCrossEntropyLoss', 'L2Loss', 'TripletLoss'
 ]

--- a/mmdet/models/losses/__init__.py
+++ b/mmdet/models/losses/__init__.py
@@ -11,7 +11,7 @@ from .gaussian_focal_loss import GaussianFocalLoss
 from .gfocal_loss import DistributionFocalLoss, QualityFocalLoss
 from .ghm_loss import GHMC, GHMR
 from .iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss, EIoULoss, GIoULoss,
-                       IoULoss, bounded_iou_loss, iou_loss)
+                       IoULoss, SIoULoss, bounded_iou_loss, iou_loss)
 from .kd_loss import KnowledgeDistillationKLDivLoss
 from .l2_loss import L2Loss
 from .margin_loss import MarginL2Loss
@@ -30,10 +30,10 @@ __all__ = [
     'FocalLoss', 'smooth_l1_loss', 'SmoothL1Loss', 'balanced_l1_loss',
     'BalancedL1Loss', 'mse_loss', 'MSELoss', 'iou_loss', 'bounded_iou_loss',
     'IoULoss', 'BoundedIoULoss', 'GIoULoss', 'DIoULoss', 'CIoULoss',
-    'EIoULoss', 'GHMC', 'GHMR', 'reduce_loss', 'weight_reduce_loss',
-    'weighted_loss', 'L1Loss', 'l1_loss', 'isr_p', 'carl_loss',
-    'AssociativeEmbeddingLoss', 'GaussianFocalLoss', 'QualityFocalLoss',
-    'DistributionFocalLoss', 'VarifocalLoss', 'KnowledgeDistillationKLDivLoss',
-    'SeesawLoss', 'DiceLoss', 'EQLV2Loss', 'MarginL2Loss',
+    'EIoULoss', 'SIoULoss', 'GHMC', 'GHMR', 'reduce_loss',
+    'weight_reduce_loss', 'weighted_loss', 'L1Loss', 'l1_loss', 'isr_p',
+    'carl_loss', 'AssociativeEmbeddingLoss', 'GaussianFocalLoss',
+    'QualityFocalLoss', 'DistributionFocalLoss', 'VarifocalLoss',
+    'KnowledgeDistillationKLDivLoss', 'SeesawLoss', 'DiceLoss', 'EQLV2Loss', 'MarginL2Loss',
     'MultiPosCrossEntropyLoss', 'L2Loss', 'TripletLoss'
 ]

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -361,7 +361,7 @@ def siou_loss(pred, target, eps=1e-7, neg_gamma=False):
     sin_alpha_2 = torch.abs(s_ch) / sigma
     threshold = pow(2, 0.5) / 2
     sin_alpha = torch.where(sin_alpha_1 > threshold, sin_alpha_2, sin_alpha_1)
-    angle_cost = torch.cos(torch.arcsin(sin_alpha) * 2 - math.pi / 2)
+    angle_cost = torch.cos(torch.asin(sin_alpha) * 2 - math.pi / 2)
 
     # distance cost
     rho_x = (s_cw / cw)**2

--- a/mmdet/models/losses/iou_loss.py
+++ b/mmdet/models/losses/iou_loss.py
@@ -303,6 +303,87 @@ def eiou_loss(pred: Tensor,
     return loss
 
 
+@weighted_loss
+def siou_loss(pred, target, eps=1e-7, neg_gamma=False):
+    r"""`Implementation of paper `SIoU Loss: More Powerful Learning
+    for Bounding Box Regression <https://arxiv.org/abs/2205.12740>`_.
+
+    Code is modified from https://github.com/meituan/YOLOv6.
+
+    Args:
+        pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
+            shape (n, 4).
+        target (Tensor): Corresponding gt bboxes, shape (n, 4).
+        eps (float): Eps to avoid log(0).
+        neg_gamma (bool): `True` follows original implementation in paper.
+
+    Return:
+        Tensor: Loss tensor.
+    """
+    # overlap
+    lt = torch.max(pred[:, :2], target[:, :2])
+    rb = torch.min(pred[:, 2:], target[:, 2:])
+    wh = (rb - lt).clamp(min=0)
+    overlap = wh[:, 0] * wh[:, 1]
+
+    # union
+    ap = (pred[:, 2] - pred[:, 0]) * (pred[:, 3] - pred[:, 1])
+    ag = (target[:, 2] - target[:, 0]) * (target[:, 3] - target[:, 1])
+    union = ap + ag - overlap + eps
+
+    # IoU
+    ious = overlap / union
+
+    # enclose area
+    enclose_x1y1 = torch.min(pred[:, :2], target[:, :2])
+    enclose_x2y2 = torch.max(pred[:, 2:], target[:, 2:])
+    # modified clamp threshold zero to eps to avoid NaN
+    enclose_wh = (enclose_x2y2 - enclose_x1y1).clamp(min=eps)
+
+    cw = enclose_wh[:, 0]
+    ch = enclose_wh[:, 1]
+
+    b1_x1, b1_y1 = pred[:, 0], pred[:, 1]
+    b1_x2, b1_y2 = pred[:, 2], pred[:, 3]
+    b2_x1, b2_y1 = target[:, 0], target[:, 1]
+    b2_x2, b2_y2 = target[:, 2], target[:, 3]
+
+    w1, h1 = b1_x2 - b1_x1, b1_y2 - b1_y1 + eps
+    w2, h2 = b2_x2 - b2_x1, b2_y2 - b2_y1 + eps
+
+    # angle cost
+    s_cw = (b2_x1 + b2_x2 - b1_x1 - b1_x2) * 0.5 + eps
+    s_ch = (b2_y1 + b2_y2 - b1_y1 - b1_y2) * 0.5 + eps
+
+    sigma = torch.pow(s_cw**2 + s_ch**2, 0.5)
+
+    sin_alpha_1 = torch.abs(s_cw) / sigma
+    sin_alpha_2 = torch.abs(s_ch) / sigma
+    threshold = pow(2, 0.5) / 2
+    sin_alpha = torch.where(sin_alpha_1 > threshold, sin_alpha_2, sin_alpha_1)
+    angle_cost = torch.cos(torch.arcsin(sin_alpha) * 2 - math.pi / 2)
+
+    # distance cost
+    rho_x = (s_cw / cw)**2
+    rho_y = (s_ch / ch)**2
+
+    # `neg_gamma=True` follows original implementation in paper
+    # but setting `neg_gamma=False` makes training more stable.
+    gamma = angle_cost - 2 if neg_gamma else 2 - angle_cost
+    distance_cost = 2 - torch.exp(gamma * rho_x) - torch.exp(gamma * rho_y)
+
+    # shape cost
+    omiga_w = torch.abs(w1 - w2) / torch.max(w1, w2)
+    omiga_h = torch.abs(h1 - h2) / torch.max(h1, h2)
+    shape_cost = torch.pow(1 - torch.exp(-1 * omiga_w), 4) + torch.pow(
+        1 - torch.exp(-1 * omiga_h), 4)
+
+    # SIoU
+    sious = ious - 0.5 * (distance_cost + shape_cost)
+    loss = 1 - sious.clamp(min=-1.0, max=1.0)
+    return loss
+
+
 @MODELS.register_module()
 class IoULoss(nn.Module):
     """IoULoss.
@@ -740,5 +821,84 @@ class EIoULoss(nn.Module):
             eps=self.eps,
             reduction=reduction,
             avg_factor=avg_factor,
+            **kwargs)
+        return loss
+
+
+@MODELS.register_module()
+class SIoULoss(nn.Module):
+    r"""`Implementation of paper `SIoU Loss: More Powerful Learning
+    for Bounding Box Regression <https://arxiv.org/abs/2205.12740>`_.
+
+    Code is modified from https://github.com/meituan/YOLOv6.
+
+    Args:
+        pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
+            shape (n, 4).
+        target (Tensor): Corresponding gt bboxes, shape (n, 4).
+        eps (float): Eps to avoid log(0).
+        neg_gamma (bool): `True` follows original implementation in paper.
+
+    Return:
+        Tensor: Loss tensor.
+    """
+
+    def __init__(self,
+                 eps: float = 1e-6,
+                 reduction: str = 'mean',
+                 loss_weight: float = 1.0,
+                 neg_gamma: bool = False) -> None:
+        super().__init__()
+        self.eps = eps
+        self.reduction = reduction
+        self.loss_weight = loss_weight
+        self.neg_gamma = neg_gamma
+
+    def forward(self,
+                pred: Tensor,
+                target: Tensor,
+                weight: Optional[Tensor] = None,
+                avg_factor: Optional[int] = None,
+                reduction_override: Optional[str] = None,
+                **kwargs) -> Tensor:
+        """Forward function.
+
+        Args:
+            pred (Tensor): Predicted bboxes of format (x1, y1, x2, y2),
+                shape (n, 4).
+            target (Tensor): The learning target of the prediction,
+                shape (n, 4).
+            weight (Optional[Tensor], optional): The weight of loss for each
+                prediction. Defaults to None.
+            avg_factor (Optional[int], optional): Average factor that is used
+                to average the loss. Defaults to None.
+            reduction_override (Optional[str], optional): The reduction method
+                used to override the original reduction method of the loss.
+                Defaults to None. Options are "none", "mean" and "sum".
+
+        Returns:
+            Tensor: Loss tensor.
+        """
+        if weight is not None and not torch.any(weight > 0):
+            if pred.dim() == weight.dim() + 1:
+                weight = weight.unsqueeze(1)
+            return (pred * weight).sum()  # 0
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+        if weight is not None and weight.dim() > 1:
+            # TODO: remove this in the future
+            # reduce the weight of shape (n, 4) to (n,) to match the
+            # giou_loss of shape (n,)
+            assert weight.shape == pred.shape
+            weight = weight.mean(-1)
+        loss = self.loss_weight * siou_loss(
+            pred,
+            target,
+            weight,
+            eps=self.eps,
+            reduction=reduction,
+            avg_factor=avg_factor,
+            neg_gamma=self.neg_gamma,
             **kwargs)
         return loss

--- a/tests/test_models/test_losses/test_loss.py
+++ b/tests/test_models/test_losses/test_loss.py
@@ -12,12 +12,13 @@ from mmdet.models.losses import (BalancedL1Loss, CrossEntropyLoss, DiceLoss,
                                  SeesawLoss, SmoothL1Loss, VarifocalLoss)
 from mmdet.models.losses.ghm_loss import GHMC, GHMR
 from mmdet.models.losses.iou_loss import (BoundedIoULoss, CIoULoss, DIoULoss,
-                                          EIoULoss, GIoULoss, IoULoss)
+                                          EIoULoss, GIoULoss, IoULoss,
+                                          SIoULoss)
 
 
-@pytest.mark.parametrize(
-    'loss_class',
-    [IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss])
+@pytest.mark.parametrize('loss_class', [
+    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss, SIoULoss
+])
 def test_iou_type_loss_zeros_weight(loss_class):
     pred = torch.rand((10, 4))
     target = torch.rand((10, 4))
@@ -29,7 +30,7 @@ def test_iou_type_loss_zeros_weight(loss_class):
 
 @pytest.mark.parametrize('loss_class', [
     BalancedL1Loss, BoundedIoULoss, CIoULoss, CrossEntropyLoss, DIoULoss,
-    EIoULoss, FocalLoss, DistributionFocalLoss, MSELoss, SeesawLoss,
+    EIoULoss, SIoULoss, FocalLoss, DistributionFocalLoss, MSELoss, SeesawLoss,
     GaussianFocalLoss, GIoULoss, QualityFocalLoss, IoULoss, L1Loss,
     VarifocalLoss, GHMR, GHMC, SmoothL1Loss, KnowledgeDistillationKLDivLoss,
     DiceLoss
@@ -68,8 +69,8 @@ def test_QualityFocalLoss_Loss(loss_class, activated):
 
 
 @pytest.mark.parametrize('loss_class', [
-    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss, MSELoss,
-    L1Loss, SmoothL1Loss, BalancedL1Loss, MarginL2Loss
+    IoULoss, BoundedIoULoss, GIoULoss, DIoULoss, CIoULoss, EIoULoss, SIoULoss,
+    MSELoss, L1Loss, SmoothL1Loss, BalancedL1Loss, MarginL2Loss
 ])
 @pytest.mark.parametrize('input_shape', [(10, 4), (0, 4)])
 def test_regression_losses(loss_class, input_shape):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The paper [SIoU Loss: More Powerful Learning for Bounding Box Regression](https://arxiv.org/abs/2205.12740) proposes SIoU that calculates IoU, shape, and distance loss, and outperforms the commonly used GIOU and DIOU in object detection.

## Modification

- Add implementation of SIoU Loss in `mmdet/models/losses/iou_loss.py`, modified from [YOLOv6](https://github.com/meituan/YOLOv6)
- Different from original realization `gamma=2-angle_cost`, setting `neg_gamma` parameter to use `gamma=angle_cost-2` seems to make training more stable.

## Use cases (Optional)

In config:
 `loss_bbox=dict(type='SIoULoss', loss_weight=1.0, neg_gamma=False)`
