### PR TITLE
[Feature] Support MaskDINO

### DIFF
--- a/configs/maskdino/maskdino_r50_8xb2-lsj-50e_coco-panoptic.py
+++ b/configs/maskdino/maskdino_r50_8xb2-lsj-50e_coco-panoptic.py
@@ -1,0 +1,242 @@
+_base_ = [
+    '../_base_/datasets/coco_panoptic.py', '../_base_/default_runtime.py'
+]
+
+image_size = (1024, 1024)
+batch_augments = [
+    dict(
+        type='BatchFixedSizePad',
+        size=image_size,
+        img_pad_value=0,
+        pad_mask=True,
+        mask_pad_value=0,
+        pad_seg=True,
+        seg_pad_value=255)
+]
+data_preprocessor = dict(
+    type='DetDataPreprocessor',
+    mean=[123.675, 116.28, 103.53],
+    std=[58.395, 57.12, 57.375],
+    bgr_to_rgb=True,
+    pad_size_divisor=32,
+    pad_mask=True,
+    mask_pad_value=0,
+    pad_seg=True,
+    seg_pad_value=255,
+    batch_augments=batch_augments)
+
+num_things_classes = 80
+num_stuff_classes = 53
+num_classes = num_things_classes + num_stuff_classes
+model = dict(
+    type='MaskDINO',
+    data_preprocessor=data_preprocessor,
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        frozen_stages=-1,
+        norm_cfg=dict(type='BN', requires_grad=False),
+        norm_eval=True,
+        style='pytorch',
+        init_cfg=dict(type='Pretrained', checkpoint='torchvision://resnet50')),
+    panoptic_head=dict(
+        type='MaskDINOHead',
+        num_stuff_classes=num_stuff_classes,
+        num_things_classes=num_things_classes,
+        encoder=dict(
+            in_channels=[256, 512, 1024, 2048],
+            in_strides=[4, 8, 16, 32],
+            transformer_dropout=0.0,
+            transformer_nheads=8,
+            transformer_dim_feedforward=2048,
+            transformer_enc_layers=6,
+            conv_dim=256,
+            mask_dim=256,
+            norm_cfg=dict(type='GN', num_groups=32),
+            transformer_in_features=['res3', 'res4', 'res5'],
+            common_stride=4,
+            num_feature_levels=3,
+            total_num_feature_levels=4,
+            feature_order='low2high'),
+        decoder=dict(
+            in_channels=256,
+            num_classes=num_things_classes+num_stuff_classes,
+            hidden_dim=256,
+            num_queries=300,
+            nheads=8,
+            dim_feedforward=2048,
+            dec_layers=9,
+            mask_dim=256,
+            enforce_input_project=False,
+            two_stage=True,
+            dn='seg',
+            noise_scale=0.4,
+            dn_num=20,
+            initialize_box_type='no',
+            initial_pred=True,
+            learn_tgt=False,
+            total_num_feature_levels=4,
+            dropout=0.0,
+            activation='relu',
+            nhead=8,
+            dec_n_points=4,
+            mask_classification=True,
+            return_intermediate_dec=True,
+            query_dim=4,
+            dec_layer_share=False,
+            semantic_ce_loss=False)),
+    panoptic_fusion_head=dict(
+        type='MaskDINOFusionHead',
+        num_things_classes=num_things_classes,
+        num_stuff_classes=num_stuff_classes,
+        loss_panoptic=None,  # MaskDINOFusionHead has no training loss
+        init_cfg=None),  # MaskDINOFusionHead has no module
+    train_cfg=dict(  # corresponds to SetCriterion
+        num_classes=num_things_classes + num_stuff_classes,
+        matcher=dict(
+            cost_class=4.0, cost_box=5.0, cost_giou=2.0,
+            cost_mask=5.0, cost_dice=5.0, num_points=100),
+        class_weight=4.0,
+        box_weight=5.0,
+        giou_weight=2.0,
+        mask_weight=5.0,
+        dice_weight=5.0,
+        dn='seg',
+        dec_layers=9,
+        box_loss=True,
+        two_stage=True,
+        eos_coef=0.1,
+        num_points=100,
+        oversample_ratio=3.0,
+        importance_sample_ratio=0.75,
+        semantic_ce_loss=False,
+        panoptic_on=False,  # TODO: Why?
+        deep_supervision=True),
+    test_cfg=dict(
+        panoptic_on=True,
+        instance_on=True,
+        semantic_on=True,
+        panoptic_postprocess_cfg=dict(
+            object_mask_thr=0.25,  # 0.8 for MaskFormer
+            iou_thr=0.8,
+            filter_low_score=True,  # it will filter mask area where score is less than 0.5.
+            panoptic_temperature=0.06,
+            transform_eval=True),
+        instance_postprocess_cfg=dict(
+            max_per_image=100,
+            focus_on_box=False)),
+    init_cfg=None)
+
+# dataset settings
+data_root = 'data/coco/'
+train_pipeline = [
+    dict(type='LoadImageFromFile', to_float32=True, imdecode_backend='pillow'),
+    dict(
+        type='LoadPanopticAnnotations',
+        with_bbox=True,
+        with_mask=True,
+        with_seg=True),
+    dict(type='RandomFlip', prob=0.5),
+    # large scale jittering
+    dict(
+        type='RandomResize',
+        scale=image_size,
+        ratio_range=(0.1, 2.0),
+        keep_ratio=True),
+    dict(
+        type='RandomCrop',
+        crop_size=image_size,
+        crop_type='absolute',
+        recompute_bbox=True,
+        allow_negative_crop=True),
+    dict(type='PackDetInputs')
+]
+
+test_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=_base_.backend_args, imdecode_backend='pillow'),
+    dict(type='Resize', scale=(1333, 800), keep_ratio=True, backend='pillow'),
+    dict(type='LoadPanopticAnnotations', backend_args=_base_.backend_args, imdecode_backend='pillow'),
+    dict(
+        type='PackDetInputs',
+        meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape',
+                   'scale_factor'))
+]
+
+train_dataloader = dict(dataset=dict(pipeline=train_pipeline))
+val_dataloader = dict(dataset=dict(pipeline=test_pipeline))
+test_dataloader = val_dataloader
+
+val_evaluator = [
+    dict(
+        type='CocoPanopticMetric',
+        ann_file=data_root + 'annotations/panoptic_val2017.json',
+        seg_prefix=data_root + 'annotations/panoptic_val2017/'
+    ),
+    dict(
+        type='CocoMetric',
+        ann_file=data_root + 'annotations/instances_val2017.json',
+        metric=['bbox', 'segm']
+    ),
+    dict(type='SemSegMetric', iou_metrics=['mIoU'])
+]
+test_evaluator = val_evaluator
+
+# optimizer
+embed_multi = dict(lr_mult=1.0, decay_mult=0.0)
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(
+        type='AdamW',
+        lr=0.0001,
+        weight_decay=0.05,
+        eps=1e-8,
+        betas=(0.9, 0.999)),
+    paramwise_cfg=dict(
+        custom_keys={
+            'backbone': dict(lr_mult=0.1, decay_mult=1.0),
+            'query_embed': embed_multi,
+            'query_feat': embed_multi,
+            'level_embed': embed_multi,
+        },
+        norm_decay_mult=0.0),
+    clip_grad=dict(max_norm=0.01, norm_type=2))
+
+# learning policy
+max_iters = 368750
+param_scheduler = dict(
+    type='MultiStepLR',
+    begin=0,
+    end=max_iters,
+    by_epoch=False,
+    milestones=[327778, 355092],
+    gamma=0.1)
+
+# Before 365001th iteration, we do evaluation every 5000 iterations.
+# After 365000th iteration, we do evaluation every 368750 iterations,
+# which means that we do evaluation at the end of training.
+interval = 5000
+dynamic_intervals = [(max_iters // interval * interval + 1, max_iters)]
+train_cfg = dict(
+    type='IterBasedTrainLoop',
+    max_iters=max_iters,
+    val_interval=interval,
+    dynamic_intervals=dynamic_intervals)
+val_cfg = dict(type='ValLoop')
+test_cfg = dict(type='TestLoop')
+
+default_hooks = dict(
+    checkpoint=dict(
+        type='CheckpointHook',
+        by_epoch=False,
+        save_last=True,
+        max_keep_ckpts=3,
+        interval=interval))
+log_processor = dict(type='LogProcessor', window_size=50, by_epoch=False)
+
+# Default setting for scaling LR automatically
+#   - `enable` means enable scaling LR automatically
+#       or not by default.
+#   - `base_batch_size` = (8 GPUs) x (2 samples per GPU).
+auto_scale_lr = dict(enable=False, base_batch_size=16)

--- a/mmdet/models/dense_heads/__init__.py
+++ b/mmdet/models/dense_heads/__init__.py
@@ -50,6 +50,7 @@ from .yolact_head import YOLACTHead, YOLACTProtonet
 from .yolo_head import YOLOV3Head
 from .yolof_head import YOLOFHead
 from .yolox_head import YOLOXHead
+from .maskdino_head import MaskDINOHead
 
 __all__ = [
     'AnchorFreeHead', 'AnchorHead', 'GuidedAnchorHead', 'FeatureAdaption',
@@ -66,5 +67,5 @@ __all__ = [
     'CenterNetUpdateHead', 'RTMDetHead', 'RTMDetSepBNHead', 'CondInstBboxHead',
     'CondInstMaskHead', 'RTMDetInsHead', 'RTMDetInsSepBNHead',
     'BoxInstBboxHead', 'BoxInstMaskHead', 'ConditionalDETRHead', 'DINOHead',
-    'ATSSVLFusionHead', 'DABDETRHead'
+    'ATSSVLFusionHead', 'DABDETRHead', 'MaskDINOHead'
 ]

--- a/mmdet/models/dense_heads/maskdino_head.py
+++ b/mmdet/models/dense_heads/maskdino_head.py
@@ -1,0 +1,118 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+import warnings
+from typing import List, Tuple
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from mmcv.cnn import Conv2d
+from mmcv.ops import point_sample
+from mmengine.model import ModuleList, caffe2_xavier_init
+from mmengine.structures import InstanceData
+from torch import Tensor
+
+from mmdet.registry import MODELS, TASK_UTILS
+from mmdet.structures import SampleList
+from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig, reduce_mean
+from mmdet.structures.bbox import bbox_xyxy_to_cxcywh, bbox_cxcywh_to_xyxy
+from ..layers.transformer.maskdino_encoder_layers import MaskDINOEncoder
+from ..layers.transformer.maskdino_decoder_layers import MaskDINODecoder
+from ..losses.maskdino_loss import SetCriterion
+
+from mmdet.utils.memory import AvoidCUDAOOM
+from mmengine.structures import InstanceData, PixelData
+# from ..layers import Mask2FormerTransformerDecoder, SinePositionalEncoding
+# from ..utils import get_uncertain_point_coords_with_randomness
+# from .anchor_free_head import AnchorFreeHead
+# from .maskformer_head import MaskFormerHead
+
+
+@MODELS.register_module()
+class MaskDINOHead(nn.Module):
+
+    def __init__(
+        self,
+        num_stuff_classes: int,
+        num_things_classes: int,
+        encoder: OptConfigType,
+        decoder: OptConfigType,
+        train_cfg: OptConfigType = None,
+        test_cfg: OptConfigType = None,
+    ):
+        super().__init__()
+        self.num_stuff_classes = num_stuff_classes
+        self.num_things_classes = num_things_classes
+        self.num_classes = num_stuff_classes + num_things_classes
+        self.train_cfg = train_cfg
+        self.test_cfg = test_cfg
+
+        self.pixel_decoder = MaskDINOEncoder(**encoder)
+        self.predictor = MaskDINODecoder(**decoder)
+        self.criterion = SetCriterion(**train_cfg)
+
+    def forward(self, features, mask=None, targets=None):
+        mask_features, transformer_encoder_features, multi_scale_features = \
+            self.pixel_decoder.forward_features(features, mask)
+
+        predictions = self.predictor(multi_scale_features, mask_features,
+                                     mask, targets=targets)
+        return predictions
+
+    def loss(self, feats, batch_data_samples):
+        targets = self.prepare_targets(batch_data_samples)
+        outputs, mask_dict = self(feats, mask=None, targets=targets)  # TODO: deal with key_padding_masks ?
+        # bipartite matching-based loss
+        losses = self.criterion(outputs, targets, mask_dict)
+
+        for k in list(losses.keys()):
+            if k in self.criterion.weight_dict:
+                losses[k] *= self.criterion.weight_dict[k]
+            else:
+                # remove this loss if not specified in `weight_dict`
+                losses.pop(k)
+
+        return losses
+
+    def predict(self, feats, batch_data_samples):
+        outputs, _ = self(feats)
+        mask_cls_results = outputs["pred_logits"]
+        mask_pred_results = outputs["pred_masks"]
+        mask_box_results = outputs["pred_boxes"]
+
+        # upsample masks
+        batch_input_shape = batch_data_samples[0].metainfo['batch_input_shape']
+        mask_pred_results = F.interpolate(
+            mask_pred_results,
+            size=(batch_input_shape[0], batch_input_shape[1]),
+            mode='bilinear',
+            align_corners=False)
+
+        return mask_cls_results, mask_pred_results, mask_box_results
+
+    def prepare_targets(self, batch_data_samples):
+        # h_pad, w_pad = images.tensor.shape[-2:]  # TODO: Here is confusing
+        h_pad, w_pad = batch_data_samples[0].batch_input_shape  # TODO: make a check
+        new_targets = []
+        for data_sample in batch_data_samples:
+            # pad gt
+            device = data_sample.gt_instances.bboxes.device
+            h, w, _ = data_sample.img_shape
+            image_size_xyxy = torch.as_tensor([w, h, w, h], dtype=torch.float, device=device)
+
+            gt_masks = torch.from_numpy(data_sample.gt_instances.masks.masks).bool().to(device)
+            padded_masks = torch.zeros((gt_masks.shape[0], h_pad, w_pad), dtype=gt_masks.dtype, device=device)
+            padded_masks[:, : gt_masks.shape[1], : gt_masks.shape[2]] = gt_masks
+            new_targets.append(
+                {
+                    "labels": data_sample.gt_instances.labels,
+                    "masks": padded_masks,
+                    "boxes": bbox_xyxy_to_cxcywh(data_sample.gt_instances.bboxes) / image_size_xyxy
+                }
+            )
+
+            warnings.warn(  # TODO: align the lsj pipeline
+                'The lsj for MaskDINO and Mask2Former has not been fully aligned '
+                'with COCOPanopticNewBaselineDatasetMapper in original repo')
+
+        return new_targets

--- a/mmdet/models/detectors/__init__.py
+++ b/mmdet/models/detectors/__init__.py
@@ -56,6 +56,7 @@ from .yolact import YOLACT
 from .yolo import YOLOV3
 from .yolof import YOLOF
 from .yolox import YOLOX
+from .maskdino import MaskDINO
 
 __all__ = [
     'ATSS', 'BaseDetector', 'SingleStageDetector', 'TwoStageDetector', 'RPN',
@@ -68,5 +69,5 @@ __all__ = [
     'TwoStagePanopticSegmentor', 'PanopticFPN', 'QueryInst', 'LAD', 'TOOD',
     'MaskFormer', 'DDOD', 'Mask2Former', 'SemiBaseDetector', 'SoftTeacher',
     'RTMDet', 'Detectron2Wrapper', 'CrowdDet', 'CondInst', 'BoxInst',
-    'DetectionTransformer', 'ConditionalDETR', 'DINO', 'DABDETR', 'GLIP'
+    'DetectionTransformer', 'ConditionalDETR', 'DINO', 'DABDETR', 'GLIP', 'MaskDINO'
 ]

--- a/mmdet/models/detectors/maskdino.py
+++ b/mmdet/models/detectors/maskdino.py
@@ -1,0 +1,46 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from mmdet.registry import MODELS
+from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig
+from .maskformer import MaskFormer
+from torch import Tensor
+from ...structures import SampleList
+
+
+@MODELS.register_module()
+class MaskDINO(MaskFormer):
+    r"""Implementation of `Mask DINO: Towards A Unified Transformer-based
+    Framework for Object Detection and Segmentation
+    <https://arxiv.org/abs/2206.02777>`_."""
+
+    def __init__(self,
+                 backbone: ConfigType,
+                 neck: OptConfigType = None,
+                 panoptic_head: OptConfigType = None,
+                 panoptic_fusion_head: OptConfigType = None,
+                 train_cfg: OptConfigType = None,
+                 test_cfg: OptConfigType = None,
+                 data_preprocessor: OptConfigType = None,
+                 init_cfg: OptMultiConfig = None):
+        super().__init__(
+            backbone=backbone,
+            neck=neck,
+            panoptic_head=panoptic_head,
+            panoptic_fusion_head=panoptic_fusion_head,
+            train_cfg=train_cfg,
+            test_cfg=test_cfg,
+            data_preprocessor=data_preprocessor,
+            init_cfg=init_cfg)
+
+    def predict(self,
+                batch_inputs: Tensor,
+                batch_data_samples: SampleList,
+                rescale: bool = True) -> SampleList:
+        feats = self.extract_feat(batch_inputs)
+        mask_cls_results, mask_pred_results, mask_box_results = self.panoptic_head.predict(
+            feats, batch_data_samples)
+        results_list = self.panoptic_fusion_head.predict(
+            mask_cls_results, mask_pred_results, mask_box_results,
+            batch_data_samples, rescale=rescale)
+        results = self.add_pred_to_datasample(batch_data_samples, results_list)
+
+        return results

--- a/mmdet/models/detectors/maskformer.py
+++ b/mmdet/models/detectors/maskformer.py
@@ -145,8 +145,8 @@ class MaskFormer(SingleStageDetector):
             if 'ins_results' in pred_results:
                 data_sample.pred_instances = pred_results['ins_results']
 
-            assert 'sem_results' not in pred_results, 'segmantic ' \
-                'segmentation results are not supported yet.'
+            if 'sem_results' in pred_results:
+                data_sample.pred_sem_seg=pred_results['sem_results']
 
         return data_samples
 

--- a/mmdet/models/layers/transformer/maskdino_decoder_layers.py
+++ b/mmdet/models/layers/transformer/maskdino_decoder_layers.py
@@ -1,0 +1,811 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import logging
+import copy
+from typing import Optional
+import fvcore.nn.weight_init as weight_init
+import torch
+from torch import nn, Tensor
+from torch.cuda.amp import autocast
+from torch.nn import functional as F
+
+from mmcv.cnn import ConvModule
+from mmcv.ops import MultiScaleDeformableAttention
+from mmdet.models.layers import MLP, coordinate_to_encoding, inverse_sigmoid
+from mmdet.structures.bbox import bbox_xyxy_to_cxcywh
+from mmdet.structures.mask import mask2bbox
+
+
+class MaskDINODecoder(nn.Module):
+
+    def __init__(
+            self,
+            in_channels,
+            num_classes: int,
+            hidden_dim: int,
+            num_queries: int,
+            nheads: int,
+            dim_feedforward: int,
+            dec_layers: int,
+            mask_dim: int,
+            enforce_input_project: bool,
+            two_stage: bool,
+            dn: str,
+            noise_scale: float,
+            dn_num: int,
+            initialize_box_type: bool,
+            initial_pred: bool,
+            learn_tgt: bool,
+            total_num_feature_levels: int = 4,
+            dropout: float = 0.0,
+            activation: str = 'relu',
+            nhead: int = 8,
+            dec_n_points: int = 4,
+            mask_classification=True,
+            return_intermediate_dec: bool = True,
+            query_dim: int = 4,
+            dec_layer_share: bool = False,
+            semantic_ce_loss: bool = False,
+    ):
+        """
+        NOTE: this interface is experimental.
+        Args:
+            in_channels: channels of the input features
+            mask_classification: whether to add mask classifier or not
+            num_classes: number of classes
+            hidden_dim: Transformer feature dimension
+            num_queries: number of queries
+            nheads: number of heads
+            dim_feedforward: feature dimension in feedforward network
+            enc_layers: number of Transformer encoder layers
+            dec_layers: number of Transformer decoder layers
+            pre_norm: whether to use pre-LayerNorm or not
+            mask_dim: mask feature dimension
+            enforce_input_project: add input project 1x1 conv even if input
+                channels and hidden dim is identical
+            d_model: transformer dimension
+            dropout: dropout rate
+            activation: activation function
+            nhead: num heads in multi-head attention
+            dec_n_points: number of sampling points in decoder
+            return_intermediate_dec: return the intermediate results of decoder
+            query_dim: 4 -> (x, y, w, h)
+            dec_layer_share: whether to share each decoder layer
+            semantic_ce_loss: use ce loss for semantic segmentation
+        """
+        super().__init__()
+
+        assert mask_classification, "Only support mask classification model"
+        self.mask_classification = mask_classification
+        self.num_feature_levels = total_num_feature_levels
+        self.initial_pred = initial_pred
+
+        # define Transformer decoder here
+        self.dn=dn
+        self.learn_tgt = learn_tgt
+        self.noise_scale=noise_scale
+        self.dn_num=dn_num
+        self.num_heads = nheads
+        self.num_layers = dec_layers
+        self.two_stage=two_stage
+        self.initialize_box_type = initialize_box_type
+        self.total_num_feature_levels = total_num_feature_levels
+
+        self.num_queries = num_queries
+        self.semantic_ce_loss = semantic_ce_loss
+        # learnable query features
+        if not two_stage or self.learn_tgt:
+            self.query_feat = nn.Embedding(num_queries, hidden_dim)
+        if not two_stage and initialize_box_type == 'no':
+            self.query_embed = nn.Embedding(num_queries, 4)
+        if two_stage:
+            self.enc_output = nn.Linear(hidden_dim, hidden_dim)
+            self.enc_output_norm = nn.LayerNorm(hidden_dim)
+
+        self.input_proj = nn.ModuleList()
+        for _ in range(self.num_feature_levels):
+            if in_channels != hidden_dim or enforce_input_project:
+                self.input_proj.append(
+                    ConvModule(
+                        in_channels,
+                        hidden_dim,
+                        kernel_size=1,
+                        act_cfg=None))
+                weight_init.c2_xavier_fill(self.input_proj[-1])
+            else:
+                self.input_proj.append(nn.Sequential())
+        self.num_classes=num_classes
+        # output FFNs
+        assert self.mask_classification, "why not class embedding?"
+        if self.mask_classification:
+            if self.semantic_ce_loss:
+                self.class_embed = nn.Linear(hidden_dim, num_classes+1)
+            else:
+                self.class_embed = nn.Linear(hidden_dim, num_classes)
+        self.label_enc = nn.Embedding(num_classes,hidden_dim)
+        self.mask_embed = MLP(hidden_dim, hidden_dim, mask_dim, 3)
+
+        # init decoder
+        # self.decoder_norm = decoder_norm = nn.LayerNorm(hidden_dim)
+        decoder_norm = nn.LayerNorm(hidden_dim)
+        decoder_layer = DeformableTransformerDecoderLayer(hidden_dim, dim_feedforward,
+                                                          dropout, activation,
+                                                          self.num_feature_levels, nhead, dec_n_points)
+        self.decoder = TransformerDecoder(decoder_layer, self.num_layers, decoder_norm,
+                                          return_intermediate=return_intermediate_dec,
+                                          d_model=hidden_dim, query_dim=query_dim,
+                                          num_feature_levels=self.num_feature_levels,
+                                          dec_layer_share=dec_layer_share)
+        self.hidden_dim = hidden_dim
+        # self._bbox_embed = _bbox_embed = MLP(hidden_dim, hidden_dim, 4, 3)
+        _bbox_embed = MLP(hidden_dim, hidden_dim, 4, 3)
+        nn.init.constant_(_bbox_embed.layers[-1].weight.data, 0)
+        nn.init.constant_(_bbox_embed.layers[-1].bias.data, 0)
+        box_embed_layerlist = [_bbox_embed for i in range(self.num_layers)]  # TODO: Notice: share box prediction each layer
+        self.bbox_embed = nn.ModuleList(box_embed_layerlist)
+        # self.decoder.bbox_embed = self.bbox_embed  # TODO: add a param to forward
+
+    def prepare_for_dn(self, targets, tgt, refpoint_emb, batch_size):
+        """
+        modified from dn-detr. You can refer to dn-detr
+        https://github.com/IDEA-Research/DN-DETR/blob/main/models/dn_dab_deformable_detr/dn_components.py
+        for more details
+            :param dn_args: scalar, noise_scale
+            :param tgt: original tgt (content) in the matching part
+            :param refpoint_emb: positional anchor queries in the matching part
+            :param batch_size: bs
+            """
+        if self.training:
+            scalar, noise_scale = self.dn_num,self.noise_scale
+
+            known = [(torch.ones_like(t['labels'])).cuda() for t in targets]
+            know_idx = [torch.nonzero(t) for t in known]
+            known_num = [sum(k) for k in known]
+
+            # use fix number of dn queries
+            if max(known_num)>0:
+                scalar = scalar//(int(max(known_num)))
+            else:
+                scalar = 0
+            if scalar == 0:
+                input_query_label = None
+                input_query_bbox = None
+                attn_mask = None
+                mask_dict = None
+                return input_query_label, input_query_bbox, attn_mask, mask_dict
+
+            # can be modified to selectively denosie some label or boxes; also known label prediction
+            unmask_bbox = unmask_label = torch.cat(known)
+            labels = torch.cat([t['labels'] for t in targets])
+            boxes = torch.cat([t['boxes'] for t in targets])
+            batch_idx = torch.cat([torch.full_like(t['labels'].long(), i) for i, t in enumerate(targets)])
+            # known
+            known_indice = torch.nonzero(unmask_label + unmask_bbox)
+            known_indice = known_indice.view(-1)
+
+            # noise
+            known_indice = known_indice.repeat(scalar, 1).view(-1)
+            known_labels = labels.repeat(scalar, 1).view(-1)
+            known_bid = batch_idx.repeat(scalar, 1).view(-1)
+            known_bboxs = boxes.repeat(scalar, 1)
+            known_labels_expaned = known_labels.clone()
+            known_bbox_expand = known_bboxs.clone()
+
+            # noise on the label
+            if noise_scale > 0:
+                p = torch.rand_like(known_labels_expaned.float())
+                chosen_indice = torch.nonzero(p < (noise_scale * 0.5)).view(-1)  # half of bbox prob
+                new_label = torch.randint_like(chosen_indice, 0, self.num_classes)  # randomly put a new one here
+                known_labels_expaned.scatter_(0, chosen_indice, new_label)
+            if noise_scale > 0:
+                diff = torch.zeros_like(known_bbox_expand)
+                diff[:, :2] = known_bbox_expand[:, 2:] / 2
+                diff[:, 2:] = known_bbox_expand[:, 2:]
+                known_bbox_expand += torch.mul((torch.rand_like(known_bbox_expand) * 2 - 1.0),
+                                               diff).cuda() * noise_scale
+                known_bbox_expand = known_bbox_expand.clamp(min=0.0, max=1.0)
+
+            m = known_labels_expaned.long().to('cuda')
+            input_label_embed = self.label_enc(m)
+            input_bbox_embed = inverse_sigmoid(known_bbox_expand)
+            single_pad = int(max(known_num))
+            pad_size = int(single_pad * scalar)
+
+            padding_label = torch.zeros(pad_size, self.hidden_dim).cuda()
+            padding_bbox = torch.zeros(pad_size, 4).cuda()
+
+            if not refpoint_emb is None:
+                input_query_label = torch.cat([padding_label, tgt], dim=0).repeat(batch_size, 1, 1)
+                input_query_bbox = torch.cat([padding_bbox, refpoint_emb], dim=0).repeat(batch_size, 1, 1)
+            else:
+                input_query_label=padding_label.repeat(batch_size, 1, 1)
+                input_query_bbox = padding_bbox.repeat(batch_size, 1, 1)
+
+            # map
+            map_known_indice = torch.tensor([]).to('cuda')
+            if len(known_num):
+                map_known_indice = torch.cat([torch.tensor(range(num)) for num in known_num])  # [1,2, 1,2,3]
+                map_known_indice = torch.cat([map_known_indice + single_pad * i for i in range(scalar)]).long()
+            if len(known_bid):
+                input_query_label[(known_bid.long(), map_known_indice)] = input_label_embed
+                input_query_bbox[(known_bid.long(), map_known_indice)] = input_bbox_embed
+
+            tgt_size = pad_size + self.num_queries
+            attn_mask = torch.ones(tgt_size, tgt_size).to('cuda') < 0
+            # match query cannot see the reconstruct
+            attn_mask[pad_size:, :pad_size] = True
+            # reconstruct cannot see each other
+            for i in range(scalar):
+                if i == 0:
+                    attn_mask[single_pad * i:single_pad * (i + 1), single_pad * (i + 1):pad_size] = True
+                if i == scalar - 1:
+                    attn_mask[single_pad * i:single_pad * (i + 1), :single_pad * i] = True
+                else:
+                    attn_mask[single_pad * i:single_pad * (i + 1), single_pad * (i + 1):pad_size] = True
+                    attn_mask[single_pad * i:single_pad * (i + 1), :single_pad * i] = True
+            mask_dict = {
+                'known_indice': torch.as_tensor(known_indice).long(),
+                'batch_idx': torch.as_tensor(batch_idx).long(),
+                'map_known_indice': torch.as_tensor(map_known_indice).long(),
+                'known_lbs_bboxes': (known_labels, known_bboxs),
+                'know_idx': know_idx,
+                'pad_size': pad_size,
+                'scalar': scalar,
+            }
+        else:
+            if not refpoint_emb is None:
+                input_query_label = tgt.repeat(batch_size, 1, 1)
+                input_query_bbox = refpoint_emb.repeat(batch_size, 1, 1)
+            else:
+                input_query_label=None
+                input_query_bbox=None
+            attn_mask = None
+            mask_dict=None
+
+        # 100*batch*256
+        if not input_query_bbox is None:
+            input_query_label = input_query_label
+            input_query_bbox = input_query_bbox
+
+        return input_query_label,input_query_bbox,attn_mask,mask_dict
+
+    def dn_post_process(self,outputs_class,outputs_coord,mask_dict,outputs_mask):
+        """
+            post process of dn after output from the transformer
+            put the dn part in the mask_dict
+            """
+        assert mask_dict['pad_size'] > 0
+        output_known_class = outputs_class[:, :, :mask_dict['pad_size'], :]
+        outputs_class = outputs_class[:, :, mask_dict['pad_size']:, :]
+        output_known_coord = outputs_coord[:, :, :mask_dict['pad_size'], :]
+        outputs_coord = outputs_coord[:, :, mask_dict['pad_size']:, :]
+        if outputs_mask is not None:
+            output_known_mask = outputs_mask[:, :, :mask_dict['pad_size'], :]
+            outputs_mask = outputs_mask[:, :, mask_dict['pad_size']:, :]
+        out = {'pred_logits': output_known_class[-1], 'pred_boxes': output_known_coord[-1],'pred_masks': output_known_mask[-1]}
+
+        out['aux_outputs'] = self._set_aux_loss(output_known_class, output_known_mask,output_known_coord)
+        mask_dict['output_known_lbs_bboxes']=out
+        return outputs_class, outputs_coord, outputs_mask
+
+    def get_valid_ratio(self, mask):
+        _, H, W = mask.shape
+        valid_H = torch.sum(~mask[:, :, 0], 1)
+        valid_W = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_H.float() / H
+        valid_ratio_w = valid_W.float() / W
+        valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
+        return valid_ratio
+
+    def pred_box(self, reference, hs, ref0=None):
+        """
+        :param reference: reference box coordinates from each decoder layer
+        :param hs: content
+        :param ref0: whether there are prediction from the first layer
+        """
+        if ref0 is None:
+            outputs_coord_list = []
+        else:
+            outputs_coord_list = [ref0]
+        for dec_lid, (layer_ref_sig, layer_bbox_embed, layer_hs) in enumerate(zip(reference[:-1], self.bbox_embed, hs)):
+            layer_delta_unsig = layer_bbox_embed(layer_hs)
+            layer_outputs_unsig = layer_delta_unsig + inverse_sigmoid(layer_ref_sig)
+            layer_outputs_unsig = layer_outputs_unsig.sigmoid()
+            outputs_coord_list.append(layer_outputs_unsig)
+        outputs_coord_list = torch.stack(outputs_coord_list)
+        return outputs_coord_list
+
+    def forward(self, x, mask_features, masks, targets=None):
+        """
+        :param x: input, a list of multi-scale feature
+        :param mask_features: is the per-pixel embeddings with resolution 1/4 of the original image,
+        obtained by fusing backbone encoder encoded features. This is used to produce binary masks.
+        :param masks: mask in the original image
+        :param targets: used for denoising training
+        """
+        assert len(x) == self.num_feature_levels
+        size_list = []
+        # disable mask, it does not affect performance
+        enable_mask = 0
+        if masks is not None:
+            for src in x:
+                if src.size(2) % 32 or src.size(3) % 32:
+                    enable_mask = 1
+        if enable_mask == 0:
+            masks = [torch.zeros((src.size(0), src.size(2), src.size(3)), device=src.device, dtype=torch.bool) for src in x]
+        src_flatten = []
+        mask_flatten = []
+        spatial_shapes = []
+        for i in range(self.num_feature_levels):
+            idx=self.num_feature_levels-1-i
+            bs, c , h, w=x[idx].shape
+            size_list.append(x[i].shape[-2:])
+            spatial_shapes.append(x[idx].shape[-2:])
+            src_flatten.append(self.input_proj[idx](x[idx]).flatten(2).transpose(1, 2))
+            mask_flatten.append(masks[i].flatten(1))
+        src_flatten = torch.cat(src_flatten, 1)  # bs, \sum{hxw}, c
+        mask_flatten = torch.cat(mask_flatten, 1)  # bs, \sum{hxw}
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=src_flatten.device)
+        level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
+        valid_ratios = torch.stack([self.get_valid_ratio(m) for m in masks], 1)
+
+        predictions_class = []
+        predictions_mask = []
+        if self.two_stage:
+            output_memory, output_proposals = gen_encoder_output_proposals(src_flatten, mask_flatten, spatial_shapes)
+            output_memory = self.enc_output_norm(self.enc_output(output_memory))
+            enc_outputs_class_unselected = self.class_embed(output_memory)
+            # enc_outputs_coord_unselected = self._bbox_embed(
+            #     output_memory) + output_proposals  # (bs, \sum{hw}, 4) unsigmoid
+            enc_outputs_coord_unselected = self.bbox_embed[-1](
+                output_memory) + output_proposals  # (bs, \sum{hw}, 4) unsigmoid
+            topk = self.num_queries
+            topk_proposals = torch.topk(enc_outputs_class_unselected.max(-1)[0], topk, dim=1)[1]
+            refpoint_embed_undetach = torch.gather(enc_outputs_coord_unselected, 1,
+                                                   topk_proposals.unsqueeze(-1).repeat(1, 1, 4))  # unsigmoid
+            refpoint_embed = refpoint_embed_undetach.detach()
+
+            tgt_undetach = torch.gather(output_memory, 1,
+                                  topk_proposals.unsqueeze(-1).repeat(1, 1, self.hidden_dim))  # unsigmoid
+
+            outputs_class, outputs_mask = self.forward_prediction_heads(tgt_undetach.transpose(0, 1), mask_features)
+            tgt = tgt_undetach.detach()
+            if self.learn_tgt:
+                tgt = self.query_feat.weight[None].repeat(bs, 1, 1)
+            interm_outputs=dict()
+            interm_outputs['pred_logits'] = outputs_class
+            interm_outputs['pred_boxes'] = refpoint_embed_undetach.sigmoid()
+            interm_outputs['pred_masks'] = outputs_mask
+
+            if self.initialize_box_type != 'no':
+                # convert masks into boxes to better initialize box in the decoder
+                assert self.initial_pred
+                flaten_mask = outputs_mask.detach().flatten(0, 1)
+                h, w = outputs_mask.shape[-2:]
+                if self.initialize_box_type == 'bitmask':  # slower, but more accurate
+                    raise NotImplementedError()  # TODO: learn to write this
+                    # refpoint_embed = BitMasks(flaten_mask > 0).get_bounding_boxes().tensor.cuda()  # TODO: make a dummy BitMask?
+                elif self.initialize_box_type == 'mask2box':  # faster conversion
+                    raise NotImplementedError()  # TODO: learn to write this
+                    # refpoint_embed = mask2bbox(flaten_mask > 0).cuda()
+                else:
+                    assert NotImplementedError
+                refpoint_embed = bbox_xyxy_to_cxcywh(refpoint_embed) / torch.as_tensor([w, h, w, h], dtype=torch.float).cuda()
+                refpoint_embed = refpoint_embed.reshape(outputs_mask.shape[0], outputs_mask.shape[1], 4)
+                refpoint_embed = inverse_sigmoid(refpoint_embed)
+        elif not self.two_stage:
+            tgt = self.query_feat.weight[None].repeat(bs, 1, 1)
+            refpoint_embed = self.query_embed.weight[None].repeat(bs, 1, 1)
+
+        tgt_mask = None
+        mask_dict = None
+        if self.dn != "no" and self.training:
+            assert targets is not None
+            input_query_label, input_query_bbox, tgt_mask, mask_dict = \
+                self.prepare_for_dn(targets, None, None, x[0].shape[0])
+            if mask_dict is not None:
+                tgt=torch.cat([input_query_label, tgt],dim=1)
+
+        # direct prediction from the matching and denoising part in the begining
+        if self.initial_pred:
+            outputs_class, outputs_mask = self.forward_prediction_heads(tgt.transpose(0, 1), mask_features, self.training)
+            predictions_class.append(outputs_class)
+            predictions_mask.append(outputs_mask)
+        if self.dn != "no" and self.training and mask_dict is not None:
+            refpoint_embed=torch.cat([input_query_bbox,refpoint_embed],dim=1)
+
+        hs, references = self.decoder(
+            tgt=tgt.transpose(0, 1),
+            memory=src_flatten.transpose(0, 1),
+            memory_key_padding_mask=mask_flatten,
+            pos=None,
+            refpoints_unsigmoid=refpoint_embed.transpose(0, 1),
+            level_start_index=level_start_index,
+            spatial_shapes=spatial_shapes,
+            valid_ratios=valid_ratios,
+            tgt_mask=tgt_mask,
+            bbox_embed=self.bbox_embed
+        )
+        for i, output in enumerate(hs):
+            outputs_class, outputs_mask = self.forward_prediction_heads(output.transpose(0, 1), mask_features, self.training or (i == len(hs)-1))
+            predictions_class.append(outputs_class)
+            predictions_mask.append(outputs_mask)
+
+        # iteratively box prediction
+        if self.initial_pred:
+            out_boxes = self.pred_box(references, hs, refpoint_embed.sigmoid())
+            assert len(predictions_class) == self.num_layers + 1
+        else:
+            out_boxes = self.pred_box(references, hs)
+        if mask_dict is not None:
+            predictions_mask=torch.stack(predictions_mask)
+            predictions_class=torch.stack(predictions_class)
+            predictions_class, out_boxes,predictions_mask=\
+                self.dn_post_process(predictions_class,out_boxes,mask_dict,predictions_mask)
+            predictions_class,predictions_mask=list(predictions_class),list(predictions_mask)
+        elif self.training:  # this is to insure self.label_enc participate in the model
+            predictions_class[-1] += 0.0*self.label_enc.weight.sum()
+
+        out = {
+            'pred_logits': predictions_class[-1],
+            'pred_masks': predictions_mask[-1],
+            'pred_boxes':out_boxes[-1],
+            'aux_outputs': self._set_aux_loss(
+                predictions_class if self.mask_classification else None, predictions_mask,out_boxes
+            )
+        }
+        if self.two_stage:
+            out['interm_outputs'] = interm_outputs
+        return out, mask_dict
+
+    def forward_prediction_heads(self, output, mask_features, pred_mask=True):
+        # decoder_output = self.decoder_norm(output)  # TODO: again ???
+        decoder_output = self.decoder.norm(output)
+        decoder_output = decoder_output.transpose(0, 1)
+        outputs_class = self.class_embed(decoder_output)
+        outputs_mask = None
+        if pred_mask:
+            mask_embed = self.mask_embed(decoder_output)
+            outputs_mask = torch.einsum("bqc,bchw->bqhw", mask_embed, mask_features)
+
+        return outputs_class, outputs_mask
+
+    @torch.jit.unused
+    def _set_aux_loss(self, outputs_class, outputs_seg_masks, out_boxes=None):
+        # this is a workaround to make torchscript happy, as torchscript
+        # doesn't support dictionary with non-homogeneous values, such
+        # as a dict having both a Tensor and a list.
+        # if self.mask_classification:
+        if out_boxes is None:
+            return [
+                {"pred_logits": a, "pred_masks": b}
+                for a, b in zip(outputs_class[:-1], outputs_seg_masks[:-1])
+            ]
+        else:
+            return [
+                {"pred_logits": a, "pred_masks": b, "pred_boxes":c}
+                for a, b, c in zip(outputs_class[:-1], outputs_seg_masks[:-1], out_boxes[:-1])
+            ]
+
+
+class TransformerDecoder(nn.Module):
+
+    def __init__(self, decoder_layer, num_layers, norm=None,
+                 return_intermediate=False,
+                 d_model=256, query_dim=4,
+                 modulate_hw_attn=True,
+                 num_feature_levels=1,
+                 deformable_decoder=True,
+                 decoder_query_perturber=None,
+                 dec_layer_number=None,  # number of queries each layer in decoder
+                 rm_dec_query_scale=True,
+                 dec_layer_share=False,
+                 dec_layer_dropout_prob=None,
+                 ):
+        super().__init__()
+        if num_layers > 0:
+            self.layers = _get_clones(decoder_layer, num_layers, layer_share=dec_layer_share)
+        else:
+            self.layers = []
+        self.num_layers = num_layers
+        self.norm = norm
+        self.return_intermediate = return_intermediate
+        assert return_intermediate, "support return_intermediate only"
+        self.query_dim = query_dim
+        assert query_dim in [2, 4], "query_dim should be 2/4 but {}".format(query_dim)
+        self.num_feature_levels = num_feature_levels
+
+        self.ref_point_head = MLP(query_dim // 2 * d_model, d_model, d_model, 2)
+        if not deformable_decoder:
+            self.query_pos_sine_scale = MLP(d_model, d_model, d_model, 2)
+        else:
+            self.query_pos_sine_scale = None
+
+        if rm_dec_query_scale:
+            self.query_scale = None
+        else:
+            raise NotImplementedError
+            self.query_scale = MLP(d_model, d_model, d_model, 2)
+        # self.bbox_embed = None
+        self.class_embed = None
+
+        self.d_model = d_model
+        self.modulate_hw_attn = modulate_hw_attn
+        self.deformable_decoder = deformable_decoder
+
+        if not deformable_decoder and modulate_hw_attn:
+            self.ref_anchor_head = MLP(d_model, d_model, 2, 2)
+        else:
+            self.ref_anchor_head = None
+
+        self.decoder_query_perturber = decoder_query_perturber
+        self.box_pred_damping = None
+
+        self.dec_layer_number = dec_layer_number
+        if dec_layer_number is not None:
+            assert isinstance(dec_layer_number, list)
+            assert len(dec_layer_number) == num_layers
+            # assert dec_layer_number[0] ==
+
+        self.dec_layer_dropout_prob = dec_layer_dropout_prob
+        if dec_layer_dropout_prob is not None:
+            assert isinstance(dec_layer_dropout_prob, list)
+            assert len(dec_layer_dropout_prob) == num_layers
+            for i in dec_layer_dropout_prob:
+                assert 0.0 <= i <= 1.0
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+        for m in self.modules():
+            if isinstance(m, MultiScaleDeformableAttention):
+                m.init_weights()
+
+    def forward(self, tgt, memory,
+                tgt_mask: Optional[Tensor] = None,
+                memory_mask: Optional[Tensor] = None,
+                tgt_key_padding_mask: Optional[Tensor] = None,
+                memory_key_padding_mask: Optional[Tensor] = None,
+                pos: Optional[Tensor] = None,
+                refpoints_unsigmoid: Optional[Tensor] = None,  # num_queries, bs, 2
+                # for memory
+                level_start_index: Optional[Tensor] = None,  # num_levels
+                spatial_shapes: Optional[Tensor] = None,  # bs, num_levels, 2
+                valid_ratios: Optional[Tensor] = None,
+                bbox_embed: Optional[nn.Module] = None
+                ):
+        """
+        Input:
+            - tgt: nq, bs, d_model
+            - memory: hw, bs, d_model
+            - pos: hw, bs, d_model
+            - refpoints_unsigmoid: nq, bs, 2/4
+            - valid_ratios/spatial_shapes: bs, nlevel, 2
+        """
+        output = tgt
+
+        intermediate = []
+        reference_points = refpoints_unsigmoid.sigmoid()
+        ref_points = [reference_points]
+
+        for layer_id, layer in enumerate(self.layers):
+            # preprocess ref points
+            if self.training and self.decoder_query_perturber is not None and layer_id != 0:
+                reference_points = self.decoder_query_perturber(reference_points)
+
+            reference_points_input = reference_points[:, :, None] \
+                                         * torch.cat([valid_ratios, valid_ratios], -1)[None, :]  # nq, bs, nlevel, 4
+            query_sine_embed = coordinate_to_encoding(reference_points_input[:, :, 0, :]) # nq, bs, 256*2
+
+            raw_query_pos = self.ref_point_head(query_sine_embed)  # nq, bs, 256
+            pos_scale = self.query_scale(output) if self.query_scale is not None else 1
+            query_pos = pos_scale * raw_query_pos
+
+            output = layer(
+                tgt=output,
+                tgt_query_pos=query_pos,
+                tgt_query_sine_embed=query_sine_embed,
+                tgt_key_padding_mask=tgt_key_padding_mask,
+                tgt_reference_points=reference_points_input,
+
+                memory=memory,
+                memory_key_padding_mask=memory_key_padding_mask,
+                memory_level_start_index=level_start_index,
+                memory_spatial_shapes=spatial_shapes,
+                memory_pos=pos,
+
+                self_attn_mask=tgt_mask,
+                cross_attn_mask=memory_mask
+            )
+
+            # iter update
+            if bbox_embed is not None:
+                reference_before_sigmoid = inverse_sigmoid(reference_points)
+                delta_unsig = bbox_embed[layer_id](output)
+                outputs_unsig = delta_unsig + reference_before_sigmoid
+                new_reference_points = outputs_unsig.sigmoid()
+
+                reference_points = new_reference_points.detach()
+                # if layer_id != self.num_layers - 1:
+                ref_points.append(new_reference_points)
+
+            intermediate.append(self.norm(output))
+
+        return [
+            [itm_out.transpose(0, 1) for itm_out in intermediate],
+            [itm_refpoint.transpose(0, 1) for itm_refpoint in ref_points]
+        ]
+
+
+class DeformableTransformerDecoderLayer(nn.Module):
+
+    def __init__(self, d_model=256, d_ffn=1024,
+                 dropout=0.1, activation="relu",
+                 n_levels=4, n_heads=8, n_points=4,
+                 use_deformable_box_attn=False,
+                 key_aware_type=None,
+                 ):
+        super().__init__()
+
+        # cross attention
+        if use_deformable_box_attn:
+            raise NotImplementedError
+        else:
+            self.cross_attn = MultiScaleDeformableAttention(
+                embed_dims=d_model, num_levels=n_levels,
+                num_heads=n_heads, num_points=n_points, dropout=dropout)
+        # self.dropout1 = nn.Dropout(dropout)
+        self.norm1 = nn.LayerNorm(d_model)
+
+        # self attention
+        self.self_attn = nn.MultiheadAttention(d_model, n_heads, dropout=dropout)
+        self.dropout2 = nn.Dropout(dropout)
+        self.norm2 = nn.LayerNorm(d_model)
+
+        # ffn
+        self.linear1 = nn.Linear(d_model, d_ffn)
+        self.activation = _get_activation_fn(activation)
+        self.dropout3 = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(d_ffn, d_model)
+        self.dropout4 = nn.Dropout(dropout)
+        self.norm3 = nn.LayerNorm(d_model)
+
+        self.key_aware_type = key_aware_type
+        self.key_aware_proj = None
+
+    def rm_self_attn_modules(self):
+        self.self_attn = None
+        self.dropout2 = None
+        self.norm2 = None
+
+    @staticmethod
+    def with_pos_embed(tensor, pos):
+        return tensor if pos is None else tensor + pos
+
+    def forward_ffn(self, tgt):
+        tgt2 = self.linear2(self.dropout3(self.activation(self.linear1(tgt))))
+        tgt = tgt + self.dropout4(tgt2)
+        tgt = self.norm3(tgt)
+        return tgt
+
+    @autocast(enabled=False)
+    def forward(self,
+                # for tgt
+                tgt: Optional[Tensor],  # nq, bs, d_model
+                tgt_query_pos: Optional[Tensor] = None,  # pos for query. MLP(Sine(pos))
+                tgt_query_sine_embed: Optional[Tensor] = None,  # pos for query. Sine(pos)
+                tgt_key_padding_mask: Optional[Tensor] = None,
+                tgt_reference_points: Optional[Tensor] = None,  # nq, bs, 4
+
+                # for memory
+                memory: Optional[Tensor] = None,  # hw, bs, d_model
+                memory_key_padding_mask: Optional[Tensor] = None,
+                memory_level_start_index: Optional[Tensor] = None,  # num_levels
+                memory_spatial_shapes: Optional[Tensor] = None,  # bs, num_levels, 2
+                memory_pos: Optional[Tensor] = None,  # pos for memory
+
+                # sa
+                self_attn_mask: Optional[Tensor] = None,  # mask used for self-attention
+                cross_attn_mask: Optional[Tensor] = None,  # mask used for cross-attention
+                ):
+        """
+        Input:
+            - tgt/tgt_query_pos: nq, bs, d_model
+            -
+        """
+        # self attention
+        if self.self_attn is not None:
+            q = k = self.with_pos_embed(tgt, tgt_query_pos)
+            tgt2 = self.self_attn(q, k, tgt, attn_mask=self_attn_mask)[0]
+            tgt = tgt + self.dropout2(tgt2)
+            tgt = self.norm2(tgt)
+
+        # cross attention
+        if self.key_aware_type is not None:
+            if self.key_aware_type == 'mean':
+                tgt = tgt + memory.mean(0, keepdim=True)
+            elif self.key_aware_type == 'proj_mean':
+                tgt = tgt + self.key_aware_proj(memory).mean(0, keepdim=True)
+            else:
+                raise NotImplementedError("Unknown key_aware_type: {}".format(self.key_aware_type))
+        # tgt2 = self.cross_attn(self.with_pos_embed(tgt, tgt_query_pos).transpose(0, 1),
+        #                        tgt_reference_points.transpose(0, 1).contiguous(),
+        #                        memory.transpose(0, 1), memory_spatial_shapes, memory_level_start_index,
+        #                        memory_key_padding_mask).transpose(0, 1)
+        tgt = self.cross_attn(
+            query=tgt, query_pos=tgt_query_pos, value=memory,
+            key_padding_mask=memory_key_padding_mask, reference_points=tgt_reference_points.transpose(0, 1).contiguous(),
+            spatial_shapes=memory_spatial_shapes, level_start_index=memory_level_start_index)
+        # tgt = tgt + self.dropout1(tgt2)
+        tgt = self.norm1(tgt)
+
+        # ffn
+        tgt = self.forward_ffn(tgt)
+
+        return tgt
+
+
+def gen_encoder_output_proposals(memory:Tensor, memory_padding_mask:Tensor, spatial_shapes:Tensor):
+    """
+    Input:
+        - memory: bs, \sum{hw}, d_model
+        - memory_padding_mask: bs, \sum{hw}
+        - spatial_shapes: nlevel, 2
+    Output:
+        - output_memory: bs, \sum{hw}, d_model
+        - output_proposals: bs, \sum{hw}, 4
+    """
+    N_, S_, C_ = memory.shape
+    base_scale = 4.0
+    proposals = []
+    _cur = 0
+    for lvl, (H_, W_) in enumerate(spatial_shapes):
+        mask_flatten_ = memory_padding_mask[:, _cur:(_cur + H_ * W_)].view(N_, H_, W_, 1)
+        valid_H = torch.sum(~mask_flatten_[:, :, 0, 0], 1)
+        valid_W = torch.sum(~mask_flatten_[:, 0, :, 0], 1)
+
+        grid_y, grid_x = torch.meshgrid(torch.linspace(0, H_ - 1, H_, dtype=torch.float32, device=memory.device),
+                                        torch.linspace(0, W_ - 1, W_, dtype=torch.float32, device=memory.device))
+        grid = torch.cat([grid_x.unsqueeze(-1), grid_y.unsqueeze(-1)], -1)
+
+        scale = torch.cat([valid_W.unsqueeze(-1), valid_H.unsqueeze(-1)], 1).view(N_, 1, 1, 2)
+        grid = (grid.unsqueeze(0).expand(N_, -1, -1, -1) + 0.5) / scale
+        wh = torch.ones_like(grid) * 0.05 * (2.0 ** lvl)
+        proposal = torch.cat((grid, wh), -1).view(N_, -1, 4)
+        proposals.append(proposal)
+        _cur += (H_ * W_)
+    output_proposals = torch.cat(proposals, 1)
+    output_proposals_valid = ((output_proposals > 0.01) & (output_proposals < 0.99)).all(-1, keepdim=True)
+    output_proposals = torch.log(output_proposals / (1 - output_proposals))
+    output_proposals = output_proposals.masked_fill(memory_padding_mask.unsqueeze(-1), float('inf'))
+    output_proposals = output_proposals.masked_fill(~output_proposals_valid, float('inf'))
+
+    output_memory = memory
+    output_memory = output_memory.masked_fill(memory_padding_mask.unsqueeze(-1), float(0))
+    output_memory = output_memory.masked_fill(~output_proposals_valid, float(0))
+    return output_memory, output_proposals
+
+
+def _get_activation_fn(activation):
+    """Return an activation function given a string"""
+    if activation == "relu":
+        return F.relu
+    if activation == "gelu":
+        return F.gelu
+    if activation == "glu":
+        return F.glu
+    if activation == "prelu":
+        return nn.PReLU()
+    if activation == "selu":
+        return F.selu
+    raise RuntimeError(F"activation should be relu/gelu, not {activation}.")
+
+
+def _get_clones(module, N, layer_share=False):
+
+    if layer_share:
+        return nn.ModuleList([module for i in range(N)])
+    else:
+        return nn.ModuleList([copy.deepcopy(module) for i in range(N)])

--- a/mmdet/models/layers/transformer/maskdino_encoder_layers.py
+++ b/mmdet/models/layers/transformer/maskdino_encoder_layers.py
@@ -1,0 +1,360 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import warnings
+import numpy as np
+from typing import List
+from collections import namedtuple
+import fvcore.nn.weight_init as weight_init
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch.nn.init import normal_
+from torch.cuda.amp import autocast
+
+from mmcv.cnn import ConvModule
+from mmdet.models.layers import SinePositionalEncoding, DeformableDetrTransformerEncoder
+from mmcv.ops import MultiScaleDeformableAttention
+
+
+class MaskDINOEncoder(nn.Module):
+    """
+    This is the multi-scale encoder in detection models, also named as pixel decoder in segmentation models.
+    """
+
+    def __init__(
+        self,
+        in_channels=[256, 512, 1024, 2048],  # TODO: typeint ask Mask2former
+        in_strides=[4, 8, 16, 32],  # TODO: typeint ask Mask2former
+        transformer_dropout: float = 0.0,
+        transformer_nheads: int = 8,
+        transformer_dim_feedforward: int = 2048,
+        transformer_enc_layers: int = 6,
+        conv_dim: int = 256,
+        mask_dim: int = 256,
+        norm_cfg = dict(type='GN', num_groups=32),  # TODO: typeint ask Mask2former
+        # deformable transformer encoder args
+        transformer_in_features: List[str] = ['res3', 'res4', 'res5'],
+        common_stride: int = 4,
+        num_feature_levels: int = 3,
+        total_num_feature_levels: int = 4,
+        feature_order: str = 'low2high',
+    ):
+        """
+        NOTE: this interface is experimental.
+        Args:
+            input_shape: shapes (channels and stride) of the input features
+            transformer_dropout: dropout probability in transformer
+            transformer_nheads: number of heads in transformer
+            transformer_dim_feedforward: dimension of feedforward network
+            transformer_enc_layers: number of transformer encoder layers
+            conv_dims: number of output channels for the intermediate conv layers.
+            mask_dim: number of output channels for the final conv layer.
+            norm_cfg (str or callable): normalization for all conv layers
+            num_feature_levels: feature scales used
+            total_num_feature_levels: total feautre scales used (include the downsampled features)
+            feature_order: 'low2high' or 'high2low', i.e., 'low2high' means low-resolution features are put in the first.
+        """
+        super().__init__()
+
+        # Make a dummy detectron2.layers.ShapeSpec to let input_shape happy
+        assert len(in_channels) == len(in_strides) == 4  # TODO: refine this
+        DummyShapeSpec = namedtuple('DummyShapeSpec', ('channels', 'stride'))
+        input_shape = {f'res{i+2}': DummyShapeSpec(channels=in_channels[i],
+                                         stride=in_strides[i])
+                       for i in range(len(in_channels))}
+        warnings.warn(f'The input feature names are set '
+                      f'{input_shape.keys()} with hardcode.')
+
+        transformer_input_shape = {
+            k: v for k, v in input_shape.items() if k in transformer_in_features
+        }
+        # this is the input shape of pixel decoder
+        input_shape = sorted(input_shape.items(), key=lambda x: x[1].stride)
+        self.in_features = [k for k, v in input_shape]  # starting from "res2" to "res5"
+        self.feature_strides = [v.stride for k, v in input_shape]
+        self.feature_channels = [v.channels for k, v in input_shape]
+        self.feature_order = feature_order
+
+        if feature_order == "low2high":
+            transformer_input_shape = sorted(transformer_input_shape.items(), key=lambda x: -x[1].stride)
+        else:
+            transformer_input_shape = sorted(transformer_input_shape.items(), key=lambda x: x[1].stride)
+        self.transformer_in_features = [k for k, v in transformer_input_shape]  # starting from "res2" to "res5"
+        transformer_in_channels = [v.channels for k, v in transformer_input_shape]
+        self.transformer_feature_strides = [v.stride for k, v in transformer_input_shape]  # to decide extra FPN layers
+
+        self.maskdino_num_feature_levels = num_feature_levels  # always use 3 scales
+        self.total_num_feature_levels = total_num_feature_levels
+        self.common_stride = common_stride
+
+        self.transformer_num_feature_levels = len(self.transformer_in_features)
+        self.low_resolution_index = transformer_in_channels.index(max(transformer_in_channels))
+        self.high_resolution_index = 0 if self.feature_order == 'low2high' else -1
+        if self.transformer_num_feature_levels > 1:
+            input_proj_list = []
+            for in_channels in transformer_in_channels[::-1]:
+                input_proj_list.append(nn.Sequential(
+                    nn.Conv2d(in_channels, conv_dim, kernel_size=1),
+                    nn.GroupNorm(32, conv_dim),
+                ))
+            # input projectino for downsample
+            in_channels = max(transformer_in_channels)
+            for _ in range(self.total_num_feature_levels - self.transformer_num_feature_levels):  # exclude the res2
+                input_proj_list.append(nn.Sequential(
+                    nn.Conv2d(in_channels, conv_dim, kernel_size=3, stride=2, padding=1),
+                    nn.GroupNorm(32, conv_dim),
+                ))
+                in_channels = conv_dim
+            self.input_proj = nn.ModuleList(input_proj_list)
+        else:
+            self.input_proj = nn.ModuleList([
+                nn.Sequential(
+                    nn.Conv2d(transformer_in_channels[-1], conv_dim, kernel_size=1),
+                    nn.GroupNorm(32, conv_dim),
+                )])
+
+        for proj in self.input_proj:
+            nn.init.xavier_uniform_(proj[0].weight, gain=1)
+            nn.init.constant_(proj[0].bias, 0)
+
+        self.transformer = MSDeformAttnTransformerEncoderOnly(
+            # TODO: consider using **transformer_cfg
+            d_model=conv_dim,
+            dropout=transformer_dropout,
+            nhead=transformer_nheads,
+            dim_feedforward=transformer_dim_feedforward,
+            num_encoder_layers=transformer_enc_layers,
+            num_feature_levels=self.total_num_feature_levels,
+        )
+        N_steps = conv_dim // 2
+        self.pe_layer = SinePositionalEncoding(N_steps, normalize=True)
+
+        self.mask_dim = mask_dim
+        # use 1x1 conv instead
+        # self.mask_features = ConvModule(conv_dim, mask_dim, kernel_size=1,
+        #                                 stride=1, padding=0, bias=True,
+        #                                 norm_cfg=None, act_cfg=None)
+        ## This raise the following error, may be because of fvcore init func
+        ## AttributeError: 'ConvModule' object has no attribute 'weight'
+        self.mask_features = nn.Conv2d(conv_dim, mask_dim, kernel_size=1,
+                                       stride=1, padding=0)
+        weight_init.c2_xavier_fill(self.mask_features)  # TODO: Ask Mask2Former whether fvcore is essential
+        # extra fpn levels
+        stride = min(self.transformer_feature_strides)
+        self.num_fpn_levels = max(int(np.log2(stride) - np.log2(self.common_stride)), 1)
+
+        lateral_convs = []
+        output_convs = []
+
+        use_bias = False
+        for idx, in_channels in enumerate(self.feature_channels[:self.num_fpn_levels]):
+            # TODO: check along with Mask2Former
+            lateral_conv = ConvModule(
+                in_channels,
+                conv_dim,
+                kernel_size=1,
+                stride=1,
+                padding=0,
+                bias=use_bias,
+                norm_cfg=norm_cfg,
+                act_cfg=None)
+            output_conv = ConvModule(
+                conv_dim,
+                conv_dim,
+                kernel_size=3,
+                stride=1,
+                padding=1,
+                bias=use_bias,
+                norm_cfg=norm_cfg,
+                act_cfg=dict(type='ReLU'))
+            # This is because ConvModule raise the following error in fvcore
+            # AttributeError: 'ConvModule' object has no attribute 'weight'
+            # lateral_conv.weight = lateral_conv.conv.weight
+            # lateral_conv.bias = lateral_conv.conv.bias
+            # output_conv.weight = output_conv.conv.weight  # TODO: Whether to create a pr for ConvModule, or only pass conv to c2_xavier_fill
+            # output_conv.bias = output_conv.conv.bias
+            # weight_init.c2_xavier_fill(lateral_conv)  # TODO: Ask Mask2Former whether fvcore is essential
+            # weight_init.c2_xavier_fill(output_conv)  # TODO: Ask Mask2Former whether fvcore is essential
+
+            self.add_module("adapter_{}".format(idx + 1), lateral_conv)
+            self.add_module("layer_{}".format(idx + 1), output_conv)
+
+            lateral_convs.append(lateral_conv)
+            output_convs.append(output_conv)
+        # Place convs into top-down order (from low to high resolution)
+        # to make the top-down computation in forward clearer.
+        self.lateral_convs = lateral_convs[::-1]
+        self.output_convs = output_convs[::-1]
+
+    @autocast(enabled=False)
+    def forward_features(self, features, masks):
+        """
+        :param features: multi-scale features from the backbone
+        :param masks: image mask
+        :return: enhanced multi-scale features and mask feature (1/4 resolution) for the decoder to produce binary mask
+        """
+        # this hard code make detectron2 style feature # TODO: refactor this
+        features = {f'res{i+2}': feat for i, feat in enumerate(features)}
+
+        # backbone features
+        srcs = []
+        pos = []
+        # additional downsampled features
+        srcsl = []
+        posl = []
+        if self.total_num_feature_levels > self.transformer_num_feature_levels:
+            smallest_feat = features[self.transformer_in_features[self.low_resolution_index]].float()
+            _len_srcs = self.transformer_num_feature_levels
+            for l in range(_len_srcs, self.total_num_feature_levels):
+                if l == _len_srcs:
+                    src = self.input_proj[l](smallest_feat)
+                else:
+                    src = self.input_proj[l](srcsl[-1])
+                srcsl.append(src)
+                # TODO: Here generate a dummy mask
+                mask = torch.zeros((src.size(0), src.size(2), src.size(3)),
+                                   device=src.device, dtype=torch.bool)
+                posl.append(self.pe_layer(mask))
+        srcsl = srcsl[::-1]
+        # Reverse feature maps
+        for idx, f in enumerate(self.transformer_in_features[::-1]):
+            x = features[f].float()  # deformable detr does not support half precision
+            srcs.append(self.input_proj[idx](x))
+            # TODO: Here generate a dummy mask
+            mask = torch.zeros((x.size(0), x.size(2), x.size(3)),
+                               device=x.device, dtype=torch.bool)
+            pos.append(self.pe_layer(mask))
+        srcs.extend(srcsl) if self.feature_order == 'low2high' else srcsl.extend(srcs)
+        pos.extend(posl) if self.feature_order == 'low2high' else posl.extend(pos)
+        if self.feature_order != 'low2high':
+            srcs = srcsl
+            pos = posl
+        y, spatial_shapes, level_start_index = self.transformer(srcs, masks, pos)
+        bs = y.shape[0]
+
+        split_size_or_sections = [None] * self.total_num_feature_levels
+        for i in range(self.total_num_feature_levels):
+            if i < self.total_num_feature_levels - 1:
+                split_size_or_sections[i] = level_start_index[i + 1] - level_start_index[i]
+            else:
+                split_size_or_sections[i] = y.shape[1] - level_start_index[i]
+        y = torch.split(y, split_size_or_sections, dim=1)
+
+        out = []
+        multi_scale_features = []
+        num_cur_levels = 0
+        for i, z in enumerate(y):
+            out.append(z.transpose(1, 2).view(bs, -1, spatial_shapes[i][0], spatial_shapes[i][1]))
+
+        # append `out` with extra FPN levels
+        # Reverse feature maps into top-down order (from low to high resolution)
+        for idx, f in enumerate(self.in_features[:self.num_fpn_levels][::-1]):
+            x = features[f].float()
+            lateral_conv = self.lateral_convs[idx]
+            output_conv = self.output_convs[idx]
+            cur_fpn = lateral_conv(x)
+            # Following FPN implementation, we use nearest upsampling here
+            y = cur_fpn + F.interpolate(out[self.high_resolution_index], size=cur_fpn.shape[-2:], mode="bilinear", align_corners=False)
+            y = output_conv(y)
+            out.append(y)
+        for o in out:
+            if num_cur_levels < self.total_num_feature_levels:
+                multi_scale_features.append(o)
+                num_cur_levels += 1
+        return self.mask_features(out[-1]), out[0], multi_scale_features
+
+
+class MSDeformAttnTransformerEncoderOnly(nn.Module):
+    """MSDeformAttn Transformer encoder in deformable detr"""
+    def __init__(self,
+                 d_model=256,
+                 nhead=8,
+                 num_encoder_layers=6,
+                 dim_feedforward=1024,
+                 dropout=0.1,
+                 act_cfg=dict(type='ReLU', inplace=True),
+                 num_feature_levels=4,
+                 enc_n_points=4,):
+        super().__init__()
+        self.d_model = d_model
+        self.nhead = nhead
+        self.encoder = DeformableDetrTransformerEncoder(
+            # TODO: consider using **encoder_cfg
+            num_layers=num_encoder_layers,
+            layer_cfg=dict(
+                self_attn_cfg=dict(
+                    embed_dims=d_model,
+                    num_heads=nhead,
+                    dropout=dropout,
+                    num_points=enc_n_points),
+                ffn_cfg=dict(
+                    embed_dims=d_model,
+                    feedforward_channels=dim_feedforward,
+                    num_fcs=2,
+                    ffn_drop=dropout,
+                    act_cfg=act_cfg),
+                norm_cfg=dict(type='LN')))
+
+        self.level_embed = nn.Parameter(torch.Tensor(num_feature_levels, d_model))
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for p in self.parameters():
+            if p.dim() > 1:
+                nn.init.xavier_uniform_(p)
+        for m in self.modules():
+            if isinstance(m, MultiScaleDeformableAttention):
+                m.init_weights()
+        normal_(self.level_embed)
+
+    def get_valid_ratio(self, mask):
+        _, H, W = mask.shape
+        valid_H = torch.sum(~mask[:, :, 0], 1)
+        valid_W = torch.sum(~mask[:, 0, :], 1)
+        valid_ratio_h = valid_H.float() / H
+        valid_ratio_w = valid_W.float() / W
+        valid_ratio = torch.stack([valid_ratio_w, valid_ratio_h], -1)
+        return valid_ratio
+
+    def forward(self, srcs, masks, pos_embeds):
+        enable_mask=0
+        if masks is not None:
+            for src in srcs:
+                if src.size(2)%32 or src.size(3)%32:
+                    enable_mask = 1
+        if enable_mask==0:
+            masks = [torch.zeros((x.size(0), x.size(2), x.size(3)), device=x.device, dtype=torch.bool) for x in srcs]
+        # prepare input for encoder
+        src_flatten = []
+        mask_flatten = []
+        lvl_pos_embed_flatten = []
+        spatial_shapes = []
+        for lvl, (src, mask, pos_embed) in enumerate(zip(srcs, masks, pos_embeds)):
+            bs, c, h, w = src.shape
+            spatial_shape = (h, w)
+            spatial_shapes.append(spatial_shape)
+            src = src.flatten(2).transpose(1, 2)
+            mask = mask.flatten(1)
+            pos_embed = pos_embed.flatten(2).transpose(1, 2)
+            lvl_pos_embed = pos_embed + self.level_embed[lvl].view(1, 1, -1)
+            lvl_pos_embed_flatten.append(lvl_pos_embed)
+            src_flatten.append(src)
+            mask_flatten.append(mask)
+        src_flatten = torch.cat(src_flatten, 1)
+        mask_flatten = torch.cat(mask_flatten, 1)
+        lvl_pos_embed_flatten = torch.cat(lvl_pos_embed_flatten, 1)
+        spatial_shapes = torch.as_tensor(spatial_shapes, dtype=torch.long, device=src_flatten.device)
+        level_start_index = torch.cat((spatial_shapes.new_zeros((1, )), spatial_shapes.prod(1).cumsum(0)[:-1]))
+        valid_ratios = torch.stack([self.get_valid_ratio(m) for m in masks], 1)
+
+        # encoder
+        memory = self.encoder(
+            query=src_flatten,
+            spatial_shapes=spatial_shapes,
+            level_start_index=level_start_index,
+            valid_ratios=valid_ratios,
+            query_pos=lvl_pos_embed_flatten,
+            key_padding_mask=mask_flatten)
+
+        return memory, spatial_shapes, level_start_index

--- a/mmdet/models/losses/maskdino_loss.py
+++ b/mmdet/models/losses/maskdino_loss.py
@@ -1,0 +1,567 @@
+# ------------------------------------------------------------------------
+# DINO
+# Copyright (c) 2022 IDEA. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+# Modified from DINO https://github.com/IDEA-Research/DINO by Feng Li and Hao Zhang.
+# ------------------------------------------------------------------------
+"""
+MaskFormer criterion.
+"""
+import logging
+from typing import List
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torchvision.ops import generalized_box_iou
+
+from mmengine.dist import get_world_size
+from mmcv.ops import point_sample
+from mmdet.structures.bbox import bbox_xyxy_to_cxcywh, bbox_cxcywh_to_xyxy
+from .misc import is_dist_avail_and_initialized, nested_tensor_from_tensor_list
+from .matcher import HungarianMatcher
+
+
+def sigmoid_focal_loss(inputs, targets, num_boxes, alpha: float = 0.25, gamma: float = 2):
+    """
+    Loss used in RetinaNet for dense detection: https://arxiv.org/abs/1708.02002.
+    Args:
+        inputs: A float tensor of arbitrary shape.
+                The predictions for each example.
+        targets: A float tensor with the same shape as inputs. Stores the binary
+                 classification label for each element in inputs
+                (0 for the negative class and 1 for the positive class).
+        alpha: (optional) Weighting factor in range (0,1) to balance
+                positive vs negative examples. Default = -1 (no weighting).
+        gamma: Exponent of the modulating factor (1 - p_t) to
+               balance easy vs hard examples.
+    Returns:
+        Loss tensor
+    """
+    prob = inputs.sigmoid()
+    ce_loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
+    p_t = prob * targets + (1 - prob) * (1 - targets)
+    loss = ce_loss * ((1 - p_t) ** gamma)
+
+    if alpha >= 0:
+        alpha_t = alpha * targets + (1 - alpha) * (1 - targets)
+        loss = alpha_t * loss
+
+
+    return loss.mean(1).sum() / num_boxes
+
+
+def dice_loss(
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        num_masks: float,
+    ):
+    """
+    Compute the DICE loss, similar to generalized IOU for masks
+    Args:
+        inputs: A float tensor of arbitrary shape.
+                The predictions for each example.
+        targets: A float tensor with the same shape as inputs. Stores the binary
+                 classification label for each element in inputs
+                (0 for the negative class and 1 for the positive class).
+    """
+    inputs = inputs.sigmoid()
+    inputs = inputs.flatten(1)
+    numerator = 2 * (inputs * targets).sum(-1)
+    denominator = inputs.sum(-1) + targets.sum(-1)
+    loss = 1 - (numerator + 1) / (denominator + 1)
+    return loss.sum() / num_masks
+
+
+dice_loss_jit = torch.jit.script(
+    dice_loss
+)  # type: torch.jit.ScriptModule
+
+
+def sigmoid_ce_loss(
+        inputs: torch.Tensor,
+        targets: torch.Tensor,
+        num_masks: float,
+    ):
+    """
+    Args:
+        inputs: A float tensor of arbitrary shape.
+                The predictions for each example.
+        targets: A float tensor with the same shape as inputs. Stores the binary
+                 classification label for each element in inputs
+                (0 for the negative class and 1 for the positive class).
+    Returns:
+        Loss tensor
+    """
+    loss = F.binary_cross_entropy_with_logits(inputs, targets, reduction="none")
+
+    return loss.mean(1).sum() / num_masks
+
+
+sigmoid_ce_loss_jit = torch.jit.script(
+    sigmoid_ce_loss
+)  # type: torch.jit.ScriptModule
+
+
+def calculate_uncertainty(logits):
+    """
+    We estimate uncerainty as L1 distance between 0.0 and the logit prediction in 'logits' for the
+        foreground class in `classes`.
+    Args:
+        logits (Tensor): A tensor of shape (R, 1, ...) for class-specific or
+            class-agnostic, where R is the total number of predicted masks in all images and C is
+            the number of foreground classes. The values are logits.
+    Returns:
+        scores (Tensor): A tensor of shape (R, 1, ...) that contains uncertainty scores with
+            the most uncertain locations having the highest uncertainty score.
+    """
+    assert logits.shape[1] == 1
+    gt_class_logits = logits.clone()
+    return -(torch.abs(gt_class_logits))
+
+
+class SetCriterion(nn.Module):
+    """This class computes the loss for DETR.
+    The process happens in two steps:
+        1) we compute hungarian assignment between ground truth boxes and the outputs of the model
+        2) we supervise each pair of matched ground-truth / prediction (supervise class and box)
+    """
+
+    def __init__(self,
+                 num_classes,
+                 matcher,
+                 class_weight=4.0,
+                 box_weight=5.0,
+                 giou_weight=2.0,
+                 mask_weight=5.0,
+                 dice_weight=5.0,
+                 dn='seg',
+                 dec_layers=9,
+                 box_loss=True,
+                 eos_coef=0.1,
+                 num_points=100,
+                 oversample_ratio=3.0,
+                 importance_sample_ratio=0.75,
+                 semantic_ce_loss=False,
+                 panoptic_on=False,
+                 two_stage=True,
+                 deep_supervision=True):
+        """Create the criterion.
+        Parameters:
+            num_classes: number of object categories, omitting the special no-object category
+            matcher: module able to compute a matching between targets and proposals
+            weight_dict: dict containing as key the names of the losses and as values their relative weight.
+            eos_coef: relative classification weight applied to the no-object category
+            losses: list of all the losses to be applied. See get_loss for list of available losses.
+        """
+        super().__init__()
+        self.num_classes = num_classes
+        self.matcher = HungarianMatcher(**matcher, panoptic_on=panoptic_on)
+
+        weight_dict, losses, dn_losses = _process_criterion_info(
+            class_weight, mask_weight, dice_weight,
+            box_weight, giou_weight,
+            dn=dn, dec_layers=dec_layers, box_loss=box_loss,
+            two_stage=two_stage, deep_supervision=deep_supervision)
+
+        self.weight_dict = weight_dict
+        self.eos_coef = eos_coef
+        self.losses = losses
+        self.dn=dn
+        self.dn_losses=dn_losses
+        empty_weight = torch.ones(self.num_classes + 1)
+        empty_weight[-1] = self.eos_coef
+        self.register_buffer("empty_weight", empty_weight)
+
+        # pointwise mask loss parameters
+        self.num_points = num_points
+        self.oversample_ratio = oversample_ratio
+        self.importance_sample_ratio = importance_sample_ratio
+        self.focal_alpha = 0.25
+
+        self.panoptic_on = panoptic_on
+        self.semantic_ce_loss = semantic_ce_loss
+
+    def loss_labels_ce(self, outputs, targets, indices, num_masks):
+        """Classification loss (NLL)
+        targets dicts must contain the key "labels" containing a tensor of dim [nb_target_boxes]
+        """
+        assert "pred_logits" in outputs
+        src_logits = outputs["pred_logits"].float()
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat([t["labels"][J] for t, (_, J) in zip(targets, indices)])
+        target_classes = torch.full(
+            src_logits.shape[:2], self.num_classes, dtype=torch.int64, device=src_logits.device
+        )
+        target_classes[idx] = target_classes_o
+
+        loss_ce = F.cross_entropy(src_logits.transpose(1, 2), target_classes, self.empty_weight)
+        losses = {"loss_ce": loss_ce}
+        return losses
+
+    def loss_labels(self, outputs, targets, indices, num_boxes, log=True):
+        """Classification loss (Binary focal loss)
+        targets dicts must contain the key "labels" containing a tensor of dim [nb_target_boxes]
+        """
+        assert 'pred_logits' in outputs
+        src_logits = outputs['pred_logits']
+
+        idx = self._get_src_permutation_idx(indices)
+        target_classes_o = torch.cat([t["labels"][J] for t, (_, J) in zip(targets, indices)])
+        target_classes = torch.full(src_logits.shape[:2], self.num_classes,
+                                    dtype=torch.int64, device=src_logits.device)
+        target_classes[idx] = target_classes_o
+
+        target_classes_onehot = torch.zeros([src_logits.shape[0], src_logits.shape[1], src_logits.shape[2]+1],
+                                            dtype=src_logits.dtype, layout=src_logits.layout, device=src_logits.device)
+        target_classes_onehot.scatter_(2, target_classes.unsqueeze(-1), 1)
+
+        target_classes_onehot = target_classes_onehot[:,:,:-1]
+        loss_ce = sigmoid_focal_loss(src_logits, target_classes_onehot, num_boxes, alpha=self.focal_alpha, gamma=2) * src_logits.shape[1]
+        losses = {'loss_ce': loss_ce}
+
+        return losses
+
+    def loss_boxes(self, outputs, targets, indices, num_boxes):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
+           targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
+           The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
+        """
+        assert 'pred_boxes' in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs['pred_boxes'][idx]
+        target_boxes = torch.cat([t['boxes'][i] for t, (_, i) in zip(targets, indices)], dim=0)
+
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction='none')
+        losses = {}
+        losses['loss_bbox'] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(generalized_box_iou(
+            bbox_cxcywh_to_xyxy(src_boxes),
+            bbox_cxcywh_to_xyxy(target_boxes)))
+        losses['loss_giou'] = loss_giou.sum() / num_boxes
+
+        return losses
+
+    def loss_boxes_panoptic(self, outputs, targets, indices, num_boxes):
+        """Compute the losses related to the bounding boxes, the L1 regression loss and the GIoU loss
+           targets dicts must contain the key "boxes" containing a tensor of dim [nb_target_boxes, 4]
+           The target boxes are expected in format (center_x, center_y, w, h), normalized by the image size.
+        """
+        assert 'pred_boxes' in outputs
+        idx = self._get_src_permutation_idx(indices)
+        src_boxes = outputs['pred_boxes'][idx]
+        target_boxes = torch.cat([t['boxes'][i] for t, (_, i) in zip(targets, indices)], dim=0)
+        target_labels = torch.cat([t['labels'][i] for t, (_, i) in zip(targets, indices)], dim=0)
+        isthing=target_labels<80
+        target_boxes=target_boxes[isthing]
+        src_boxes=src_boxes[isthing]
+
+        loss_bbox = F.l1_loss(src_boxes, target_boxes, reduction='none')
+        losses = {}
+        losses['loss_bbox'] = loss_bbox.sum() / num_boxes
+
+        loss_giou = 1 - torch.diag(generalized_box_iou(
+            bbox_cxcywh_to_xyxy(src_boxes),
+            bbox_cxcywh_to_xyxy(target_boxes)))
+        losses['loss_giou'] = loss_giou.sum() / num_boxes
+
+        return losses
+
+    def loss_masks(self, outputs, targets, indices, num_masks):
+        """Compute the losses related to the masks: the focal loss and the dice loss.
+        targets dicts must contain the key "masks" containing a tensor of dim [nb_target_boxes, h, w]
+        """
+        assert "pred_masks" in outputs
+
+        src_idx = self._get_src_permutation_idx(indices)
+        tgt_idx = self._get_tgt_permutation_idx(indices)
+        src_masks = outputs["pred_masks"]
+        src_masks = src_masks[src_idx]
+        masks = [t["masks"] for t in targets]
+        # TODO use valid to mask invalid areas due to padding in loss
+        target_masks, valid = nested_tensor_from_tensor_list(masks).decompose()
+        target_masks = target_masks.to(src_masks)
+        target_masks = target_masks[tgt_idx]
+
+        # No need to upsample predictions as we are using normalized coordinates :)
+        # N x 1 x H x W
+        src_masks = src_masks[:, None]
+        target_masks = target_masks[:, None]
+
+        with torch.no_grad():
+            # sample point_coords
+            point_coords = get_uncertain_point_coords_with_randomness(
+                src_masks,
+                lambda logits: calculate_uncertainty(logits),
+                self.num_points,
+                self.oversample_ratio,
+                self.importance_sample_ratio,
+            )
+            # get gt labels
+            point_labels = point_sample(
+                target_masks,
+                point_coords,
+                align_corners=False,
+            ).squeeze(1)
+
+        point_logits = point_sample(
+            src_masks,
+            point_coords,
+            align_corners=False,
+        ).squeeze(1)
+
+        losses = {
+            "loss_mask": sigmoid_ce_loss_jit(point_logits, point_labels, num_masks),
+            "loss_dice": dice_loss_jit(point_logits, point_labels, num_masks),
+        }
+
+        del src_masks
+        del target_masks
+        return losses
+
+    def prep_for_dn(self,mask_dict):
+        output_known_lbs_bboxes = mask_dict['output_known_lbs_bboxes']
+
+        known_indice = mask_dict['known_indice']
+        scalar,pad_size=mask_dict['scalar'],mask_dict['pad_size']
+        assert pad_size % scalar==0
+        single_pad=pad_size//scalar
+
+        num_tgt = known_indice.numel()
+        return output_known_lbs_bboxes,num_tgt,single_pad,scalar
+
+    def _get_src_permutation_idx(self, indices):
+        # permute predictions following indices
+        batch_idx = torch.cat([torch.full_like(src, i) for i, (src, _) in enumerate(indices)])
+        src_idx = torch.cat([src for (src, _) in indices])
+        return batch_idx, src_idx
+
+    def _get_tgt_permutation_idx(self, indices):
+        # permute targets following indices
+        batch_idx = torch.cat([torch.full_like(tgt, i) for i, (_, tgt) in enumerate(indices)])
+        tgt_idx = torch.cat([tgt for (_, tgt) in indices])
+        return batch_idx, tgt_idx
+
+    def get_loss(self, loss, outputs, targets, indices, num_masks):
+        loss_map = {
+            'labels': self.loss_labels_ce if self.semantic_ce_loss else self.loss_labels,
+            'masks': self.loss_masks,
+            'boxes': self.loss_boxes_panoptic if self.panoptic_on else self.loss_boxes,
+        }
+        assert loss in loss_map, f"do you really want to compute {loss} loss?"
+        return loss_map[loss](outputs, targets, indices, num_masks)
+
+    def forward(self, outputs, targets, mask_dict=None):
+        """This performs the loss computation.
+        Parameters:
+             outputs: dict of tensors, see the output specification of the model for the format
+             targets: list of dicts, such that len(targets) == batch_size.
+                      The expected keys in each dict depends on the losses applied, see each loss' doc
+        """
+        outputs_without_aux = {k: v for k, v in outputs.items() if k != "aux_outputs"}
+
+        # Retrieve the matching between the outputs of the last layer and the targets
+        if self.dn is not "no" and mask_dict is not None:
+            output_known_lbs_bboxes,num_tgt,single_pad,scalar = self.prep_for_dn(mask_dict)
+            exc_idx = []
+            for i in range(len(targets)):
+                if len(targets[i]['labels']) > 0:
+                    t = torch.arange(0, len(targets[i]['labels'])).long().cuda()
+                    t = t.unsqueeze(0).repeat(scalar, 1)
+                    tgt_idx = t.flatten()
+                    output_idx = (torch.tensor(range(scalar)) * single_pad).long().cuda().unsqueeze(1) + t
+                    output_idx = output_idx.flatten()
+                else:
+                    output_idx = tgt_idx = torch.tensor([]).long().cuda()
+                exc_idx.append((output_idx, tgt_idx))
+        indices = self.matcher(outputs_without_aux, targets)
+        # Compute the average number of target boxes accross all nodes, for normalization purposes
+        num_masks = sum(len(t["labels"]) for t in targets)
+        num_masks = torch.as_tensor(
+            [num_masks], dtype=torch.float, device=next(iter(outputs.values())).device
+        )
+        if is_dist_avail_and_initialized():
+            torch.distributed.all_reduce(num_masks)
+        num_masks = torch.clamp(num_masks / get_world_size(), min=1).item()
+
+        # Compute all the requested losses
+        losses = {}
+        for loss in self.losses:
+            losses.update(self.get_loss(loss, outputs, targets, indices, num_masks))
+
+        if self.dn != "no" and mask_dict is not None:
+            l_dict={}
+            for loss in self.dn_losses:
+                l_dict.update(self.get_loss(loss, output_known_lbs_bboxes, targets, exc_idx, num_masks*scalar))
+            l_dict = {k + f'_dn': v for k, v in l_dict.items()}
+            losses.update(l_dict)
+        elif self.dn != "no":
+            l_dict = dict()
+            l_dict['loss_bbox_dn'] = torch.as_tensor(0.).to('cuda')
+            l_dict['loss_giou_dn'] = torch.as_tensor(0.).to('cuda')
+            l_dict['loss_ce_dn'] = torch.as_tensor(0.).to('cuda')
+            if self.dn == "seg":
+                l_dict['loss_mask_dn'] = torch.as_tensor(0.).to('cuda')
+                l_dict['loss_dice_dn'] = torch.as_tensor(0.).to('cuda')
+            losses.update(l_dict)
+
+        # In case of auxiliary losses, we repeat this process with the output of each intermediate layer.
+        if "aux_outputs" in outputs:
+            for i, aux_outputs in enumerate(outputs["aux_outputs"]):
+                indices = self.matcher(aux_outputs, targets)
+                for loss in self.losses:
+                    l_dict = self.get_loss(loss, aux_outputs, targets, indices, num_masks)
+                    l_dict = {k + f"_{i}": v for k, v in l_dict.items()}
+                    losses.update(l_dict)
+                if 'interm_outputs' in outputs:
+                    start = 0
+                else:
+                    start = 1
+                if i>=start:
+                    if self.dn != "no" and mask_dict is not None:
+                        out_=output_known_lbs_bboxes['aux_outputs'][i]
+                        l_dict = {}
+                        for loss in self.dn_losses:
+                            l_dict.update(
+                                self.get_loss(loss, out_, targets, exc_idx, num_masks * scalar))
+                        l_dict = {k + f'_dn_{i}': v for k, v in l_dict.items()}
+                        losses.update(l_dict)
+                    elif self.dn != "no":
+                        l_dict = dict()
+                        l_dict[f'loss_bbox_dn_{i}'] = torch.as_tensor(0.).to('cuda')
+                        l_dict[f'loss_giou_dn_{i}'] = torch.as_tensor(0.).to('cuda')
+                        l_dict[f'loss_ce_dn_{i}'] = torch.as_tensor(0.).to('cuda')
+                        if self.dn == "seg":
+                            l_dict[f'loss_mask_dn_{i}'] = torch.as_tensor(0.).to('cuda')
+                            l_dict[f'loss_dice_dn_{i}'] = torch.as_tensor(0.).to('cuda')
+                        losses.update(l_dict)
+        # interm_outputs loss
+        if 'interm_outputs' in outputs:
+            interm_outputs = outputs['interm_outputs']
+            indices = self.matcher(interm_outputs, targets)
+            for loss in self.losses:
+                l_dict = self.get_loss(loss, interm_outputs, targets, indices, num_masks)
+                l_dict = {k + f'_interm': v for k, v in l_dict.items()}
+                losses.update(l_dict)
+
+        return losses
+
+    def __repr__(self):
+        head = "Criterion " + self.__class__.__name__
+        body = [
+            "matcher: {}".format(self.matcher.__repr__(_repr_indent=8)),
+            "losses: {}".format(self.losses),
+            "weight_dict: {}".format(self.weight_dict),
+            "num_classes: {}".format(self.num_classes),
+            "eos_coef: {}".format(self.eos_coef),
+            "num_points: {}".format(self.num_points),
+            "oversample_ratio: {}".format(self.oversample_ratio),
+            "importance_sample_ratio: {}".format(self.importance_sample_ratio),
+        ]
+        _repr_indent = 4
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)
+
+
+def get_uncertain_point_coords_with_randomness(
+    coarse_logits, uncertainty_func, num_points, oversample_ratio, importance_sample_ratio
+):
+    """
+    Sample points in [0, 1] x [0, 1] coordinate space based on their uncertainty. The unceratinties
+        are calculated for each point using 'uncertainty_func' function that takes point's logit
+        prediction as input.
+    See PointRend paper for details.
+
+    Args:
+        coarse_logits (Tensor): A tensor of shape (N, C, Hmask, Wmask) or (N, 1, Hmask, Wmask) for
+            class-specific or class-agnostic prediction.
+        uncertainty_func: A function that takes a Tensor of shape (N, C, P) or (N, 1, P) that
+            contains logit predictions for P points and returns their uncertainties as a Tensor of
+            shape (N, 1, P).
+        num_points (int): The number of points P to sample.
+        oversample_ratio (int): Oversampling parameter.
+        importance_sample_ratio (float): Ratio of points that are sampled via importnace sampling.
+
+    Returns:
+        point_coords (Tensor): A tensor of shape (N, P, 2) that contains the coordinates of P
+            sampled points.
+    """
+    assert oversample_ratio >= 1
+    assert importance_sample_ratio <= 1 and importance_sample_ratio >= 0
+    num_boxes = coarse_logits.shape[0]
+    num_sampled = int(num_points * oversample_ratio)
+    point_coords = torch.rand(num_boxes, num_sampled, 2, device=coarse_logits.device)
+    point_logits = point_sample(coarse_logits, point_coords, align_corners=False)
+    # It is crucial to calculate uncertainty based on the sampled prediction value for the points.
+    # Calculating uncertainties of the coarse predictions first and sampling them for points leads
+    # to incorrect results.
+    # To illustrate this: assume uncertainty_func(logits)=-abs(logits), a sampled point between
+    # two coarse predictions with -1 and 1 logits has 0 logits, and therefore 0 uncertainty value.
+    # However, if we calculate uncertainties for the coarse predictions first,
+    # both will have -1 uncertainty, and the sampled point will get -1 uncertainty.
+    point_uncertainties = uncertainty_func(point_logits)
+    num_uncertain_points = int(importance_sample_ratio * num_points)
+    num_random_points = num_points - num_uncertain_points
+    idx = torch.topk(point_uncertainties[:, 0, :], k=num_uncertain_points, dim=1)[1]
+    shift = num_sampled * torch.arange(num_boxes, dtype=torch.long, device=coarse_logits.device)
+    idx += shift[:, None]
+    point_coords = point_coords.view(-1, 2)[idx.view(-1), :].view(
+        num_boxes, num_uncertain_points, 2
+    )
+    if num_random_points > 0:
+        point_coords = cat(
+            [
+                point_coords,
+                torch.rand(num_boxes, num_random_points, 2, device=coarse_logits.device),
+            ],
+            dim=1,
+        )
+    return point_coords
+
+
+def cat(tensors: List[torch.Tensor], dim: int = 0):
+    """
+    Efficient version of torch.cat that avoids a copy if there is only a single element in a list
+    """
+    assert isinstance(tensors, (list, tuple))
+    if len(tensors) == 1:
+        return tensors[0]
+    return torch.cat(tensors, dim)
+
+
+def _process_criterion_info(class_weight, mask_weight, dice_weight,
+                            box_weight, giou_weight, dn, dec_layers, box_loss,
+                            two_stage=True, deep_supervision=True):
+    weight_dict = {"loss_ce": class_weight}
+    weight_dict.update({"loss_mask": mask_weight, "loss_dice": dice_weight})
+    weight_dict.update({"loss_bbox": box_weight, "loss_giou": giou_weight})
+    # two stage is the query selection scheme
+    if two_stage:
+        interm_weight_dict = {}
+        interm_weight_dict.update(
+            {k + f'_interm': v for k, v in weight_dict.items()})
+        weight_dict.update(interm_weight_dict)
+    # denoising training
+    if dn == "standard":
+        weight_dict.update({k + f"_dn": v for k, v in weight_dict.items() if
+                            k != "loss_mask" and k != "loss_dice"})
+        dn_losses = ["labels", "boxes"]
+    elif dn == "seg":
+        weight_dict.update({k + f"_dn": v for k, v in weight_dict.items()})
+        dn_losses = ["labels", "masks", "boxes"]
+    else:
+        dn_losses = []
+    if deep_supervision:
+        aux_weight_dict = {}
+        for i in range(dec_layers):
+            aux_weight_dict.update(
+                {k + f"_{i}": v for k, v in weight_dict.items()})
+        weight_dict.update(aux_weight_dict)
+    if box_loss:
+        losses = ["labels", "masks", "boxes"]
+    else:
+        losses = ["labels", "masks"]
+    return weight_dict, losses, dn_losses

--- a/mmdet/models/losses/matcher.py
+++ b/mmdet/models/losses/matcher.py
@@ -1,0 +1,231 @@
+# ------------------------------------------------------------------------
+# DINO
+# Copyright (c) 2022 IDEA. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 [see LICENSE for details]
+# ------------------------------------------------------------------------
+# Modified from DINO https://github.com/IDEA-Research/DINO by Feng Li and Hao Zhang.
+
+"""
+Modules to compute the matching cost and solve the corresponding LSAP.
+"""
+import torch
+import torch.nn.functional as F
+from scipy.optimize import linear_sum_assignment
+from torch import nn
+from torch.cuda.amp import autocast
+from torchvision.ops import generalized_box_iou
+
+from mmcv.ops import point_sample
+from mmdet.structures.bbox import bbox_cxcywh_to_xyxy, bbox_xyxy_to_cxcywh
+
+
+def batch_dice_loss(inputs: torch.Tensor, targets: torch.Tensor):
+    """
+    Compute the DICE loss, similar to generalized IOU for masks
+    Args:
+        inputs: A float tensor of arbitrary shape.
+                The predictions for each example.
+        targets: A float tensor with the same shape as inputs. Stores the binary
+                 classification label for each element in inputs
+                (0 for the negative class and 1 for the positive class).
+    """
+    inputs = inputs.sigmoid()
+    inputs = inputs.flatten(1)
+    numerator = 2 * torch.einsum("nc,mc->nm", inputs, targets)
+    denominator = inputs.sum(-1)[:, None] + targets.sum(-1)[None, :]
+    loss = 1 - (numerator + 1) / (denominator + 1)
+    return loss
+
+
+batch_dice_loss_jit = torch.jit.script(
+    batch_dice_loss
+)  # type: torch.jit.ScriptModule
+
+
+def batch_sigmoid_ce_loss(inputs: torch.Tensor, targets: torch.Tensor):
+    """
+    Args:
+        inputs: A float tensor of arbitrary shape.
+                The predictions for each example.
+        targets: A float tensor with the same shape as inputs. Stores the binary
+                 classification label for each element in inputs
+                (0 for the negative class and 1 for the positive class).
+    Returns:
+        Loss tensor
+    """
+    hw = inputs.shape[1]
+
+    pos = F.binary_cross_entropy_with_logits(
+        inputs, torch.ones_like(inputs), reduction="none"
+    )
+    neg = F.binary_cross_entropy_with_logits(
+        inputs, torch.zeros_like(inputs), reduction="none"
+    )
+
+    loss = torch.einsum("nc,mc->nm", pos, targets) + torch.einsum(
+        "nc,mc->nm", neg, (1 - targets)
+    )
+
+    return loss / hw
+
+
+batch_sigmoid_ce_loss_jit = torch.jit.script(
+    batch_sigmoid_ce_loss
+)  # type: torch.jit.ScriptModule
+
+
+class HungarianMatcher(nn.Module):
+    """This class computes an assignment between the targets and the predictions of the network
+
+    For efficiency reasons, the targets don't include the no_object. Because of this, in general,
+    there are more predictions than targets. In this case, we do a 1-to-1 matching of the best predictions,
+    while the others are un-matched (and thus treated as non-objects).
+    """
+
+    def __init__(self, cost_class: float = 1, cost_mask: float = 1, cost_dice: float = 1, num_points: int = 0,
+                 cost_box: float = 0, cost_giou: float = 0, panoptic_on: bool = False):
+        """Creates the matcher
+
+        Params:
+            cost_class: This is the relative weight of the classification error in the matching cost
+            cost_mask: This is the relative weight of the focal loss of the binary mask in the matching cost
+            cost_dice: This is the relative weight of the dice loss of the binary mask in the matching cost
+        """
+        super().__init__()
+        self.cost_class = cost_class
+        self.cost_mask = cost_mask
+        self.cost_dice = cost_dice
+        self.cost_box = cost_box
+        self.cost_giou = cost_giou
+
+        self.panoptic_on = panoptic_on
+
+        assert cost_class != 0 or cost_mask != 0 or cost_dice != 0, "all costs cant be 0"
+
+        self.num_points = num_points
+
+    @torch.no_grad()
+    def memory_efficient_forward(self, outputs, targets, cost=["cls", "box", "mask"]):
+        """More memory-friendly matching. Change cost to compute only certain loss in matching"""
+        bs, num_queries = outputs["pred_logits"].shape[:2]
+
+        indices = []
+
+        # Iterate through batch size
+        for b in range(bs):
+            out_bbox = outputs["pred_boxes"][b]
+            if 'box' in cost:
+                tgt_bbox=targets[b]["boxes"]
+                cost_bbox = torch.cdist(out_bbox, tgt_bbox, p=1)
+                cost_giou = -generalized_box_iou(bbox_cxcywh_to_xyxy(out_bbox), bbox_cxcywh_to_xyxy(tgt_bbox))
+            else:
+                cost_bbox = torch.tensor(0).to(out_bbox)
+                cost_giou = torch.tensor(0).to(out_bbox)
+
+            out_prob = outputs["pred_logits"][b].sigmoid()  # [num_queries, num_classes]
+            tgt_ids = targets[b]["labels"]
+            # focal loss
+            alpha = 0.25
+            gamma = 2.0
+            neg_cost_class = (1 - alpha) * (out_prob ** gamma) * (-(1 - out_prob + 1e-8).log())
+            pos_cost_class = alpha * ((1 - out_prob) ** gamma) * (-(out_prob + 1e-8).log())
+            cost_class = pos_cost_class[:, tgt_ids] - neg_cost_class[:, tgt_ids]
+
+            # Compute the classification cost. Contrary to the loss, we don't use the NLL,
+            # but approximate it in 1 - proba[target class].
+            # The 1 is a constant that doesn't change the matching, it can be ommitted.
+            # cost_class = -out_prob[:, tgt_ids]
+            if 'mask' in cost:
+                out_mask = outputs["pred_masks"][b]  # [num_queries, H_pred, W_pred]
+                # gt masks are already padded when preparing target
+                tgt_mask = targets[b]["masks"].to(out_mask)
+
+                out_mask = out_mask[:, None]
+                tgt_mask = tgt_mask[:, None]
+                # all masks share the same set of points for efficient matching!
+                point_coords = torch.rand(1, self.num_points, 2, device=out_mask.device)
+                # get gt labels
+                tgt_mask = point_sample(
+                    tgt_mask,
+                    point_coords.repeat(tgt_mask.shape[0], 1, 1),
+                    align_corners=False,
+                ).squeeze(1)
+
+                out_mask = point_sample(
+                    out_mask,
+                    point_coords.repeat(out_mask.shape[0], 1, 1),
+                    align_corners=False,
+                ).squeeze(1)
+
+                with autocast(enabled=False):
+                    out_mask = out_mask.float()
+                    tgt_mask = tgt_mask.float()
+                    # If there's no annotations
+                    if out_mask.shape[0] == 0 or tgt_mask.shape[0] == 0:
+                        # Compute the focal loss between masks
+                        cost_mask = batch_sigmoid_ce_loss(out_mask, tgt_mask)
+                        # Compute the dice loss betwen masks
+                        cost_dice = batch_dice_loss(out_mask, tgt_mask)
+                    else:
+                        cost_mask = batch_sigmoid_ce_loss_jit(out_mask, tgt_mask)
+                        cost_dice = batch_dice_loss_jit(out_mask, tgt_mask)
+
+            else:
+                cost_mask = torch.tensor(0).to(out_bbox)
+                cost_dice = torch.tensor(0).to(out_bbox)
+            
+            # Final cost matrix
+            if self.panoptic_on:
+                isthing = tgt_ids<80
+                cost_bbox[:, ~isthing] = cost_bbox[:, isthing].mean()
+                cost_giou[:, ~isthing] = cost_giou[:, isthing].mean()
+                cost_bbox[cost_bbox.isnan()] = 0.0
+                cost_giou[cost_giou.isnan()] = 0.0
+
+            C = (
+                self.cost_mask * cost_mask
+                + self.cost_class * cost_class
+                + self.cost_dice * cost_dice
+                + self.cost_box*cost_bbox
+                + self.cost_giou*cost_giou
+            )
+            C = C.reshape(num_queries, -1).cpu()
+            indices.append(linear_sum_assignment(C))
+
+        return [
+            (torch.as_tensor(i, dtype=torch.int64), torch.as_tensor(j, dtype=torch.int64))
+            for i, j in indices
+        ]
+
+    @torch.no_grad()
+    def forward(self, outputs, targets, cost=["cls", "box", "mask"]):
+        """Performs the matching
+
+        Params:
+            outputs: This is a dict that contains at least these entries:
+                 "pred_logits": Tensor of dim [batch_size, num_queries, num_classes] with the classification logits
+                 "pred_masks": Tensor of dim [batch_size, num_queries, H_pred, W_pred] with the predicted masks
+
+            targets: This is a list of targets (len(targets) = batch_size), where each target is a dict containing:
+                 "labels": Tensor of dim [num_target_boxes] (where num_target_boxes is the number of ground-truth
+                           objects in the target) containing the class labels
+                 "masks": Tensor of dim [num_target_boxes, H_gt, W_gt] containing the target masks
+
+        Returns:
+            A list of size batch_size, containing tuples of (index_i, index_j) where:
+                - index_i is the indices of the selected predictions (in order)
+                - index_j is the indices of the corresponding selected targets (in order)
+            For each batch element, it holds:
+                len(index_i) = len(index_j) = min(num_queries, num_target_boxes)
+        """
+        return self.memory_efficient_forward(outputs, targets, cost)
+
+    def __repr__(self, _repr_indent=4):
+        head = "Matcher " + self.__class__.__name__
+        body = [
+            "cost_class: {}".format(self.cost_class),
+            "cost_mask: {}".format(self.cost_mask),
+            "cost_dice: {}".format(self.cost_dice),
+        ]
+        lines = [head] + [" " * _repr_indent + line for line in body]
+        return "\n".join(lines)

--- a/mmdet/models/losses/misc.py
+++ b/mmdet/models/losses/misc.py
@@ -1,0 +1,135 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# Modified by Bowen Cheng from https://github.com/facebookresearch/detr/blob/master/util/misc.py
+"""
+Misc functions, including distributed helpers.
+
+Mostly copy-paste from torchvision references.
+"""
+from typing import List, Optional
+
+import torch
+import torch.distributed as dist
+import torchvision
+from torch import Tensor
+
+
+def _max_by_axis(the_list):
+    # type: (List[List[int]]) -> List[int]
+    maxes = the_list[0]
+    for sublist in the_list[1:]:
+        for index, item in enumerate(sublist):
+            maxes[index] = max(maxes[index], item)
+    return maxes
+
+
+class NestedTensor(object):
+    def __init__(self, tensors, mask: Optional[Tensor]):
+        self.tensors = tensors
+        self.mask = mask
+
+    def to(self, device):
+        # type: (Device) -> NestedTensor # noqa
+        cast_tensor = self.tensors.to(device)
+        mask = self.mask
+        if mask is not None:
+            assert mask is not None
+            cast_mask = mask.to(device)
+        else:
+            cast_mask = None
+        return NestedTensor(cast_tensor, cast_mask)
+
+    def decompose(self):
+        return self.tensors, self.mask
+
+    def __repr__(self):
+        return str(self.tensors)
+
+
+def nested_tensor_from_tensor_list(tensor_list: List[Tensor]):
+    # TODO make this more general
+    if tensor_list[0].ndim == 3:
+        if torchvision._is_tracing():
+            # nested_tensor_from_tensor_list() does not export well to ONNX
+            # call _onnx_nested_tensor_from_tensor_list() instead
+            return _onnx_nested_tensor_from_tensor_list(tensor_list)
+
+        # TODO make it support different-sized images
+        max_size = _max_by_axis([list(img.shape) for img in tensor_list])
+        # min_size = tuple(min(s) for s in zip(*[img.shape for img in tensor_list]))
+        batch_shape = [len(tensor_list)] + max_size
+        b, c, h, w = batch_shape
+        dtype = tensor_list[0].dtype
+        device = tensor_list[0].device
+        tensor = torch.zeros(batch_shape, dtype=dtype, device=device)
+        mask = torch.ones((b, h, w), dtype=torch.bool, device=device)
+        for img, pad_img, m in zip(tensor_list, tensor, mask):
+            pad_img[: img.shape[0], : img.shape[1], : img.shape[2]].copy_(img)
+            m[: img.shape[1], : img.shape[2]] = False
+    else:
+        raise ValueError("not supported")
+    return NestedTensor(tensor, mask)
+
+
+# _onnx_nested_tensor_from_tensor_list() is an implementation of
+# nested_tensor_from_tensor_list() that is supported by ONNX tracing.
+@torch.jit.unused
+def _onnx_nested_tensor_from_tensor_list(tensor_list: List[Tensor]) -> NestedTensor:
+    max_size = []
+    for i in range(tensor_list[0].dim()):
+        max_size_i = torch.max(
+            torch.stack([img.shape[i] for img in tensor_list]).to(torch.float32)
+        ).to(torch.int64)
+        max_size.append(max_size_i)
+    max_size = tuple(max_size)
+
+    # work around for
+    # pad_img[: img.shape[0], : img.shape[1], : img.shape[2]].copy_(img)
+    # m[: img.shape[1], :img.shape[2]] = False
+    # which is not yet supported in onnx
+    padded_imgs = []
+    padded_masks = []
+    for img in tensor_list:
+        padding = [(s1 - s2) for s1, s2 in zip(max_size, tuple(img.shape))]
+        padded_img = torch.nn.functional.pad(img, (0, padding[2], 0, padding[1], 0, padding[0]))
+        padded_imgs.append(padded_img)
+
+        m = torch.zeros_like(img[0], dtype=torch.int, device=img.device)
+        padded_mask = torch.nn.functional.pad(m, (0, padding[2], 0, padding[1]), "constant", 1)
+        padded_masks.append(padded_mask.to(torch.bool))
+
+    tensor = torch.stack(padded_imgs)
+    mask = torch.stack(padded_masks)
+
+    return NestedTensor(tensor, mask=mask)
+
+
+def is_dist_avail_and_initialized():
+    if not dist.is_available():
+        return False
+    if not dist.is_initialized():
+        return False
+    return True
+
+def masks_to_boxes(masks):
+    """Compute the bounding boxes around the provided masks
+    The masks should be in format [N, H, W] where N is the number of masks, (H, W) are the spatial dimensions.
+    Returns a [N, 4] tensors, with the boxes in xyxy format
+    """
+    if masks.numel() == 0:
+        return torch.zeros((0, 4), device=masks.device)
+
+    h, w = masks.shape[-2:]
+
+    y = torch.arange(0, h, dtype=torch.float)
+    x = torch.arange(0, w, dtype=torch.float)
+    y, x = torch.meshgrid(y, x)
+
+    x_mask = masks * x.unsqueeze(0)
+    x_max = x_mask.flatten(1).max(-1)[0]
+    x_min = x_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
+
+    y_mask = masks * y.unsqueeze(0)
+    y_max = y_mask.flatten(1).max(-1)[0]
+    y_min = y_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
+
+    return torch.stack([x_min, y_min, x_max, y_max], 1)

--- a/mmdet/models/seg_heads/panoptic_fusion_heads/__init__.py
+++ b/mmdet/models/seg_heads/panoptic_fusion_heads/__init__.py
@@ -3,3 +3,4 @@ from .base_panoptic_fusion_head import \
     BasePanopticFusionHead  # noqa: F401,F403
 from .heuristic_fusion_head import HeuristicFusionHead  # noqa: F401,F403
 from .maskformer_fusion_head import MaskFormerFusionHead  # noqa: F401,F403
+from .maskdino_fusion_head import MaskDINOFusionHead

--- a/mmdet/models/seg_heads/panoptic_fusion_heads/maskdino_fusion_head.py
+++ b/mmdet/models/seg_heads/panoptic_fusion_heads/maskdino_fusion_head.py
@@ -1,0 +1,282 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+from mmengine.structures import InstanceData, PixelData
+from torch import Tensor
+
+from mmdet.evaluation.functional import INSTANCE_OFFSET
+from mmdet.registry import MODELS
+from mmdet.structures import SampleList
+from mmdet.structures.bbox import bbox_cxcywh_to_xyxy
+from mmdet.structures.mask import mask2bbox
+from mmdet.utils import OptConfigType, OptMultiConfig
+from mmdet.models.seg_heads.panoptic_fusion_heads import MaskFormerFusionHead
+from mmdet.utils.memory import AvoidCUDAOOM
+
+
+@MODELS.register_module()
+class MaskDINOFusionHead(MaskFormerFusionHead):
+    """MaskDINO fusion head which postprocesses results for panoptic
+    segmentation, instance segmentation and semantic segmentation."""
+
+    def __init__(self,
+                 num_things_classes: int = 80,
+                 num_stuff_classes: int = 53,
+                 test_cfg: OptConfigType = None,
+                 loss_panoptic: OptConfigType = None,
+                 init_cfg: OptMultiConfig = None,
+                 **kwargs):
+        super().__init__(
+            num_things_classes=num_things_classes,
+            num_stuff_classes=num_stuff_classes,
+            test_cfg=test_cfg,
+            loss_panoptic=loss_panoptic,
+            init_cfg=init_cfg,
+            **kwargs)
+        self.semantic_ce_loss=False # TODO 
+
+    def predict(self,
+                mask_cls_results: Tensor,
+                mask_pred_results: Tensor,
+                mask_box_results: Tensor,
+                batch_data_samples: SampleList,
+                rescale: bool = False,
+                **kwargs) -> List[dict]:
+        """ segment without test-time aumengtation.
+        """
+        batch_img_metas = [
+            data_sample.metainfo for data_sample in batch_data_samples
+        ]
+        panoptic_on = self.test_cfg.get('panoptic_on', True)
+        semantic_on = self.test_cfg.get('semantic_on', False)
+        instance_on = self.test_cfg.get('instance_on', False)
+
+        batch_input_shape = batch_data_samples[0].metainfo['batch_input_shape']
+        # upsample masks
+        mask_pred_results = F.interpolate(
+            mask_pred_results,
+            size=(batch_input_shape[-2], batch_input_shape[-1]),
+            mode="bilinear",
+            align_corners=False,
+        )
+
+        results = []
+        for mask_cls_result, mask_pred_result, mask_box_result, meta in zip(
+                mask_cls_results, mask_pred_results, mask_box_results, batch_img_metas):
+            # shape of image before pipeline
+            ori_height, ori_width = meta['ori_shape'][:2]
+            # shape of image after pipeline and before padding divisibly
+            img_height, img_width = meta['img_shape'][:2]
+
+            # remove padding
+            mask_pred_result = mask_pred_result[:, :img_height, :img_width]
+
+            if rescale:
+                # return result in original resolution
+                mask_pred_result = F.interpolate(
+                    mask_pred_result[:, None],
+                    size=(ori_height, ori_width),
+                    mode='bilinear',
+                    align_corners=False)[:, 0]
+
+            result = dict()
+            if panoptic_on:
+                result['pan_results'] = self.panoptic_postprocess(
+                    mask_cls_result, mask_pred_result)
+
+            if instance_on:
+                mask_box_result = bbox_cxcywh_to_xyxy(mask_box_result)
+                height_factor = batch_input_shape[0] / img_height * ori_height
+                width_factor = batch_input_shape[1] / img_width * ori_width
+                mask_box_result[:, 0::2] = mask_box_result[:, 0::2] * width_factor
+                mask_box_result[:, 1::2] = mask_box_result[:, 1::2] * height_factor
+                result['ins_results'] = self.instance_postprocess(
+                    mask_cls_result, mask_pred_result, mask_box_result)
+
+            if semantic_on:
+                result['sem_results'] = self.semantic_postprocess(
+                    mask_cls_result, mask_pred_result)
+
+            results.append(result)
+
+        return results
+    
+    @AvoidCUDAOOM.retry_if_cuda_oom
+    def semantic_postprocess(self, mask_cls: Tensor,
+                             mask_pred: Tensor) -> PixelData:
+        """Semantic segmengation postprocess.
+
+        Args:
+            mask_cls (Tensor): Classfication outputs of shape
+                (num_queries, cls_out_channels) for a image.
+                Note `cls_out_channels` should includes
+                background.
+            mask_pred (Tensor): Mask outputs of shape
+                (num_queries, h, w) for a image.
+
+        Returns:
+            :obj:`PixelData`: Semantic segment result.
+        """
+        # if use cross-entropy loss in training, evaluate with softmax
+        if self.semantic_ce_loss:
+            mask_cls = F.softmax(mask_cls, dim=-1)[..., :-1]
+            mask_pred = mask_pred.sigmoid()
+            semseg = torch.einsum("qc,qhw->chw", mask_cls, mask_pred)
+        # if use focal loss in training, evaluate with sigmoid. As sigmoid is mainly for detection and not sharp
+        # enough for semantic and panoptic segmentation, we additionally use use softmax with a temperature to
+        # make the score sharper.
+        else:
+            test_cfg = self.test_cfg.panoptic_postprocess_cfg
+            panoptic_temperature = test_cfg.get('panoptic_temperature', 0.06)
+            transform_eval = test_cfg.get('transform_eval', True)
+            mask_cls = mask_cls.sigmoid()
+            if transform_eval:
+                mask_cls = F.softmax(mask_cls / panoptic_temperature, dim=-1)  # already sigmoid
+            mask_pred = mask_pred.sigmoid()
+            semseg = torch.einsum("qc,qhw->chw", mask_cls, mask_pred)
+        
+        semseg = semseg.max(0)[1]
+        pred_sem_seg = PixelData(sem_seg=semseg[None])
+        return pred_sem_seg
+        
+    @AvoidCUDAOOM.retry_if_cuda_oom
+    def panoptic_postprocess(self, mask_cls: Tensor,
+                             mask_pred: Tensor) -> PixelData:
+        """Panoptic segmengation inference.
+
+        Args:
+            mask_cls (Tensor): Classfication outputs of shape
+                (num_queries, cls_out_channels) for a image.
+                Note `cls_out_channels` should includes
+                background.
+            mask_pred (Tensor): Mask outputs of shape
+                (num_queries, h, w) for a image.
+
+        Returns:
+            :obj:`PixelData`: Panoptic segment result of shape \
+                (h, w), each element in Tensor means: \
+                ``segment_id = _cls + instance_id * INSTANCE_OFFSET``.
+        """
+        test_cfg = self.test_cfg.panoptic_postprocess_cfg
+        object_mask_thr = test_cfg.get('object_mask_thr', 0.25)  # 0.8 for mask2former
+        iou_thr = test_cfg.get('iou_thr', 0.8)
+        filter_low_score = test_cfg.get('filter_low_score', False)
+        panoptic_temperature = test_cfg.get('panoptic_temperature', 0.06)  # TODO: difference
+        transform_eval = test_cfg.get('transform_eval', True)  # TODO: difference
+
+        # As we use focal loss in training, evaluate with sigmoid. As sigmoid is mainly for detection and not sharp
+        # enough for semantic and panoptic segmentation, we additionally use use softmax with a temperature to
+        # make the score sharper.  # TODO: difference
+        scores, labels = mask_cls.sigmoid().max(-1)  # TODO: difference
+        keep = labels.ne(self.num_classes) & (scores > object_mask_thr)
+
+        # added process
+        if transform_eval:  # TODO: difference
+            scores, labels = F.softmax(mask_cls.sigmoid() / panoptic_temperature, dim=-1).max(-1)
+        mask_pred = mask_pred.sigmoid()
+        cur_scores = scores[keep]
+        cur_classes = labels[keep]
+        cur_masks = mask_pred[keep]
+
+        cur_prob_masks = cur_scores.view(-1, 1, 1) * cur_masks  # TODO： ？
+
+        h, w = cur_masks.shape[-2:]
+        panoptic_seg = torch.full((h, w),
+                                  self.num_classes,
+                                  dtype=torch.int32,
+                                  device=cur_masks.device)
+        if cur_masks.shape[0] == 0:
+            # We didn't detect any mask :(
+            pass
+        else:
+            cur_mask_ids = cur_prob_masks.argmax(0)
+            instance_id = 1
+            for k in range(cur_classes.shape[0]):
+                pred_class = int(cur_classes[k].item())
+                isthing = pred_class < self.num_things_classes
+                mask = cur_mask_ids == k
+                mask_area = mask.sum().item()
+                original_area = (cur_masks[k] >= 0.5).sum().item()
+
+                if filter_low_score:
+                    mask = mask & (cur_masks[k] >= 0.5)  # TODO： ？
+
+                if mask_area > 0 and original_area > 0:
+                    if mask_area / original_area < iou_thr:  # TODO： ？
+                        continue
+
+                    if not isthing:
+                        # different stuff regions of same class will be
+                        # merged here, and stuff share the instance_id 0.
+                        panoptic_seg[mask] = pred_class
+                    else:
+                        panoptic_seg[mask] = (
+                            pred_class + instance_id * INSTANCE_OFFSET)
+                        instance_id += 1
+
+        return PixelData(sem_seg=panoptic_seg[None])
+
+    @AvoidCUDAOOM.retry_if_cuda_oom
+    def instance_postprocess(self, mask_cls: Tensor,
+                             mask_pred: Tensor, mask_box: Optional[Tensor]) -> InstanceData:
+        """Instance segmengation postprocess.
+
+        Args:
+            mask_cls (Tensor): Classfication outputs of shape
+                (num_queries, cls_out_channels) for a image.
+                Note `cls_out_channels` should includes
+                background.
+            mask_pred (Tensor): Mask outputs of shape
+                (num_queries, h, w) for a image.
+            mask_box (Tensor): TODO
+
+        Returns:
+            :obj:`InstanceData`: Instance segmentation results.
+
+                - scores (Tensor): Classification scores, has a shape
+                    (num_instance, )
+                - labels (Tensor): Labels of bboxes, has a shape
+                    (num_instances, ).
+                - bboxes (Tensor): Has a shape (num_instances, 4),
+                    the last dimension 4 arrange as (x1, y1, x2, y2).
+                - masks (Tensor): Has a shape (num_instances, H, W).
+        """
+        # TODO: merge into MaskFormerFusionHead
+        max_per_image = self.test_cfg.get('max_per_image', 100)
+        focus_on_box = self.test_cfg.get('focus_on_box', False)
+
+        num_queries = mask_cls.shape[0]
+        # shape (num_queries, num_class)
+        scores = mask_cls.sigmoid()  # TODO: modify MaskFormerFusionHead to add an arg use_sigmoid  # TODO: difference
+        scores_per_image, top_indices = scores.flatten(0, 1).topk(max_per_image, sorted=False)  # TODO：why ？
+        # shape (num_queries * num_class)
+        labels = torch.arange(self.num_classes, device=mask_cls.device).unsqueeze(0).repeat(num_queries, 1).flatten(0, 1)  # TODO：why ？
+        labels_per_image = labels[top_indices]
+
+        query_indices = top_indices // self.num_classes  # TODO：why ？
+        mask_pred = mask_pred[query_indices]
+        mask_box = mask_box[query_indices] if mask_box is not None else None  # TODO: difference
+
+        # extract things  # TODO： if self.panoptic_on ?
+        is_thing = labels_per_image < self.num_things_classes
+        scores_per_image = scores_per_image[is_thing]
+        labels_per_image = labels_per_image[is_thing]
+        mask_pred = mask_pred[is_thing]
+        mask_box = mask_box[is_thing] if mask_box is not None else None  # TODO: difference
+
+        mask_pred_binary = (mask_pred > 0).float()
+        mask_scores_per_image = (mask_pred.sigmoid() *
+                                 mask_pred_binary).flatten(1).sum(1) / (
+                                     mask_pred_binary.flatten(1).sum(1) + 1e-6)  # TODO：why ？
+        det_scores = scores_per_image * mask_scores_per_image  # TODO：why ？
+        mask_pred_binary = mask_pred_binary.bool()
+        bboxes = mask_box if mask_box is not None else mask2bbox(mask_pred_binary)  # TODO: difference
+
+        results = InstanceData()
+        results.bboxes = bboxes
+        results.labels = labels_per_image
+        results.scores = det_scores if not focus_on_box else 1.0
+        results.masks = mask_pred_binary
+        return results

--- a/tools/model_converters/maskdino_to_mmdet.py
+++ b/tools/model_converters/maskdino_to_mmdet.py
@@ -1,0 +1,125 @@
+# script of converting detr ckpt of mmdet-2.x to mmdet-3.x
+import json
+from pathlib import Path
+from typing import OrderedDict
+import torch
+from mmengine import Config, build_model_from_cfg
+from mmdet.registry import MODELS
+from mmdet.utils import register_all_modules
+
+register_all_modules()
+
+INDEX = 0
+
+
+def get_mapped_name(name: str):
+    new_name = name
+
+    if 'backbone' in new_name:
+        new_name = convert_backbone_keys(new_name)
+
+    elif 'sem_seg_head' in new_name:
+        new_name = new_name.replace('sem_seg_head', 'panoptic_head')
+        # bbox_embed
+        new_name = new_name.replace('decoder.bbox_embed', 'bbox_embed')
+        # transformer encoder
+        if 'transformer.encoder' in new_name:
+            new_name = new_name.replace('linear1', 'ffn.layers.0.0')
+            new_name = new_name.replace('linear2', 'ffn.layers.1')
+            new_name = new_name.replace('norm1', 'norms.0')
+            new_name = new_name.replace('norm2', 'norms.1')
+        # conv in pixel decoder
+        if ('pixel_decoder.adapter_1' in new_name
+                or 'pixel_decoder.layer_1' in new_name):
+            new_name = new_name.replace('norm', 'gn')
+            new_name = new_name.replace('_1.weight', '_1.conv.weight')
+
+    elif 'criterion' in new_name:
+        new_name = new_name.replace('criterion', 'panoptic_head.criterion')
+
+    return new_name
+
+
+def convert_backbone_keys(name: str):
+    if 'backbone.stem' in name:
+        name = name.replace('backbone.stem.conv1.weight', 'backbone.conv1.weight')
+        name = name.replace('backbone.stem.conv1.norm', 'backbone.bn1')
+    elif 'backbone.res' in name:
+        key_name_split = name.split('.')
+        # weight_type = key_name_split[-1]
+        res_id = int(key_name_split[1][-1]) - 1
+        # deal with short cut
+        if 'shortcut' in key_name_split[3]:
+            if 'shortcut' == key_name_split[-2]:
+                name = f'backbone.layer{res_id}.' \
+                       f'{key_name_split[2]}.downsample.0.' \
+                       f'{key_name_split[-1]}'
+            elif 'shortcut' == key_name_split[-3]:
+                name = f'backbone.layer{res_id}.' \
+                       f'{key_name_split[2]}.downsample.1.' \
+                       f'{key_name_split[-1]}'
+            else:
+                print(f'Unvalid key {k}')
+        # deal with conv
+        elif 'conv' in key_name_split[-2]:
+            conv_id = int(key_name_split[-2][-1])
+            name = f'backbone.layer{res_id}.{key_name_split[2]}' \
+                   f'.conv{conv_id}.{key_name_split[-1]}'
+        # deal with BN
+        elif key_name_split[-2] == 'norm':
+            conv_id = int(key_name_split[-3][-1])
+            name = f'backbone.layer{res_id}.{key_name_split[2]}.' \
+                   f'bn{conv_id}.{key_name_split[-1]}'
+        else:
+            print(f'{k} is invalid')
+    return name
+
+
+def mapping_state_dict(state_dict: OrderedDict) -> OrderedDict:
+    out = OrderedDict()
+    for name, param in state_dict.items():
+        new_name = get_mapped_name(name)
+        assert new_name not in out, f'{name}-->{new_name}'
+        out[new_name] = param
+    return out
+
+
+def preprocess_state_dict(state_dict: OrderedDict) -> OrderedDict:
+    out = delete_duplicated_items(state_dict)
+    return out
+
+
+def delete_duplicated_items(state_dict: OrderedDict) -> OrderedDict:
+    out = OrderedDict()
+    for name, param in state_dict.items():
+        if 'decoder_norm' in name:
+            continue
+        out[name] = param
+    return out
+
+
+if __name__ == '__main__':
+    cfg_3x = Path(['configs/maskdino/maskdino_r50_8xb2-lsj-50e_coco-panoptic.py',][INDEX])
+    ckpt_2x = Path(['../MaskDINO/maskdino_r50_50ep_300q_hid2048_3sd1_panoptic_pq53.0.pth',][INDEX])
+    save_path = str(ckpt_2x.parent) + f'/aligned_{ckpt_2x.name}'
+
+    cfg_3x = Config.fromfile(cfg_3x)
+    model_cfg = cfg_3x.model.copy()
+    model = build_model_from_cfg(model_cfg, MODELS)
+
+    sd_3x = model.state_dict()
+    ckpt_2x = torch.load(ckpt_2x)
+    sd_2x = ckpt_2x.pop('model')
+
+    # convert
+    sd_2x = preprocess_state_dict(sd_2x)
+    sd_2x = mapping_state_dict(sd_2x)
+    
+    # name_3x = sorted(list(sd_3x.keys()))
+    # name_2x = sorted(list(sd_2x.keys()))
+    # json.dump(name_3x, open(
+    #     r'./model_converters/names_1.json', 'w'), indent=0)
+    # json.dump(name_2x, open(
+    #     r'./model_converters/names_2.json', 'w'), indent=0)
+
+    torch.save(sd_2x, save_path)


### PR DESCRIPTION
From https://github.com/open-mmlab/mmdetection/pull/9808

Implement Mask DINO for panoptic segmentation:
paper: [Mask DINO: Towards A Unified Transformer-based Framework for Object Detection and Segmentation](https://arxiv.org/abs/2206.02777)
official repo: https://github.com/IDEA-Research/MaskDINO

# Milestones

- [x] Alignment with coco panoptic segmentation

`configs/maskdino/maskdino_r50_8xb2-lsj-50e_coco-panoptic.py`

```bash
python train_net.py --eval-only --num-gpus 8 --config-file configs/coco/panoptic-segmentation/maskdino_R50_bs16_50ep_3s_dowsample1_2048.yaml MODEL.WEIGHTS maskdino_r50_50ep_300q_hid2048_3sd1_panoptic_pq53.0.pth
```

repo | PQ | Mask AP | Box AP | mIoU
-- | -- | -- | -- | --
office | 53.0 | 48.9 | 44.4 | 60.6|
mmdet| 53.0 | 48.9 | 44.4 | 60.6|

```python
coco_panoptic/PQ: 52.9517  coco_panoptic/SQ: 83.6799  coco_panoptic/RQ: 62.5597  coco_panoptic/PQ_th: 58.9513  coco_panoptic/SQ_th: 84.9681  coco_panoptic/RQ_th: 69.0360  coco_panoptic/PQ_st: 43.8956  coco_panoptic/SQ_st: 81.7354  coco_panoptic/RQ_st: 52.7843  coco/bbox_mAP: 0.4890  coco/bbox_mAP_50: 0.6860  coco/bbox_mAP_75: 0.5330  coco/bbox_mAP_s: 0.3170  coco/bbox_mAP_m: 0.5190  coco/bbox_mAP_l: 0.6420  coco/segm_mAP: 0.4440  coco/segm_mAP_50: 0.6720  coco/segm_mAP_75: 0.4820  coco/segm_mAP_s: 0.2440  coco/segm_mAP_m: 0.4780  coco/segm_mAP_l: 0.6360  aAcc: 73.0700  mIoU: 60.5600  mAcc: 73.0700  data_time: 0.0053  time: 0.2139
```






