### PR TITLE
Fix: remove some unicode chars from `en/` docs

### DIFF
--- a/configs/convnext/README.md
+++ b/configs/convnext/README.md
@@ -2,6 +2,8 @@
 
 > [A ConvNet for the 2020s](https://arxiv.org/abs/2201.03545)
 
+<!-- [ALGORITHM] -->
+
 ## Abstract
 
 The "Roaring 20s" of visual recognition began with the introduction of Vision Transformers (ViTs), which quickly superseded ConvNets as the state-of-the-art image classification model. A vanilla ViT, on the other hand, faces difficulties when applied to general computer vision tasks such as object detection and semantic segmentation. It is the hierarchical Transformers (e.g., Swin Transformers) that reintroduced several ConvNet priors, making Transformers practically viable as a generic vision backbone and demonstrating remarkable performance on a wide variety of vision tasks. However, the effectiveness of such hybrid approaches is still largely credited to the intrinsic superiority of Transformers, rather than the inherent inductive biases of convolutions. In this work, we reexamine the design spaces and test the limits of what a pure ConvNet can achieve. We gradually "modernize" a standard ResNet toward the design of a vision Transformer, and discover several key components that contribute to the performance difference along the way. The outcome of this exploration is a family of pure ConvNet models dubbed ConvNeXt. Constructed entirely from standard ConvNet modules, ConvNeXts compete favorably with Transformers in terms of accuracy and scalability, achieving 87.8% ImageNet top-1 accuracy and outperforming Swin Transformers on COCO detection and ADE20K segmentation, while maintaining the simplicity and efficiency of standard ConvNets.

--- a/configs/dsdl/README.md
+++ b/configs/dsdl/README.md
@@ -1,5 +1,7 @@
 # DSDL: Standard Description Language for DataSet
 
+<!-- [DATASET] -->
+
 ## 1. Abstract
 
 Data is the cornerstone of artificial intelligence. The efficiency of data acquisition, exchange, and application directly impacts the advances in technologies and applications. Over the long history of AI, a vast quantity of data sets have been developed and distributed. However, these datasets are defined in very different forms, which incurs significant overhead when it comes to exchange, integration, and utilization -- it is often the case that one needs to develop a new customized tool or script in order to incorporate a new dataset into a workflow.
@@ -35,7 +37,7 @@ To overcome such difficulties, we develop **Data Set Description Language (DSDL)
   python tools/train.py {config_file}
   ```
 
-  - using slrum:
+  - using slurm:
 
   ```
   ./tools/slurm_train.sh {partition} {job_name} {config_file} {work_dir} {gpu_nums}

--- a/docs/en/get_started.md
+++ b/docs/en/get_started.md
@@ -227,7 +227,7 @@ The following table lists affected algorithms.
 
 |                        Operator                         |                                          Model                                           |
 | :-----------------------------------------------------: | :--------------------------------------------------------------------------------------: |
-| Deformable Convolution/Modulated Deformable Convolution | DCN、Guided Anchoring、RepPoints、CentripetalNet、VFNet、CascadeRPN、NAS-FCOS、DetectoRS |
+| Deformable Convolution/Modulated Deformable Convolution | DCN, Guided Anchoring, RepPoints, CentripetalNet, VFNet, CascadeRPN, NAS-FCOS, DetectoRS |
 |                      MaskedConv2d                       |                                     Guided Anchoring                                     |
 |                         CARAFE                          |                                          CARAFE                                          |
 |                      SyncBatchNorm                      |                                         ResNeSt                                          |

--- a/docs/en/migration/config_migration.md
+++ b/docs/en/migration/config_migration.md
@@ -713,7 +713,7 @@ log_config = dict(interval=50)
 ```python
 default_hooks = dict(
     logger=dict(type='LoggerHook', interval=50))
-# Optional： set moving average window size
+# Optional: set moving average window size
 log_processor = dict(
     type='LogProcessor', window_size=50)
 ```

--- a/docs/en/notes/changelog.md
+++ b/docs/en/notes/changelog.md
@@ -258,7 +258,7 @@ Thanks @liuyanyi, @RangeKing, @lihua199710, @MambaWong, @sanbuphy, @Xiangxu-0103
 
 - Update the docs of GIoU Loss in README (#8810)
 - Handle dataset wrapper in `inference_detector` (#9144)
-- Update the type of `counts` in COCO’s compressed RLE (#9274)
+- Update the type of `counts` in COCO's compressed RLE (#9274)
 - Support saving config file in `print_config` (#9276)
 - Update docs about video inference (#9305)
 - Update guide about model deployment (#9344)

--- a/docs/en/stat.py
+++ b/docs/en/stat.py
@@ -26,9 +26,8 @@ for f in files:
 
     if len(ckpts) == 0:
         continue
-    print(f'{f = }, papertype: ')
+
     _papertype = [x for x in re.findall(r'\[([A-Z]+)\]', content)]
-    print(f'{_papertype = }')
     assert len(_papertype) > 0
     papertype = _papertype[0]
 

--- a/docs/en/stat.py
+++ b/docs/en/stat.py
@@ -26,8 +26,9 @@ for f in files:
 
     if len(ckpts) == 0:
         continue
-
+    print(f'{f = }, papertype: ')
     _papertype = [x for x in re.findall(r'\[([A-Z]+)\]', content)]
+    print(f'{_papertype = }')
     assert len(_papertype) > 0
     papertype = _papertype[0]
 

--- a/docs/en/user_guides/dataset_prepare.md
+++ b/docs/en/user_guides/dataset_prepare.md
@@ -198,17 +198,17 @@ Then the directory should be like this:
 data
 ├── coco
 │   ├── refcoco
-│   │   ├── instances.json
-│   │   ├── refs(google).p
-│   │   └── refs(unc).p
-│   ├── refcoco+
-│   │   ├── instances.json
-│   │   └── refs(unc).p
-│   ├── refcocog
-│   │   ├── instances.json
-│   │   ├── refs(google).p
-│   │   └── refs(umd).p
-|   |── train2014
+│   │   ├── instances.json
+│   │   ├── refs(google).p
+│   │   └── refs(unc).p
+│   ├── refcoco+
+│   │   ├── instances.json
+│   │   └── refs(unc).p
+│   ├── refcocog
+│   │   ├── instances.json
+│   │   ├── refs(google).p
+│   │   └── refs(umd).p
+│   │── train2014
 ```
 
 ### ADE20K 2016 Dataset Preparation
@@ -234,49 +234,49 @@ The directory should be like this.
 ```text
 data
 ├── ADEChallengeData2016
-│   ├── ade20k_instance_train.json
-│   ├── ade20k_instance_val.json
-│   ├── ade20k_panoptic_train
-|   |   ├── ADE_train_00000001.png
-|   |   ├── ADE_train_00000002.png
-|   |   ├── ...
-│   ├── ade20k_panoptic_train.json
-│   ├── ade20k_panoptic_val
-|   |   ├── ADE_val_00000001.png
-|   |   ├── ADE_val_00000002.png
-|   |   ├── ...
-│   ├── ade20k_panoptic_val.json
-│   ├── annotations
-|   |   ├── training
-|   |   |   ├── ADE_train_00000001.png
-|   |   |   ├── ADE_train_00000002.png
-|   |   |   ├── ...
-|   |   ├── validation
-|   |   |   ├── ADE_val_00000001.png
-|   |   |   ├── ADE_val_00000002.png
-|   |   |   ├── ...
-│   ├── annotations_instance
-|   |   ├── training
-|   |   |   ├── ADE_train_00000001.png
-|   |   |   ├── ADE_train_00000002.png
-|   |   |   ├── ...
-|   |   ├── validation
-|   |   |   ├── ADE_val_00000001.png
-|   |   |   ├── ADE_val_00000002.png
-|   |   |   ├── ...
-│   ├── categoryMapping.txt
-│   ├── images
-│   |   ├── training
-|   |   |   ├── ADE_train_00000001.jpg
-|   |   |   ├── ADE_train_00000002.jpg
-|   |   |   ├── ...
-|   |   ├── validation
-|   |   |   ├── ADE_val_00000001.jpg
-|   |   |   ├── ADE_val_00000002.jpg
-|   |   |   ├── ...
-│   ├── imgCatIds.json
-│   ├── objectInfo150.txt
-|   |── sceneCategories.txt
+│   ├── ade20k_instance_train.json
+│   ├── ade20k_instance_val.json
+│   ├── ade20k_panoptic_train
+│   │   ├── ADE_train_00000001.png
+│   │   ├── ADE_train_00000002.png
+│   │   ├── ...
+│   ├── ade20k_panoptic_train.json
+│   ├── ade20k_panoptic_val
+│   │   ├── ADE_val_00000001.png
+│   │   ├── ADE_val_00000002.png
+│   │   ├── ...
+│   ├── ade20k_panoptic_val.json
+│   ├── annotations
+│   │   ├── training
+│   │   │   ├── ADE_train_00000001.png
+│   │   │   ├── ADE_train_00000002.png
+│   │   │   ├── ...
+│   │   ├── validation
+│   │   │   ├── ADE_val_00000001.png
+│   │   │   ├── ADE_val_00000002.png
+│   │   │   ├── ...
+│   ├── annotations_instance
+│   │   ├── training
+│   │   │   ├── ADE_train_00000001.png
+│   │   │   ├── ADE_train_00000002.png
+│   │   │   ├── ...
+│   │   ├── validation
+│   │   │   ├── ADE_val_00000001.png
+│   │   │   ├── ADE_val_00000002.png
+│   │   │   ├── ...
+│   ├── categoryMapping.txt
+│   ├── images
+│   │   ├── training
+│   │   │   ├── ADE_train_00000001.jpg
+│   │   │   ├── ADE_train_00000002.jpg
+│   │   │   ├── ...
+│   │   ├── validation
+│   │   │   ├── ADE_val_00000001.jpg
+│   │   │   ├── ADE_val_00000002.jpg
+│   │   │   ├── ...
+│   ├── imgCatIds.json
+│   ├── objectInfo150.txt
+│   │── sceneCategories.txt
 ```
 
 The above folders include all data of ADE20K's semantic segmentation, instance segmentation, and panoptic segmentation.

--- a/docs/en/user_guides/init_cfg.md
+++ b/docs/en/user_guides/init_cfg.md
@@ -111,7 +111,7 @@ init_cfg = [dict(type='Constant', layer='Conv1d', val=1),
 - When initializing some specific part with its attribute name, we can use `override` key, and the value in `override` will ignore the value in init_cfg.
 
   ```python
-  # layers：
+  # layers:
   # self.feat = nn.Conv1d(3, 1, 3)
   # self.reg = nn.Conv2d(3, 3, 3)
   # self.cls = nn.Linear(1,2)
@@ -126,7 +126,7 @@ init_cfg = [dict(type='Constant', layer='Conv1d', val=1),
 - If `layer` is None in init_cfg, only sub-module with the name in override will be initialized, and type and other args in override can be omitted.
 
   ```python
-  # layers：
+  # layers:
   # self.feat = nn.Conv1d(3, 1, 3)
   # self.reg = nn.Conv2d(3, 3, 3)
   # self.cls = nn.Linear(1,2)

--- a/docs/en/user_guides/semi_det.md
+++ b/docs/en/user_guides/semi_det.md
@@ -4,12 +4,13 @@ Semi-supervised object detection uses both labeled data and unlabeled data for t
 
 A typical procedure to train a semi-supervised object detector is as below:
 
-- [Prepare and split dataset](#Prepare-and-split-dataset)
-- [Configure multi-branch pipeline](#Configure-multi-branch-pipeline)
-- [Configure semi-supervised dataloader](#Configure-semi-supervised-dataloader)
-- [Configure semi-supervised model](#Configure-semi-supervised-model)
-- [Configure MeanTeacherHook](#Configure-MeanTeacherHook)
-- [Configure TeacherStudentValLoop](#Configure-TeacherStudentValLoop)
+- [Semi-supervised Object Detection](#semi-supervised-object-detection)
+  - [Prepare and split dataset](#prepare-and-split-dataset)
+  - [Configure multi-branch pipeline](#configure-multi-branch-pipeline)
+  - [Configure semi-supervised dataloader](#configure-semi-supervised-dataloader)
+  - [Configure semi-supervised model](#configure-semi-supervised-model)
+  - [Configure MeanTeacherHook](#configure-meanteacherhook)
+  - [Configure TeacherStudentValLoop](#configure-teacherstudentvalloop)
 
 ## Prepare and split dataset
 
@@ -111,7 +112,7 @@ and [pseudo label](https://www.researchgate.net/profile/Dong-Hyun-Lee/publicatio
 Consistency regularization often requires some careful design, while pseudo label have a simpler form and are easier to extend to downstream tasks.
 We adopt a teacher-student joint training semi-supervised object detection framework based on pseudo label, so labeled data and unlabeled data need to configure different data pipeline:
 
-(1) Pipeline for labeled data：
+(1) Pipeline for labeled data:
 
 ```python
 # pipeline used to augment labeled data,
@@ -127,7 +128,7 @@ sup_pipeline = [
 ]
 ```
 
-(2) Pipeline for unlabeled data：
+(2) Pipeline for unlabeled data:
 
 ```python
 # pipeline used to augment unlabeled data weakly,

--- a/docs/en/user_guides/test.md
+++ b/docs/en/user_guides/test.md
@@ -84,7 +84,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
    ```
 
 4. Test Mask R-CNN with 8 GPUs, and evaluate.
-   Config and checkpoint files are available arguments: [here](../../../configs/mask_rcnn).
+   Config and checkpoint files are available [here](../../../configs/mask_rcnn).
 
    ```shell
    ./tools/dist_test.sh \

--- a/docs/en/user_guides/test.md
+++ b/docs/en/user_guides/test.md
@@ -84,7 +84,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
    ```
 
 4. Test Mask R-CNN with 8 GPUs, and evaluate.
-   Config and checkpoint files are available [here](../../../configs/mask_rcnn).
+   Config and checkpoint files are available arguments: [here](../../../configs/mask_rcnn).
 
    ```shell
    ./tools/dist_test.sh \
@@ -138,7 +138,7 @@ Assuming that you have already downloaded the checkpoints to the directory `chec
 
 MMDetection supports to test models without ground-truth annotations using `CocoDataset`. If your dataset format is not in COCO format, please convert them to COCO format. For example, if your dataset format is VOC, you can directly convert it to COCO format by the [script in tools.](../../../tools/dataset_converters/pascal_voc.py) If your dataset format is Cityscapes, you can directly convert it to COCO format by the [script in tools.](../../../tools/dataset_converters/cityscapes.py) The rest of the formats can be converted using [this script](../../../tools/dataset_converters/images2coco.py).
 
-```shel
+```shell
 python tools/dataset_converters/images2coco.py \
     ${IMG_PATH} \
     ${CLASSES} \
@@ -146,7 +146,7 @@ python tools/dataset_converters/images2coco.py \
     [--exclude-extensions]
 ```
 
-arguments：
+arguments:
 
 - `IMG_PATH`: The root path of images.
 - `CLASSES`: The text file with a list of categories.

--- a/docs/en/user_guides/train.md
+++ b/docs/en/user_guides/train.md
@@ -392,7 +392,7 @@ Using the function above, users can successfully convert the annotation file int
 
 ## Prepare a config
 
-The second step is to prepare a config thus the dataset could be successfully loaded. Assume that we want to use Mask R-CNN with FPN, the config to train the detector on balloon dataset is as below. Assume the config is under directory `configs/balloon/` and named as `mask-rcnn_r50-caffe_fpn_ms-poly-1x_balloon.py`, the config is as below. Please refer [Learn about Configs — MMDetection 3.0.0 documentation](https://mmdetection.readthedocs.io/en/latest/user_guides/config.html) to get detailed information about config files.
+The second step is to prepare a config thus the dataset could be successfully loaded. Assume that we want to use Mask R-CNN with FPN, the config to train the detector on balloon dataset is as below. Assume the config is under directory `configs/balloon/` and named as `mask-rcnn_r50-caffe_fpn_ms-poly-1x_balloon.py`, the config is as below. Please refer [Learn about Configs - MMDetection 3.0.0 documentation](https://mmdetection.readthedocs.io/en/latest/user_guides/config.html) to get detailed information about config files.
 
 ```python
 # The new config inherits a base config to highlight the necessary modification

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -71,7 +71,7 @@ Description of all arguments:
 - `config` : The path of a model config file.
 - `prediction_path`:  Output result file in pickle format from `tools/test.py`
 - `show_dir`: Directory where painted GT and detection images will be saved
-- `--show`：Determines whether to show painted images, If not specified, it will be set to `False`
+- `--show`: Determines whether to show painted images, If not specified, it will be set to `False`
 - `--wait-time`: The interval of show (s), 0 is block
 - `--topk`: The number of saved images that have the highest and lowest `topk` scores after sorting. If not specified, it will be set to `20`.
 - `--show-score-thr`:  Show score threshold. If not specified, it will be set to `0`.

--- a/mmdet/datasets/transforms/loading.py
+++ b/mmdet/datasets/transforms/loading.py
@@ -179,7 +179,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
                 # [x1, y1, ..., xn, yn] (n≥3). The Xs and Ys are absolute
                 # coordinates in unit of pixels.
                 # 2. If dict, it represents the per-pixel segmentation mask in
-                # COCO’s compressed RLE format. The dict should have keys
+                # COCO's compressed RLE format. The dict should have keys
                 # “size” and “counts”.  Can be loaded by pycocotools
                 'mask': list[list[float]] or dict,
 

--- a/mmdet/datasets/transforms/loading.py
+++ b/mmdet/datasets/transforms/loading.py
@@ -176,7 +176,7 @@ class LoadAnnotations(MMCV_LoadAnnotations):
                 # 1. If list[list[float]], it represents a list of polygons,
                 # one for each connected component of the object. Each
                 # list[float] is one simple polygon in the format of
-                # [x1, y1, ..., xn, yn] (n≥3). The Xs and Ys are absolute
+                # [x1, y1, ..., xn, yn] (n >= 3). The Xs and Ys are absolute
                 # coordinates in unit of pixels.
                 # 2. If dict, it represents the per-pixel segmentation mask in
                 # COCO's compressed RLE format. The dict should have keys
@@ -950,7 +950,7 @@ class LoadTrackAnnotations(LoadAnnotations):
                 # 1. If list[list[float]], it represents a list of polygons,
                 # one for each connected component of the object. Each
                 # list[float] is one simple polygon in the format of
-                # [x1, y1, ..., xn, yn] (n≥3). The Xs and Ys are absolute
+                # [x1, y1, ..., xn, yn] (n >= 3). The Xs and Ys are absolute
                 # coordinates in unit of pixels.
                 # 2. If dict, it represents the per-pixel segmentation mask in
                 # COCO's compressed RLE format. The dict should have keys

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -56,7 +56,7 @@ def _fixed_scale_size(
     if isinstance(scale, (float, int)):
         scale = (scale, scale)
     w, h = size
-    # don’t need o.5 offset
+    # don't need o.5 offset
     return int(w * float(scale[0])), int(h * float(scale[1]))
 
 

--- a/mmdet/datasets/utils.py
+++ b/mmdet/datasets/utils.py
@@ -37,7 +37,7 @@ def get_loading_pipeline(pipeline):
     loading_pipeline_cfg = []
     for cfg in pipeline:
         obj_cls = TRANSFORMS.get(cfg['type'])
-        # TODO：use more elegant way to distinguish loading modules
+        # TODO:use more elegant way to distinguish loading modules
         if obj_cls is not None and obj_cls in (LoadImageFromFile,
                                                LoadAnnotations,
                                                LoadPanopticAnnotations):

--- a/mmdet/evaluation/metrics/crowdhuman_metric.py
+++ b/mmdet/evaluation/metrics/crowdhuman_metric.py
@@ -276,7 +276,7 @@ class CrowdHumanMetric(BaseMetric):
                 a list of tuples (dtbox, label, imgID) in the descending
                 sort of dtbox.score.
             gt_num(int): The number of gt boxes in the entire dataset.
-            img_num(int)： The number of images in the entire dataset.
+            img_num(int): The number of images in the entire dataset.
 
         Returns:
             ap(float): result of average precision.

--- a/mmdet/models/data_preprocessors/data_preprocessor.py
+++ b/mmdet/models/data_preprocessors/data_preprocessor.py
@@ -179,7 +179,7 @@ class DetDataPreprocessor(ImgDataPreprocessor):
         else:
             raise TypeError('Output of `cast_data` should be a dict '
                             'or a tuple with inputs and data_samples, but got'
-                            f'{type(data)}： {data}')
+                            f'{type(data)}: {data}')
         return batch_pad_shape
 
     def pad_gt_masks(self,

--- a/mmdet/models/data_preprocessors/data_preprocessor.py
+++ b/mmdet/models/data_preprocessors/data_preprocessor.py
@@ -108,7 +108,7 @@ class DetDataPreprocessor(ImgDataPreprocessor):
         self.boxtype2tensor = boxtype2tensor
 
     def forward(self, data: dict, training: bool = False) -> dict:
-        """Perform normalization、padding and bgr2rgb conversion based on
+        """Perform normalization,padding and bgr2rgb conversion based on
         ``BaseDataPreprocessor``.
 
         Args:
@@ -474,7 +474,7 @@ class MultiBranchDataPreprocessor(BaseDataPreprocessor):
         self.data_preprocessor = MODELS.build(data_preprocessor)
 
     def forward(self, data: dict, training: bool = False) -> dict:
-        """Perform normalization、padding and bgr2rgb conversion based on
+        """Perform normalization,padding and bgr2rgb conversion based on
         ``BaseDataPreprocessor`` for multi-branch data.
 
         Args:

--- a/mmdet/models/data_preprocessors/track_data_preprocessor.py
+++ b/mmdet/models/data_preprocessors/track_data_preprocessor.py
@@ -72,7 +72,7 @@ class TrackDataPreprocessor(DetDataPreprocessor):
                                  torch.tensor(std).view(1, -1, 1, 1), False)
 
     def forward(self, data: dict, training: bool = False) -> Dict:
-        """Perform normalization、padding and bgr2rgb conversion based on
+        """Perform normalization,padding and bgr2rgb conversion based on
         ``TrackDataPreprocessor``.
 
         Args:

--- a/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdet/models/dense_heads/base_dense_head.py
@@ -461,7 +461,7 @@ class BaseDenseHead(BaseModule, metaclass=ABCMeta):
             results.bboxes = scale_boxes(results.bboxes, scale_factor)
 
         if hasattr(results, 'score_factors'):
-            # TODO： Add sqrt operation in order to be consistent with
+            # TODO: Add sqrt operation in order to be consistent with
             #  the paper.
             score_factors = results.pop('score_factors')
             results.scores = results.scores * score_factors

--- a/mmdet/models/dense_heads/centernet_update_head.py
+++ b/mmdet/models/dense_heads/centernet_update_head.py
@@ -366,7 +366,7 @@ class CenterNetUpdateHead(AnchorFreeHead):
         inside_gt_center3x3_mask = (dist_x <= strides[..., 0]) & \
                                    (dist_y <= strides[..., 0])
 
-        # condition3： limit the regression range for each location
+        # condition3: limit the regression range for each location
         bbox_target_wh = bbox_target[..., :2] + bbox_target[..., 2:]
         crit = (bbox_target_wh**2).sum(dim=2)**0.5 / 2
         inside_fpn_level_mask = (crit >= regress_ranges[:, [0]]) & \

--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -466,7 +466,7 @@ class RTMDetInsHead(RTMDetHead):
             results.bboxes = scale_boxes(results.bboxes, scale_factor)
 
         if hasattr(results, 'score_factors'):
-            # TODO： Add sqrt operation in order to be consistent with
+            # TODO: Add sqrt operation in order to be consistent with
             #  the paper.
             score_factors = results.pop('score_factors')
             results.scores = results.scores * score_factors

--- a/mmdet/models/dense_heads/yolof_head.py
+++ b/mmdet/models/dense_heads/yolof_head.py
@@ -223,10 +223,10 @@ class YOLOFHead(AnchorHead):
         multiple images.
 
         Args:
-            cls_scores_list (list[Tensor])： Classification scores of
+            cls_scores_list (list[Tensor]): Classification scores of
                 each image. each is a 4D-tensor, the shape is
                 (h * w, num_anchors * num_classes).
-            bbox_preds_list (list[Tensor])： Bbox preds of each image.
+            bbox_preds_list (list[Tensor]): Bbox preds of each image.
                 each is a 4D-tensor, the shape is (h * w, num_anchors * 4).
             anchor_list (list[Tensor]): Anchors of each image. Each element of
                 is a tensor of shape (h * w * num_anchors, 4).

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -58,8 +58,8 @@ def remove_punctuation(text: str) -> str:
         str: The text with punctuation removed.
     """
     punctuation = [
-        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"',
-        '\'', '`', '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
+        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', '`',
+        '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
     ]
     for p in punctuation:
         text = text.replace(p, '')

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -58,8 +58,8 @@ def remove_punctuation(text: str) -> str:
         str: The text with punctuation removed.
     """
     punctuation = [
-        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', ''',
-        '`', '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
+        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"',
+        '\'', '`', '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
     ]
     for p in punctuation:
         text = text.replace(p, '')

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -58,8 +58,8 @@ def remove_punctuation(text: str) -> str:
         str: The text with punctuation removed.
     """
     punctuation = [
-        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', '`',
-        '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
+        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', '’',
+        '`', '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
     ]
     for p in punctuation:
         text = text.replace(p, '')

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -58,7 +58,7 @@ def remove_punctuation(text: str) -> str:
         str: The text with punctuation removed.
     """
     punctuation = [
-        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', '’',
+        '|', ':', ';', '@', '(', ')', '[', ']', '{', '}', '^', '\'', '\"', ''',
         '`', '?', '$', '%', '#', '!', '&', '*', '+', ',', '.'
     ]
     for p in punctuation:

--- a/mmdet/models/detectors/rtmdet.py
+++ b/mmdet/models/detectors/rtmdet.py
@@ -46,7 +46,7 @@ class RTMDet(SingleStageDetector):
             data_preprocessor=data_preprocessor,
             init_cfg=init_cfg)
 
-        # TODO： Waiting for mmengine support
+        # TODO: Waiting for mmengine support
         if use_syncbn and get_world_size() > 1:
             torch.nn.SyncBatchNorm.convert_sync_batchnorm(self)
             print_log('Using SyncBatchNorm()', 'current')


### PR DESCRIPTION

## Motivation

I am trying to `make latexpdf` the `en/` docs.
Fullwidth chars cause issues for `latexpdf` build targets, so I replaced them with their normal (half-width) variants.

## Modification

- Added some missing `papertype` indicators in docs
- Replaced some unicode fullwidth chars with their halfwidth variants in docs and python code

## Use cases

You used to be able to download the docs as `pdf` until `v3.1.0`.
I don't know what broke this, but at least some of the work done in this branch should help narrow down probable causes of the pdf build breakage.

## Checklist

1. ✅ Pre-commit or other linting tools are used to fix the potential lint issues.
2. ✅ The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. ✅ If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. ✅ The documentation has been modified accordingly, like docstring or example tutorials.
