### PR TITLE
Add FROC metrics

### DIFF
--- a/mmdet/evaluation/metrics/__init__.py
+++ b/mmdet/evaluation/metrics/__init__.py
@@ -9,9 +9,10 @@ from .dump_proposals_metric import DumpProposals
 from .lvis_metric import LVISMetric
 from .openimages_metric import OpenImagesMetric
 from .voc_metric import VOCMetric
+from .coco_froc_metric import CocoFROCMetric
 
 __all__ = [
     'CityScapesMetric', 'CocoMetric', 'CocoPanopticMetric', 'OpenImagesMetric',
     'VOCMetric', 'LVISMetric', 'CrowdHumanMetric', 'DumpProposals',
-    'CocoOccludedSeparatedMetric', 'DumpDetResults'
+    'CocoOccludedSeparatedMetric', 'DumpDetResults', 'CocoFROCMetric'
 ]

--- a/mmdet/evaluation/metrics/coco_froc_metric.py
+++ b/mmdet/evaluation/metrics/coco_froc_metric.py
@@ -1,0 +1,536 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import datetime
+import itertools
+import os.path as osp
+import tempfile
+from collections import OrderedDict
+from typing import Dict, List, Optional, Sequence, Union
+
+import numpy as np
+import torch, os
+from mmengine.evaluator import BaseMetric
+from mmengine.fileio import dump, get_local_path, load
+from mmengine.logging import MMLogger
+from terminaltables import AsciiTable
+
+from mmdet.datasets.api_wrappers import COCO, COCOeval
+from mmdet.registry import METRICS
+from mmdet.structures.mask import encode_mask_results
+from ..functional.bbox_overlaps import bbox_overlaps
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# reference: https://github.com/fpgdubost/FROC-Free-response-Receiver-Operating-Characteristic-curve
+@METRICS.register_module()
+class CocoFROCMetric(BaseMetric):
+    """
+    Args:
+        ann_file (str, optional): Path to the coco format annotation file.
+            If not specified, ground truth annotations from the dataset will
+            be converted to coco format. Defaults to None.
+        metric (str | List[str]): Metrics to be evaluated. Valid metrics
+            include 'bbox', 'segm', 'proposal', and 'proposal_fast'.
+            Defaults to 'bbox'.
+        classwise (bool): Whether to evaluate the metric class-wise.
+            Defaults to False.
+        proposal_nums (Sequence[int]): Numbers of proposals to be evaluated.
+            Defaults to (100, 300, 1000).
+        iou_thr (float | optional): IoU threshold.
+        log_thres (Sequence[int]): Horizontal coordinate of a log indicator.
+        metric_items (List[str], optional): Metric result names to be
+            recorded in the evaluation result. Defaults to None.
+        format_only (bool): Format the output results without perform
+            evaluation. It is useful when you want to format the result
+            to a specific format and submit it to the test server.
+            Defaults to False.
+        outfile_prefix (str, optional): The prefix of json files. It includes
+            the file path and the prefix of filename, e.g., "a/b/prefix".
+            If not specified, a temp file will be created. Defaults to None.
+        file_client_args (dict, optional): Arguments to instantiate the
+            corresponding backend in mmdet <= 3.0.0rc6. Defaults to None.
+        backend_args (dict, optional): Arguments to instantiate the
+            corresponding backend. Defaults to None.
+        collect_device (str): Device name used for collecting results from
+            different ranks during distributed training. Must be 'cpu' or
+            'gpu'. Defaults to 'cpu'.
+        prefix (str, optional): The prefix that will be added in the metric
+            names to disambiguate homonymous metrics of different evaluators.
+            If prefix is not provided in the argument, self.default_prefix
+            will be used instead. Defaults to None.
+        sort_categories (bool): Whether sort categories in annotations. Only
+            used for `Objects365V1Dataset`. Defaults to False.
+    """
+    default_prefix: Optional[str] = 'coco'
+
+    def __init__(self,
+                 ann_file: Optional[str] = None,
+                 metric: Union[str, List[str]] = 'bbox_froc',
+                 classwise: bool = False,
+                 proposal_nums: Sequence[int] = (100, 300, 1000),
+                 iou_thr: Optional[float] = 0.3,
+                 log_thres: Sequence[int] = (1, 5, 10, 15, 20, 30),
+                 metric_items: Optional[Sequence[str]] = None,
+                 format_only: bool = False,
+                 outfile_prefix: Optional[str] = None,
+                 file_client_args: dict = None,
+                 backend_args: dict = None,
+                 collect_device: str = 'cpu',
+                 prefix: Optional[str] = None,
+                 sort_categories: bool = False) -> None:
+        super().__init__(collect_device=collect_device, prefix=prefix)
+        # coco evaluation metrics
+        self.metrics = metric if isinstance(metric, list) else [metric]
+        allowed_metrics = ['bbox_froc']
+        for metric in self.metrics:
+            if metric not in allowed_metrics:
+                raise KeyError(
+                    "metric should be one of 'bbox_froc' ..., but got {metric}.")
+
+        # do class wise evaluation, default False
+        self.classwise = classwise
+
+        # false_pos_nums used to compute recall or precision.
+        self.proposal_nums = list(proposal_nums)
+
+        self.iou_thr = iou_thr
+        self.log_thres = log_thres
+        self.metric_items = metric_items
+        self.format_only = format_only
+        if self.format_only:
+            assert outfile_prefix is not None, 'outfile_prefix must be not'
+            'None when format_only is True, otherwise the result files will'
+            'be saved to a temp directory which will be cleaned up at the end.'
+
+        self.outfile_prefix = outfile_prefix
+
+        self.backend_args = backend_args
+        if file_client_args is not None:
+            raise RuntimeError(
+                'The `file_client_args` is deprecated, '
+                'please use `backend_args` instead, please refer to'
+                'https://github.com/open-mmlab/mmdetection/blob/main/configs/_base_/datasets/coco_detection.py'  # noqa: E501
+            )
+
+        # if ann_file is not specified,
+        # initialize coco api with the converted dataset
+        if ann_file is not None:
+            with get_local_path(
+                    ann_file, backend_args=self.backend_args) as local_path:
+                self._coco_api = COCO(local_path)
+                if sort_categories:
+                    # 'categories' list in objects365_train.json and
+                    # objects365_val.json is inconsistent, need sort
+                    # list(or dict) before get cat_ids.
+                    cats = self._coco_api.cats
+                    sorted_cats = {i: cats[i] for i in sorted(cats)}
+                    self._coco_api.cats = sorted_cats
+                    categories = self._coco_api.dataset['categories']
+                    sorted_categories = sorted(
+                        categories, key=lambda i: i['id'])
+                    self._coco_api.dataset['categories'] = sorted_categories
+        else:
+            self._coco_api = None
+
+        # handle dataset lazy init
+        self.cat_ids = None
+        self.img_ids = None
+    
+    def _eval_recalls(self, gt_bboxes, pred_bboxes, proposal_nums, iou_thr, image_files=None, logger=None):
+        img_num = len(gt_bboxes)
+        assert img_num == len(pred_bboxes)
+
+        if isinstance(proposal_nums, Sequence):
+            proposal_nums = np.array(proposal_nums)
+        elif isinstance(proposal_nums, int):
+            proposal_nums = np.array([proposal_nums])
+
+        thres_range = []
+        for pred_bboex in pred_bboxes:
+            thres_range += [round(score, 3) for score in pred_bboex[:, 4]]
+        thres_range = np.unique(thres_range).tolist()[1:]
+
+        recalls, avg_fps = [], []
+        for confidence_thre in thres_range:
+            recall_list, fp_list = [], []
+            for i in range(img_num):
+                pred_index = pred_bboxes[i][:, 4] >= confidence_thre
+                bboxes = pred_bboxes[i][pred_index]
+                if bboxes.ndim == 2 and bboxes.shape[1] == 5:
+                    scores = bboxes[:, 4]
+                    sort_idx = np.argsort(scores)[::-1]
+                    img_proposal = bboxes[sort_idx, :]
+                else: 
+                    img_proposal = bboxes
+                    
+                prop_num = img_proposal.shape[0]
+                if gt_bboxes[i] is None or gt_bboxes[i].shape[0] == 0:
+                    ious = np.zeros((0, img_proposal.shape[0]), dtype=np.float32)
+                else:
+                    ious = bbox_overlaps(
+                        gt_bboxes[i],
+                        img_proposal[:prop_num, :4])
+
+                if ious.size == 0:
+                    fp_list.append(prop_num)
+                    continue
+
+                gt_ious = np.zeros((ious.shape[0]))
+                for j in range(ious.shape[0]):
+                    gt_max_overlaps = ious.argmax(axis=1)
+                    max_ious = ious[np.arange(0, ious.shape[0]), gt_max_overlaps]
+                    gt_idx = max_ious.argmax()
+                    gt_ious[j] = max_ious[gt_idx]
+                    box_idx = gt_max_overlaps[gt_idx]
+                    ious[gt_idx, :] = -1
+                    ious[:, box_idx] = -1
+
+                P = ious.shape[0]
+                TP = np.sum(gt_ious >= iou_thr)
+                FP = prop_num - TP
+                fp_list.append(FP)
+                recall_list.append(1.0 * TP / P)
+
+            # if image_files:
+            #     logger.info(f'froc threshold: {confidence_thre}')
+            #     logger.info(f'froc FP:' + str({name: fp_list[i] for i, name in enumerate(image_files)}))
+
+            recalls.append(np.mean(recall_list))
+            avg_fps.append(np.mean(fp_list))
+
+        return recalls, avg_fps, thres_range
+
+    def eval_froc(self, results: List[dict],
+                        proposal_nums: Sequence[int],
+                        iou_thr, 
+                         logger: Optional[MMLogger] = None):
+        """Evaluate proposal recall with eval_froc.
+
+        Args:
+            results (List[dict]): Results of the dataset.
+            proposal_nums (Sequence[int]): Proposal numbers used for
+                evaluation.
+            iou_thrs (Sequence[float]): IoU thresholds used for evaluation.
+            logger (MMLogger, optional): Logger used for logging the recall
+                summary.
+        Returns:
+            np.ndarray: Averaged recall results.`
+        """
+        gt_bboxes = []
+        pred_bboxes = [np.hstack([result['bboxes'], result['scores'].reshape(-1, 1)]) 
+                        for result in results]
+        image_files = [result['img_path'] for result in results]
+        
+        for i in range(len(self.img_ids)):
+            ann_ids = self._coco_api.get_ann_ids(img_ids=self.img_ids[i])
+            ann_info = self._coco_api.load_anns(ann_ids)
+            if len(ann_info) == 0:
+                gt_bboxes.append(np.zeros((0, 4)))
+                continue
+            bboxes = []
+            for ann in ann_info:
+                if ann.get('ignore', False) or ann['iscrowd']:
+                    continue
+                x1, y1, w, h = ann['bbox']
+                bboxes.append([x1, y1, x1 + w, y1 + h])
+            bboxes = np.array(bboxes, dtype=np.float32)
+            if bboxes.shape[0] == 0:
+                bboxes = np.zeros((0, 4))
+            gt_bboxes.append(bboxes)
+
+        recalls, avg_fps, thres = self._eval_recalls(
+                    gt_bboxes, pred_bboxes, proposal_nums, iou_thr, 
+                    image_files=image_files, logger=logger)
+        
+        return recalls, avg_fps, thres
+
+    def xyxy2xywh(self, bbox: np.ndarray) -> list:
+        """Convert ``xyxy`` style bounding boxes to ``xywh`` style for COCO
+        evaluation.
+
+        Args:
+            bbox (numpy.ndarray): The bounding boxes, shape (4, ), in
+                ``xyxy`` order.
+
+        Returns:
+            list[float]: The converted bounding boxes, in ``xywh`` order.
+        """
+
+        _bbox: List = bbox.tolist()
+        return [
+            _bbox[0],
+            _bbox[1],
+            _bbox[2] - _bbox[0],
+            _bbox[3] - _bbox[1],
+        ]
+
+    def results2json(self, results: Sequence[dict],
+                     outfile_prefix: str) -> dict:
+        """Dump the detection results to a COCO style json file.
+
+        There are 3 types of results: proposals, bbox predictions, mask
+        predictions, and they have different data types. This method will
+        automatically recognize the type, and dump them to json files.
+
+        Args:
+            results (Sequence[dict]): Testing results of the
+                dataset.
+            outfile_prefix (str): The filename prefix of the json files. If the
+                prefix is "somepath/xxx", the json files will be named
+                "somepath/xxx.bbox.json", "somepath/xxx.segm.json",
+                "somepath/xxx.proposal.json".
+
+        Returns:
+            dict: Possible keys are "bbox", "segm", "proposal", and
+            values are corresponding filenames.
+        """
+        bbox_json_results = []
+        segm_json_results = [] if 'masks' in results[0] else None
+        for idx, result in enumerate(results):
+            image_id = result.get('img_id', idx)
+            labels = result['labels']
+            bboxes = result['bboxes']
+            scores = result['scores']
+            # bbox results
+            for i, label in enumerate(labels):
+                data = dict()
+                data['image_id'] = image_id
+                data['bbox'] = self.xyxy2xywh(bboxes[i])
+                data['score'] = float(scores[i])
+                data['category_id'] = self.cat_ids[label]
+                bbox_json_results.append(data)
+
+            if segm_json_results is None:
+                continue
+
+            # segm results
+            masks = result['masks']
+            mask_scores = result.get('mask_scores', scores)
+            for i, label in enumerate(labels):
+                data = dict()
+                data['image_id'] = image_id
+                data['bbox'] = self.xyxy2xywh(bboxes[i])
+                data['score'] = float(mask_scores[i])
+                data['category_id'] = self.cat_ids[label]
+                if isinstance(masks[i]['counts'], bytes):
+                    masks[i]['counts'] = masks[i]['counts'].decode()
+                data['segmentation'] = masks[i]
+                segm_json_results.append(data)
+
+        result_files = dict()
+        result_files['bbox'] = f'{outfile_prefix}.bbox.json'
+        result_files['proposal'] = f'{outfile_prefix}.bbox.json'
+        dump(bbox_json_results, result_files['bbox'])
+
+        if segm_json_results is not None:
+            result_files['segm'] = f'{outfile_prefix}.segm.json'
+            dump(segm_json_results, result_files['segm'])
+
+        return result_files
+
+    def gt_to_coco_json(self, gt_dicts: Sequence[dict],
+                        outfile_prefix: str) -> str:
+        """Convert ground truth to coco format json file.
+
+        Args:
+            gt_dicts (Sequence[dict]): Ground truth of the dataset.
+            outfile_prefix (str): The filename prefix of the json files. If the
+                prefix is "somepath/xxx", the json file will be named
+                "somepath/xxx.gt.json".
+        Returns:
+            str: The filename of the json file.
+        """
+        categories = [
+            dict(id=id, name=name)
+            for id, name in enumerate(self.dataset_meta['classes'])
+        ]
+        image_infos = []
+        annotations = []
+
+        for idx, gt_dict in enumerate(gt_dicts):
+            img_id = gt_dict.get('img_id', idx)
+            image_info = dict(
+                id=img_id,
+                width=gt_dict['width'],
+                height=gt_dict['height'],
+                file_name='')
+            image_infos.append(image_info)
+            for ann in gt_dict['anns']:
+                label = ann['bbox_label']
+                bbox = ann['bbox']
+                coco_bbox = [
+                    bbox[0],
+                    bbox[1],
+                    bbox[2] - bbox[0],
+                    bbox[3] - bbox[1],
+                ]
+
+                annotation = dict(
+                    id=len(annotations) +
+                    1,  # coco api requires id starts with 1
+                    image_id=img_id,
+                    bbox=coco_bbox,
+                    iscrowd=ann.get('ignore_flag', 0),
+                    category_id=int(label),
+                    area=coco_bbox[2] * coco_bbox[3])
+                if ann.get('mask', None):
+                    mask = ann['mask']
+                    # area = mask_util.area(mask)
+                    if isinstance(mask, dict) and isinstance(
+                            mask['counts'], bytes):
+                        mask['counts'] = mask['counts'].decode()
+                    annotation['segmentation'] = mask
+                    # annotation['area'] = float(area)
+                annotations.append(annotation)
+
+        info = dict(
+            date_created=str(datetime.datetime.now()),
+            description='Coco json file converted by mmdet CocoMetric.')
+        coco_json = dict(
+            info=info,
+            images=image_infos,
+            categories=categories,
+            licenses=None,
+        )
+        if len(annotations) > 0:
+            coco_json['annotations'] = annotations
+        converted_json_path = f'{outfile_prefix}.gt.json'
+        dump(coco_json, converted_json_path)
+        return converted_json_path
+
+    # TODO: data_batch is no longer needed, consider adjusting the
+    #  parameter position
+    def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
+        """Process one batch of data samples and predictions. The processed
+        results should be stored in ``self.results``, which will be used to
+        compute the metrics when all batches have been processed.
+
+        Args:
+            data_batch (dict): A batch of data from the dataloader.
+            data_samples (Sequence[dict]): A batch of data samples that
+                contain annotations and predictions.
+        """
+        for data_sample in data_samples:
+            result = dict()
+            pred = data_sample['pred_instances']
+            result['img_path'] = data_sample['img_path']
+            result['img_id'] = data_sample['img_id']
+            result['bboxes'] = pred['bboxes'].cpu().numpy()
+            result['scores'] = pred['scores'].cpu().numpy()
+            result['labels'] = pred['labels'].cpu().numpy()
+            # encode mask to RLE
+            if 'masks' in pred:
+                result['masks'] = encode_mask_results(
+                    pred['masks'].detach().cpu().numpy()) if isinstance(
+                        pred['masks'], torch.Tensor) else pred['masks']
+            # some detectors use different scores for bbox and mask
+            if 'mask_scores' in pred:
+                result['mask_scores'] = pred['mask_scores'].cpu().numpy()
+
+            # parse gt
+            gt = dict()
+            gt['width'] = data_sample['ori_shape'][1]
+            gt['height'] = data_sample['ori_shape'][0]
+            gt['img_id'] = data_sample['img_id']
+            if self._coco_api is None:
+                # TODO: Need to refactor to support LoadAnnotations
+                assert 'instances' in data_sample, \
+                    'ground truth is required for evaluation when ' \
+                    '`ann_file` is not provided'
+                gt['anns'] = data_sample['instances']
+            # add converted result to the results list
+            self.results.append((gt, result))
+
+    def compute_metrics(self, results: list) -> Dict[str, float]:
+        """Compute the metrics from processed results.
+
+        Args:
+            results (list): The processed results of each batch.
+
+        Returns:
+            Dict[str, float]: The computed metrics. The keys are the names of
+            the metrics, and the values are corresponding results.
+        """
+        logger: MMLogger = MMLogger.get_current_instance()
+
+        # split gt and prediction list
+        gts, preds = zip(*results)
+
+        tmp_dir = None
+        if self.outfile_prefix is None:
+            tmp_dir = tempfile.TemporaryDirectory()
+            outfile_prefix = osp.join(tmp_dir.name, 'results')
+        else:
+            outfile_prefix = self.outfile_prefix
+
+        if self._coco_api is None:
+            # use converted gt json file to initialize coco api
+            logger.info('Converting ground truth to coco format...')
+            coco_json_path = self.gt_to_coco_json(
+                gt_dicts=gts, outfile_prefix=outfile_prefix)
+            self._coco_api = COCO(coco_json_path)
+
+        # handle lazy init
+        if self.cat_ids is None:
+            self.cat_ids = self._coco_api.get_cat_ids(
+                cat_names=self.dataset_meta['classes'])
+        if self.img_ids is None:
+            self.img_ids = self._coco_api.get_img_ids()
+
+        # convert predictions to coco format and dump to json file
+        # result_files = self.results2json(preds, outfile_prefix)
+
+        eval_results = OrderedDict()
+        if self.format_only:
+            logger.info('results are saved in '
+                        f'{osp.dirname(outfile_prefix)}')
+            return eval_results
+
+        for metric in self.metrics:
+            logger.info(f'Evaluating {metric}...')
+            
+            work_dir = os.path.dirname(logger.log_file)
+            if metric == 'bbox_froc':
+                # ars = [[...]:num1, [...]:num2, ...]
+                recalls, avg_fps, thres = self.eval_froc(preds, self.proposal_nums, 
+                                        self.iou_thr, logger=logger)
+                
+                # draw froc curve
+                plt.plot(avg_fps, recalls, '-')
+                plt.xlabel('False Positive Per Image')
+                plt.ylabel('Recall')
+                plt.xlim([1e-1, 1e2])
+                ax = plt.gca()
+                ax.set_xscale('log')
+                plt.savefig(os.path.join(work_dir, f'recall.png'))
+                
+                # save curve data
+                frame_json = {"recalls": recalls,
+                              "avg_fps": avg_fps,
+                              "thres": thres}
+                frame_data = pd.DataFrame(frame_json)
+                frame_data.to_csv(os.path.join(work_dir, f'recall.csv'),
+                                  index=False)
+                
+                log_msg = []
+                for thrs in self.log_thres:
+                    log_msg.append('\nR@{}: {}'.format(thrs, 
+                                self._interp(avg_fps, recalls, thrs)))
+                log_msg = ''.join(log_msg)
+                logger.info(log_msg)
+                continue
+
+        if tmp_dir is not None:
+            tmp_dir.cleanup()
+        return eval_results
+
+    def _interp(self, X, Y, x):
+        try:
+            min_idx = np.where(x <= np.array(X))[0][-1]
+            max_idx = np.where(np.array(X) <= x)[0][0]
+            min_x, max_x = X[min_idx], X[max_idx]
+            min_y, max_y = Y[min_idx], Y[max_idx]
+            inter_y = min_y + (max_y - min_y) * (x - min_x) / (max_x - min_x + 1e-8)
+            return round(inter_y * 100, 2)
+        except:
+            return np.nan


### PR DESCRIPTION
Add FROC curve drawing and read its performance metrics

## Motivation

In a scenario with many outliers, the AP index and ROC curve do not play a large role. The R(false positive per image) indicator and FROC curve play important roles in this scenario.

## Modification

Added the FROC metrics file and the corresponding registration component

## Use cases
``` python
val_evaluator = dict(
    type='CocoFROCMetric',
    ann_file=data_root + 'annotations/val.json',
    metric='bbox_froc',
    proposal_nums=(100, 300, 1000),
    iou_thr=0.1,
    log_thres=(1, 5, 10, 15, 20, 30),
    format_only=False,
    backend_args=backend_args)
```

- reference: https://github.com/fpgdubost/FROC-Free-response-Receiver-Operating-Characteristic-curve
