### PR TITLE
Fix device of the tensors in set_nms

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/multi_instance_bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/multi_instance_bbox_head.py
@@ -601,6 +601,10 @@ class MultiInstanceBBoxHead(BBoxHead):
 
         keep = torch.ones(len(ordered_bboxes)) == 1
         ruler = torch.arange(len(ordered_bboxes))
+
+        keep = keep.to(bboxes.device)
+        ruler = ruler.to(bboxes.device)
+        
         while ruler.shape[0] > 0:
             basement = ruler[0]
             ruler = ruler[1:]

--- a/mmdet/models/roi_heads/bbox_heads/multi_instance_bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/multi_instance_bbox_head.py
@@ -604,7 +604,7 @@ class MultiInstanceBBoxHead(BBoxHead):
 
         keep = keep.to(bboxes.device)
         ruler = ruler.to(bboxes.device)
-        
+
         while ruler.shape[0] > 0:
             basement = ruler[0]
             ruler = ruler[1:]


### PR DESCRIPTION
## Motivation

Fixed `RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)` when running CrowdDet model on cuda device (the model uses MultiInstanceBBoxHead roi_head)

## Modification

Just added `tensor.to(device)` to fix the issue in `set_nms` method.
```
        keep = keep.to(bboxes.device)
        ruler = ruler.to(bboxes.device)
```

versions:
- torch==2.0.1
- mmdet==3.0.0
- mmengine==0.7.4