### PR TITLE
[Fix] fix the input variables of eval_recalls in voc_metric

### DIFF
--- a/mmdet/evaluation/metrics/voc_metric.py
+++ b/mmdet/evaluation/metrics/voc_metric.py
@@ -157,11 +157,11 @@ class VOCMetric(BaseMetric):
             eval_results['mAP'] = sum(mean_aps) / len(mean_aps)
             eval_results.move_to_end('mAP', last=False)
         elif self.metric == 'recall':
-            # TODO: Currently not checked.
-            gt_bboxes = [ann['bboxes'] for ann in self.annotations]
+            gt_bboxes = [gt['bboxes'] for gt in gts]
+            pr_bboxes = [pr[0] for pr in prs]
             recalls = eval_recalls(
                 gt_bboxes,
-                results,
+                pr_bboxes,
                 self.proposal_nums,
                 self.iou_thrs,
                 logger=logger,


### PR DESCRIPTION
## Motivation

When using `recall` in VOCMetric, `compute_metrics()` return error like this:

```
Traceback (most recent call last):
  File "tools/train.py", line 145, in <module>
    main()
  File "tools/train.py", line 141, in main
    runner.train()
  File "/usr/local/lib/python3.8/dist-packages/mmengine/runner/runner.py", line 1721, in train
    model = self.train_loop.run()  # type: ignore
  File "/usr/local/lib/python3.8/dist-packages/mmengine/runner/loops.py", line 102, in run
    self.runner.val_loop.run()
  File "/usr/local/lib/python3.8/dist-packages/mmengine/runner/loops.py", line 366, in run
    metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
  File "/usr/local/lib/python3.8/dist-packages/mmengine/evaluator/evaluator.py", line 79, in evaluate
    _results = metric.evaluate(size)
  File "/usr/local/lib/python3.8/dist-packages/mmengine/evaluator/metric.py", line 133, in evaluate
    _metrics = self.compute_metrics(results)  # type: ignore
  File "/workspace/mmdetection/mmdet/evaluation/metrics/voc_metric.py", line 235, in compute_metrics
    gt_bboxes = [ann['bboxes'] for ann in self.annotations]
AttributeError: 'VOCMetric' object has no attribute 'annotations'
```

## Modification

`annotations` is not defined in VOCMetric. And `eval_recalls()` should be provided with `gts` and `proposals` in the following format.

![image](https://github.com/gotjd709/mmdetection/assets/70703320/d7fd93f7-90eb-430e-9164-0eae5d817f69)

So, I currently fix it, by using lists of bboxes in `gts`, `preds` variable. When I conducted tests using binary class datasets, I successfully obtained recall values.

```
+------+-------+
|      | 0.5   |
+------+-------+
| 100  | 0.930 |
| 300  | 0.930 |
| 1000 | 0.930 |
+------+-------+                                                                                                        
```