### PR TITLE
修复rtmdet-ins tiny没有开启recompute_bbox导致bbox和mask对不上的bug

### DIFF
--- a/configs/rtmdet/rtmdet-ins_tiny_8xb32-300e_coco.py
+++ b/configs/rtmdet/rtmdet-ins_tiny_8xb32-300e_coco.py
@@ -29,7 +29,11 @@ train_pipeline = [
         scale=(1280, 1280),
         ratio_range=(0.5, 2.0),
         keep_ratio=True),
-    dict(type='RandomCrop', crop_size=(640, 640)),
+    dict(
+        type='RandomCrop',
+        crop_size=(640, 640),
+        recompute_bbox=True,
+        allow_negative_crop=True),
     dict(type='YOLOXHSVRandomAug'),
     dict(type='RandomFlip', prob=0.5),
     dict(type='Pad', size=(640, 640), pad_val=dict(img=(114, 114, 114))),


### PR DESCRIPTION
## Motivation

害，搞了很久，原来是你们的bug，唯独rtmdet-ins tiny是没有开启recompute_bbox的！没有开启就不会根据mask重新调整bbox的位置，和bbox对不上还怎么训练。好奇你们当初是怎么用错误的配置训练出来的？

## Modification

开启rtmdet-ins tiny的recompute_bbox
