### PR TITLE
[fix] fix `pred` and `weight` dims unmatch in [Smooth]L1Loss

### DIFF
--- a/mmdet/models/losses/smooth_l1_loss.py
+++ b/mmdet/models/losses/smooth_l1_loss.py
@@ -96,6 +96,10 @@ class SmoothL1Loss(nn.Module):
         Returns:
             Tensor: Calculated loss
         """
+        if weight is not None and not torch.any(weight > 0):
+            if pred.dim() == weight.dim() + 1:
+                weight = weight.unsqueeze(1)
+            return (pred * weight).sum()  # 0
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)
@@ -149,6 +153,10 @@ class L1Loss(nn.Module):
         Returns:
             Tensor: Calculated loss
         """
+        if weight is not None and not torch.any(weight > 0):
+            if pred.dim() == weight.dim() + 1:
+                weight = weight.unsqueeze(1)
+            return (pred * weight).sum()  # 0
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)

--- a/mmdet/models/losses/smooth_l1_loss.py
+++ b/mmdet/models/losses/smooth_l1_loss.py
@@ -99,7 +99,7 @@ class SmoothL1Loss(nn.Module):
         if weight is not None and not torch.any(weight > 0):
             if pred.dim() == weight.dim() + 1:
                 weight = weight.unsqueeze(1)
-            return (pred * weight).sum()  # 0
+            return (pred * weight).sum()
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)

--- a/mmdet/models/losses/smooth_l1_loss.py
+++ b/mmdet/models/losses/smooth_l1_loss.py
@@ -156,7 +156,7 @@ class L1Loss(nn.Module):
         if weight is not None and not torch.any(weight > 0):
             if pred.dim() == weight.dim() + 1:
                 weight = weight.unsqueeze(1)
-            return (pred * weight).sum()  # 0
+            return (pred * weight).sum()
         assert reduction_override in (None, 'none', 'mean', 'sum')
         reduction = (
             reduction_override if reduction_override else self.reduction)


### PR DESCRIPTION
#4982 #10323 All similar problems are caused by `weight`. Should we take them to `weighted_loss` for processing.