### PR TITLE
[Fix] Fix typo in mask-rcnn_r50_fpn_1x-wandb_coco

### DIFF
--- a/configs/mask_rcnn/mask-rcnn_r50_fpn_1x-wandb_coco.py
+++ b/configs/mask_rcnn/mask-rcnn_r50_fpn_1x-wandb_coco.py
@@ -4,7 +4,7 @@ _base_ = [
     '../_base_/schedules/schedule_1x.py', '../_base_/default_runtime.py'
 ]
 
-vis_backends = [dict(type='LocalVisBackend'), dict(type='WandBVisBackend')]
+vis_backends = [dict(type='LocalVisBackend'), dict(type='WandbVisBackend')]
 visualizer = dict(vis_backends=vis_backends)
 
 # MMEngine support the following two ways, users can choose


### PR DESCRIPTION
## Motivation

Fix the typo to make mmengine find `WandbVisBackend` correctly.

## Modification

`WandBVisBackend` --> `WandbVisBackend`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
