### PR TITLE
update version in config_migration.md

### DIFF
--- a/docs/en/migration/config_migration.md
+++ b/docs/en/migration/config_migration.md
@@ -31,7 +31,7 @@ pipeline=[
 
 </td>
 <tr>
-<td>2.x Config</td>
+<td>3.x Config</td>
 <td>
 
 ```python


### PR DESCRIPTION
## Motivation

Just a small edit, the version when comparing configs in the MIGRATE CONFIGURATION FILE FROM MMDETECTION 2.X TO 3.X were both `2.x` I just updated it.

## Modification

Change `2.x Config` to `3.x Config` in `docs/en/migration/config_migration.md`

## BC-breaking (Optional)

Not breaking

## Use cases (Optional)

Not applicable 

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMCls.
4. The documentation has been modified accordingly, like docstring or example tutorials.
