### PR TITLE
Support AlignDETR 

### DIFF
--- a/mmdet/models/detectors/deformable_detr.py
+++ b/mmdet/models/detectors/deformable_detr.py
@@ -500,7 +500,7 @@ class DeformableDETR(DetectionTransformer):
             else:
                 if not isinstance(HW, torch.Tensor):
                     HW = memory.new_tensor(HW)
-                scale = HW.unsqueeze(0).flip(dims=[0, 1]).view(bs, 1, 1, 2)
+                scale = HW.unsqueeze(0).flip(dims=[0, 1]).view(1, 1, 1, 2)
             grid_y, grid_x = torch.meshgrid(
                 torch.linspace(
                     0, H - 1, H, dtype=torch.float32, device=memory.device),

--- a/projects/AlignDETR/README.md
+++ b/projects/AlignDETR/README.md
@@ -12,10 +12,10 @@ DETR has set up a simple end-to-end pipeline for object detection by formulating
 
 ## Results and Models
 
-| Backbone |    Model    | Lr schd | box AP |                       Config                       |                                                 Download                                                 |
-| :------: | :---------: | :-----: | :----: | :------------------------------------------------: | :------------------------------------------------------------------------------------------------------: |
-|   R-50   | DINO-4scale |   12e   |  50.3  | [config](./align_detr-4scale_r50_8xb2-12e_coco.py) | [model](https://download.openmmlab.com/mmdetection) \| [log](https://download.openmmlab.com/mmdetection) |
-|   R-50   | DINO-4scale |   24e   |  51.4  | [config](./align_detr-4scale_r50_8xb2-24e_coco.py) | [model](https://download.openmmlab.com/mmdetection) \| [log](https://download.openmmlab.com/mmdetection) |
+| Backbone |    Model    | Lr schd | box AP |                       Config                       |                                                                                                                                                                    Download                                                                                                                                                                    |
+| :------: | :---------: | :-----: | :----: | :------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+|   R-50   | DINO-4scale |   12e   |  50.5  | [config](./align_detr-4scale_r50_8xb2-12e_coco.py) | [model](https://download.openmmlab.com/mmdetection/v3.0/align_detr/align_detr-4scale_r50_8xb2-12e_coco/align_detr-4scale_r50_8xb2-12e_coco_20230914_095734-61f921af.pth) \| [log](https://download.openmmlab.com/mmdetection/v3.0/align_detr/align_detr-4scale_r50_8xb2-12e_coco/align_detr-4scale_r50_8xb2-12e_coco_20230914_095734.log.json) |
+|   R-50   | DINO-4scale |   24e   |  51.4  | [config](./align_detr-4scale_r50_8xb2-24e_coco.py) | [model](https://download.openmmlab.com/mmdetection/v3.0/align_detr/align_detr-4scale_r50_8xb2-24e_coco/align_detr-4scale_r50_8xb2-24e_coco_20230919_152414-f4b6cf76.pth) \| [log](https://download.openmmlab.com/mmdetection/v3.0/align_detr/align_detr-4scale_r50_8xb2-24e_coco/align_detr-4scale_r50_8xb2-24e_coco_20230919_152414.log.json) |
 
 ## Citation
 

--- a/projects/AlignDETR/README.md
+++ b/projects/AlignDETR/README.md
@@ -1,0 +1,33 @@
+# AlignDETR
+
+> [Align-DETR: Improving DETR with Simple IoU-aware BCE loss](https://arxiv.org/abs/2304.07527)
+
+<!-- [ALGORITHM] -->
+
+## Abstract
+
+DETR has set up a simple end-to-end pipeline for object detection by formulating this task as a set prediction problem, showing promising potential. However, despite the significant progress in improving DETR, this paper identifies a problem of misalignment in the output distribution, which prevents the best-regressed samples from being assigned with high confidence, hindering the model's accuracy. We propose a metric, recall of best-regressed samples, to quantitively evaluate the misalignment problem. Observing its importance, we propose a novel Align-DETR that incorporates a localization precision-aware classification loss in optimization. The proposed loss, IA-BCE, guides the training of DETR to build a strong correlation between classification score and localization precision. We also adopt the mixed-matching strategy, to facilitate DETR-based detectors with faster training convergence while keeping an end-to-end scheme. Moreover, to overcome the dramatic decrease in sample quality induced by the sparsity of queries, we introduce a prime sample weighting mechanism to suppress the interference of unimportant samples. Extensive experiments are conducted with very competitive results reported. In particular, it delivers a 46 (+3.8)% AP on the DAB-DETR baseline with the ResNet-50 backbone and reaches a new SOTA performance of 50.2% AP in the 1x setting on the COCO validation set when employing the strong baseline DINO.
+
+![image](https://github.com/open-mmlab/mmdetection/assets/33146359/5a4fa664-b4c6-487d-b6d8-22be9d59a2bc)
+
+## Results and Models
+
+| Backbone |    Model    | Lr schd | box AP |                       Config                       |                                                 Download                                                 |
+| :------: | :---------: | :-----: | :----: | :------------------------------------------------: | :------------------------------------------------------------------------------------------------------: |
+|   R-50   | DINO-4scale |   12e   |  50.3  | [config](./align_detr-4scale_r50_8xb2-12e_coco.py) | [model](https://download.openmmlab.com/mmdetection) \| [log](https://download.openmmlab.com/mmdetection) |
+|   R-50   | DINO-4scale |   24e   |  51.4  | [config](./align_detr-4scale_r50_8xb2-24e_coco.py) | [model](https://download.openmmlab.com/mmdetection) \| [log](https://download.openmmlab.com/mmdetection) |
+
+## Citation
+
+We provide the config files for AlignDETR: [Align-DETR: Improving DETR with Simple IoU-aware BCE loss](https://arxiv.org/abs/2304.07527).
+
+```latex
+@misc{cai2023aligndetr,
+      title={Align-DETR: Improving DETR with Simple IoU-aware BCE loss},
+      author={Zhi Cai and Songtao Liu and Guodong Wang and Zheng Ge and Xiangyu Zhang and Di Huang},
+      year={2023},
+      eprint={2304.07527},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV}
+}
+```

--- a/projects/AlignDETR/align_detr/__init__.py
+++ b/projects/AlignDETR/align_detr/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .align_detr_head import AlignDETRHead
+from .mixed_hungarian_assigner import MixedHungarianAssigner
+
+__all__ = ['AlignDETRHead', 'MixedHungarianAssigner']

--- a/projects/AlignDETR/align_detr/align_detr_head.py
+++ b/projects/AlignDETR/align_detr/align_detr_head.py
@@ -1,0 +1,508 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Any, Dict, List, Tuple, Union
+
+import torch
+from mmengine.structures import InstanceData
+from torch import Tensor
+
+from mmdet.models.dense_heads import DINOHead
+from mmdet.registry import MODELS
+from mmdet.structures.bbox import (bbox_cxcywh_to_xyxy, bbox_overlaps,
+                                   bbox_xyxy_to_cxcywh)
+from mmdet.utils import InstanceList
+from .utils import KeysRecorder
+
+
+@MODELS.register_module()
+class AlignDETRHead(DINOHead):
+    r"""Head of the Align-DETR: Improving DETR with Simple IoU-aware BCE loss
+
+    Code is modified from the `official github repo
+    <https://github.com/FelixCaae/AlignDETR>`_.
+
+    More details can be found in the `paper
+    <https://arxiv.org/abs/2304.07527>`_ .
+
+    Args:
+        all_layers_num_gt_repeat List[int]: Number to repeat gt for 1-to-k
+            matching between ground truth and predictions of each decoder
+            layer. Only used for matching queries, not for denoising queries.
+            Element count is `num_pred_layer`. If `as_two_stage` is True, then
+            the last element is for encoder output, and the others for
+            decoder layers. Otherwise, all elements are for decoder layers.
+            Defaults to a list of `1` for the last decoder layer and `2` for
+            the others.
+        alpha (float): Hyper-parameter of classification loss that controls
+            the proportion of each item to calculate `t`, the weighted
+            geometric average of the confident score and the IoU score, to
+            align classification and regression scores. Defaults to `0.25`.
+        gamma (float): Hyper-parameter of classification loss to do the hard
+            negative mining. Defaults to `2.0`.
+        tau (float): Hyper-parameter of classification and regression losses,
+            it is the temperature controlling the sharpness of the function
+            to calculate positive sample weight. Defaults to `1.5`.
+    """
+
+    def __init__(self,
+                 *args,
+                 all_layers_num_gt_repeat: List[int] = None,
+                 alpha: float = 0.25,
+                 gamma: float = 2.0,
+                 tau: float = 1.5,
+                 **kwargs) -> None:
+        self.all_layers_num_gt_repeat = all_layers_num_gt_repeat
+        self.alpha = alpha
+        self.gamma = gamma
+        self.tau = tau
+        self.weight_table = torch.zeros(
+            len(all_layers_num_gt_repeat), max(all_layers_num_gt_repeat))
+        for layer_index, num_gt_repeat in enumerate(all_layers_num_gt_repeat):
+            self.weight_table[layer_index][:num_gt_repeat] = torch.exp(
+                -torch.arange(num_gt_repeat) / tau)
+
+        super().__init__(*args, **kwargs)
+        assert len(self.all_layers_num_gt_repeat) == self.num_pred_layer
+
+    def loss_by_feat(self, all_layers_cls_scores: Tensor, *args,
+                     **kwargs) -> Any:
+        """Loss function.
+            AlignDETR: This method is based on `DINOHead.loss_by_feat`.
+
+        Args:
+            all_layers_cls_scores (Tensor): Classification scores of all
+                decoder layers, has shape (num_decoder_layers, bs,
+                num_queries_total, cls_out_channels), where
+                `num_queries_total` is the sum of `num_denoising_queries`
+                and `num_matching_queries`.
+        Returns:
+            dict[str, Tensor]: A dictionary of loss components.
+        """
+        # Wrap `all_layers_cls_scores` with KeysRecorder to record its
+        #   `__getitem__` keys and get decoder layer index.
+        all_layers_cls_scores = KeysRecorder(all_layers_cls_scores)
+        result = super(AlignDETRHead,
+                       self).loss_by_feat(all_layers_cls_scores, *args,
+                                          **kwargs)
+        return result
+
+    def loss_by_feat_single(self, cls_scores: Union[KeysRecorder, Tensor],
+                            bbox_preds: Tensor,
+                            batch_gt_instances: InstanceList,
+                            batch_img_metas: List[dict]) -> Tuple[Tensor]:
+        """Loss function for outputs from a single decoder layer of a single
+        feature level.
+            AlignDETR: This method is based on `DINOHead.loss_by_feat_single`.
+
+        Args:
+            cls_scores (Union[KeysRecorder, Tensor]): Box score logits from a
+                single decoder layer for all images, has shape (bs,
+                num_queries, cls_out_channels).
+            bbox_preds (Tensor): Sigmoid outputs from a single decoder layer
+                for all images, with normalized coordinate (cx, cy, w, h) and
+                shape (bs, num_queries, 4).
+            batch_gt_instances (list[:obj:`InstanceData`]): Batch of
+                gt_instance. It usually includes ``bboxes`` and ``labels``
+                attributes.
+            batch_img_metas (list[dict]): Meta information of each image, e.g.,
+                image size, scaling factor, etc.
+
+        Returns:
+            Tuple[Tensor]: A tuple including `loss_cls`, `loss_box` and
+            `loss_iou`.
+        """
+        # AlignDETR: Get layer_index.
+        if isinstance(cls_scores, KeysRecorder):
+            # Outputs are from decoder layer. Get layer_index from
+            #   `__getitem__` keys history.
+            keys = [key for key in cls_scores.keys if isinstance(key, int)]
+            assert len(keys) == 1, \
+                'Failed to extract key from cls_scores.keys: {}'.format(keys)
+            layer_index = keys[0]
+            # Get dn_cls_scores tensor.
+            cls_scores = cls_scores.obj
+        else:
+            # Outputs are from encoder layer.
+            layer_index = self.num_pred_layer - 1
+
+        for img_meta in batch_img_metas:
+            img_meta['layer_index'] = layer_index
+
+        results = super(AlignDETRHead, self).loss_by_feat_single(
+            cls_scores,
+            bbox_preds,
+            batch_gt_instances=batch_gt_instances,
+            batch_img_metas=batch_img_metas)
+        return results
+
+    def get_targets(self, cls_scores_list: List[Tensor],
+                    bbox_preds_list: List[Tensor],
+                    batch_gt_instances: InstanceList,
+                    batch_img_metas: List[dict]) -> tuple:
+        """Compute regression and classification targets for a batch image.
+
+        Outputs from a single decoder layer of a single feature level are used.
+        AlignDETR: This method is based on `DETRHead.get_targets`.
+
+        Args:
+            cls_scores_list (list[Tensor]): Box score logits from a single
+                decoder layer for each image, has shape [num_queries,
+                cls_out_channels].
+            bbox_preds_list (list[Tensor]): Sigmoid outputs from a single
+                decoder layer for each image, with normalized coordinate
+                (cx, cy, w, h) and shape [num_queries, 4].
+            batch_gt_instances (list[:obj:`InstanceData`]): Batch of
+                gt_instance. It usually includes ``bboxes`` and ``labels``
+                attributes.
+            batch_img_metas (list[dict]): Meta information of each image, e.g.,
+                image size, scaling factor, etc.
+
+        Returns:
+            tuple: a tuple containing the following targets.
+
+            - labels_list (list[Tensor]): Labels for all images.
+            - label_weights_list (list[Tensor]): Label weights for all images.
+            - bbox_targets_list (list[Tensor]): BBox targets for all images.
+            - bbox_weights_list (list[Tensor]): BBox weights for all images.
+            - num_total_pos (int): Number of positive samples in all images.
+            - num_total_neg (int): Number of negative samples in all images.
+        """
+        results = super(AlignDETRHead,
+                        self).get_targets(cls_scores_list, bbox_preds_list,
+                                          batch_gt_instances, batch_img_metas)
+
+        # AlignDETR: `num_total_pos` for matching queries is the number of
+        #   unique gt bboxes in the batch. Refer to AlignDETR official code:
+        #   https://github.com/FelixCaae/AlignDETR/blob/8c2b1806026e1b33fe1c282577de1647e352d7f0/aligndetr/criterions/base_criterion.py#L195C15-L195C15  # noqa: E501
+        num_total_pos = sum(
+            len(gt_instances) for gt_instances in batch_gt_instances)
+
+        results = list(results)
+        results[-2] = num_total_pos
+        return tuple(results)
+
+    def _get_targets_single(self, cls_score: Tensor, bbox_pred: Tensor,
+                            gt_instances: InstanceData,
+                            img_meta: dict) -> tuple:
+        """Compute regression and classification targets for one image.
+
+        Outputs from a single decoder layer of a single feature level are used.
+        AlignDETR: This method is based on `DETRHead._get_targets_single`.
+
+        Args:
+            cls_score (Tensor): Box score logits from a single decoder layer
+                for one image. Shape [num_queries, cls_out_channels].
+            bbox_pred (Tensor): Sigmoid outputs from a single decoder layer
+                for one image, with normalized coordinate (cx, cy, w, h) and
+                shape [num_queries, 4].
+            gt_instances (:obj:`InstanceData`): Ground truth of instance
+                annotations. It should includes ``bboxes`` and ``labels``
+                attributes.
+            img_meta (dict): Meta information for one image.
+            layer_index (int): Decoder layer index for the outputs. Defaults
+                to `-1`.
+
+        Returns:
+            tuple[Tensor]: a tuple containing the following for one image.
+
+            - labels (Tensor): Labels of each image.
+            - label_weights (Tensor]): Label weights of each image.
+            - bbox_targets (Tensor): BBox targets of each image.
+            - bbox_weights (Tensor): BBox weights of each image.
+            - pos_inds (Tensor): Sampled positive indices for each image.
+            - neg_inds (Tensor): Sampled negative indices for each image.
+        """
+        img_h, img_w = img_meta['img_shape']
+        factor = bbox_pred.new_tensor([img_w, img_h, img_w,
+                                       img_h]).unsqueeze(0)
+        # convert bbox_pred from xywh, normalized to xyxy, unnormalized
+        bbox_pred = bbox_cxcywh_to_xyxy(bbox_pred)
+        bbox_pred = bbox_pred * factor
+
+        pred_instances = InstanceData(scores=cls_score, bboxes=bbox_pred)
+
+        # assigner and sampler
+        # AlignDETR: Get `k` of current layer.
+        layer_index = img_meta['layer_index']
+        num_gt_repeat = self.all_layers_num_gt_repeat[layer_index]
+        assign_result = self.assigner.assign(
+            pred_instances=pred_instances,
+            gt_instances=gt_instances,
+            img_meta=img_meta,
+            k=num_gt_repeat)
+
+        gt_bboxes = gt_instances.bboxes
+        gt_labels = gt_instances.labels
+        pos_inds = torch.nonzero(
+            assign_result.gt_inds > 0, as_tuple=False).squeeze(-1).unique()
+        neg_inds = torch.nonzero(
+            assign_result.gt_inds == 0, as_tuple=False).squeeze(-1).unique()
+        pos_assigned_gt_inds = assign_result.gt_inds[pos_inds] - 1
+        pos_gt_bboxes = gt_bboxes[pos_assigned_gt_inds.long(), :]
+
+        # AlignDETR: Get label targets, label weights, and bbox weights.
+        target_results = self._get_align_detr_targets_single(
+            cls_score,
+            bbox_pred,
+            gt_labels,
+            pos_gt_bboxes,
+            pos_inds,
+            pos_assigned_gt_inds,
+            layer_index,
+            is_matching_queries=True)
+
+        label_targets, label_weights, bbox_weights = target_results
+
+        # bbox targets
+        bbox_targets = torch.zeros_like(bbox_pred, dtype=gt_bboxes.dtype)
+
+        # DETR regress the relative position of boxes (cxcywh) in the image.
+        # Thus the learning target should be normalized by the image size, also
+        # the box format should be converted from defaultly x1y1x2y2 to cxcywh.
+        pos_gt_bboxes_normalized = pos_gt_bboxes / factor
+        pos_gt_bboxes_targets = bbox_xyxy_to_cxcywh(pos_gt_bboxes_normalized)
+        bbox_targets[pos_inds] = pos_gt_bboxes_targets
+        return (label_targets, label_weights, bbox_targets, bbox_weights,
+                pos_inds, neg_inds)
+
+    def _loss_dn_single(self, dn_cls_scores: KeysRecorder,
+                        dn_bbox_preds: Tensor,
+                        batch_gt_instances: InstanceList,
+                        batch_img_metas: List[dict],
+                        dn_meta: Dict[str, int]) -> Tuple[Tensor]:
+        """Denoising loss for outputs from a single decoder layer.
+            AlignDETR: This method is based on `DINOHead._loss_dn_single`.
+
+        Args:
+            dn_cls_scores (KeysRecorder): Classification scores of a single
+                decoder layer in denoising part, has shape (bs,
+                num_denoising_queries, cls_out_channels).
+            dn_bbox_preds (Tensor): Regression outputs of a single decoder
+                layer in denoising part. Each is a 4D-tensor with normalized
+                coordinate format (cx, cy, w, h) and has shape
+                (bs, num_denoising_queries, 4).
+            batch_gt_instances (list[:obj:`InstanceData`]): Batch of
+                gt_instance. It usually includes ``bboxes`` and ``labels``
+                attributes.
+            batch_img_metas (list[dict]): Meta information of each image, e.g.,
+                image size, scaling factor, etc.
+            dn_meta (Dict[str, int]): The dictionary saves information about
+              group collation, including 'num_denoising_queries' and
+              'num_denoising_groups'. It will be used for split outputs of
+              denoising and matching parts and loss calculation.
+
+        Returns:
+            Tuple[Tensor]: A tuple including `loss_cls`, `loss_box` and
+            `loss_iou`.
+        """
+        # AlignDETR: Get dn_cls_scores tensor.
+        dn_cls_scores = dn_cls_scores.obj
+
+        # AlignDETR: Add layer outputs to meta info because they are not
+        #   variables of method `_get_dn_targets_single`.
+        for image_index, img_meta in enumerate(batch_img_metas):
+            img_meta['dn_cls_score'] = dn_cls_scores[image_index]
+            img_meta['dn_bbox_pred'] = dn_bbox_preds[image_index]
+
+        results = super()._loss_dn_single(dn_cls_scores, dn_bbox_preds,
+                                          batch_gt_instances, batch_img_metas,
+                                          dn_meta)
+        return results
+
+    def _get_dn_targets_single(self, gt_instances: InstanceData,
+                               img_meta: dict, dn_meta: Dict[str,
+                                                             int]) -> tuple:
+        """Get targets in denoising part for one image.
+            AlignDETR: This method is based on
+            `DINOHead._get_dn_targets_single`.
+            and 1) Added passing `dn_cls_score`, `dn_bbox_pred` to this
+            method; 2) Modified the way to get targets.
+        Args:
+            dn_cls_score (Tensor): Box score logits from a single decoder
+            layer in denoising part for one image, has shape
+                [num_denoising_queries, cls_out_channels].
+            dn_bbox_pred (Tensor): Sigmoid outputs from a single decoder
+            layer in denoising part for one image, with
+                normalized coordinate (cx, cy, w, h) and shape
+                [num_denoising_queries, 4].
+            gt_instances (:obj:`InstanceData`): Ground truth of instance
+                annotations. It should includes ``bboxes`` and ``labels``
+                attributes.
+            img_meta (dict): Meta information for one image.
+            dn_meta (Dict[str, int]): The dictionary saves information about
+              group collation, including 'num_denoising_queries' and
+              'num_denoising_groups'. It will be used for split outputs of
+              denoising and matching parts and loss calculation.
+
+        Returns:
+            tuple[Tensor]: a tuple containing the following for one image.
+
+            - labels (Tensor): Labels of each image.
+            - label_weights (Tensor]): Label weights of each image.
+            - bbox_targets (Tensor): BBox targets of each image.
+            - bbox_weights (Tensor): BBox weights of each image.
+            - pos_inds (Tensor): Sampled positive indices for each image.
+            - neg_inds (Tensor): Sampled negative indices for each image.
+        """
+        gt_bboxes = gt_instances.bboxes
+        gt_labels = gt_instances.labels
+        num_groups = dn_meta['num_denoising_groups']
+        num_denoising_queries = dn_meta['num_denoising_queries']
+        num_queries_each_group = int(num_denoising_queries / num_groups)
+        device = gt_bboxes.device
+
+        if len(gt_labels) > 0:
+            t = torch.arange(len(gt_labels), dtype=torch.long, device=device)
+            t = t.unsqueeze(0).repeat(num_groups, 1)
+            pos_assigned_gt_inds = t.flatten()
+            pos_inds = torch.arange(
+                num_groups, dtype=torch.long, device=device)
+            pos_inds = pos_inds.unsqueeze(1) * num_queries_each_group + t
+            pos_inds = pos_inds.flatten()
+        else:
+            pos_inds = pos_assigned_gt_inds = \
+                gt_bboxes.new_tensor([], dtype=torch.long)
+
+        neg_inds = pos_inds + num_queries_each_group // 2
+
+        # AlignDETR: Get meta info and layer outputs.
+        img_h, img_w = img_meta['img_shape']
+        dn_cls_score = img_meta['dn_cls_score']
+        dn_bbox_pred = img_meta['dn_bbox_pred']
+        factor = dn_bbox_pred.new_tensor([img_w, img_h, img_w,
+                                          img_h]).unsqueeze(0)
+
+        # AlignDETR: Convert dn_bbox_pred from xywh, normalized to xyxy,
+        #   unnormalized.
+        dn_bbox_pred = bbox_cxcywh_to_xyxy(dn_bbox_pred)
+        dn_bbox_pred = dn_bbox_pred * factor
+
+        # AlignDETR: Get label targets, label weights, and bbox weights.
+        target_results = self._get_align_detr_targets_single(
+            dn_cls_score, dn_bbox_pred, gt_labels,
+            gt_bboxes.repeat([num_groups, 1]), pos_inds, pos_assigned_gt_inds)
+
+        label_targets, label_weights, bbox_weights = target_results
+
+        # bbox targets
+        bbox_targets = torch.zeros(num_denoising_queries, 4, device=device)
+
+        # DETR regress the relative position of boxes (cxcywh) in the image.
+        # Thus the learning target should be normalized by the image size, also
+        # the box format should be converted from defaultly x1y1x2y2 to cxcywh.
+        gt_bboxes_normalized = gt_bboxes / factor
+        gt_bboxes_targets = bbox_xyxy_to_cxcywh(gt_bboxes_normalized)
+        bbox_targets[pos_inds] = gt_bboxes_targets.repeat([num_groups, 1])
+
+        return (label_targets, label_weights, bbox_targets, bbox_weights,
+                pos_inds, neg_inds)
+
+    def _get_align_detr_targets_single(self,
+                                       cls_score: Tensor,
+                                       bbox_pred: Tensor,
+                                       gt_labels: Tensor,
+                                       pos_gt_bboxes: Tensor,
+                                       pos_inds: Tensor,
+                                       pos_assigned_gt_inds: Tensor,
+                                       layer_index: int = -1,
+                                       is_matching_queries: bool = False):
+        '''AlignDETR: Get label targets, label weights, and bbox weights based
+            on `t`, the weighted geometric average of the confident score and
+            the IoU score, to align classification and regression scores.
+
+        Args:
+            cls_score (Tensor): Box score logits from the last encoder layer
+                or a single decoder layer for one image. Shape
+                [num_queries or num_denoising_queries, cls_out_channels].
+            bbox_pred (Tensor): Sigmoid outputs from the last encoder layer
+                or a single decoder layer for one image, with unnormalized
+                coordinate (x, y, x, y) and shape
+                [num_queries or num_denoising_queries, 4].
+            gt_labels (Tensor): Ground truth classification labels for one
+                image, has shape [num_gt].
+            pos_gt_bboxes (Tensor): Positive ground truth bboxes for one
+                image, with unnormalized coordinate (x, y, x, y) and shape
+                [num_positive, 4].
+            pos_inds (Tensor): Positive prediction box indices, has shape
+                [num_positive].
+            pos_assigned_gt_inds Tensor: Positive ground truth box indices,
+                has shape [num_positive].
+            layer_index (int): decoder layer index for the outputs. Defaults
+                to `-1`.
+            is_matching_queries (bool): The outputs are from matching
+                queries or denoising queries. Defaults to `False`.
+
+        Returns:
+            tuple[Tensor]: a tuple containing the following for one image.
+
+            - label_targets (Tensor): Labels of one image. Shape
+                [num_queries or num_denoising_queries, cls_out_channels].
+            - label_weights (Tensor): Label weights of one image. Shape
+                [num_queries or num_denoising_queries, cls_out_channels].
+            - bbox_weights (Tensor): BBox weights of one image. Shape
+                [num_queries or num_denoising_queries, 4].
+        '''
+
+        # Classification loss
+        # =           1 * BCE(prob, t * rank_weights) for positive sample;
+        # = prob**gamma * BCE(prob,                0) for negative sample.
+        # That is,
+        # label_targets = 0                for negative sample;
+        #               = t * rank_weights for positive sample.
+        # label_weights = pred**gamma for negative sample;
+        #               = 1           for positive sample.
+        cls_prob = cls_score.sigmoid()
+        label_targets = torch.zeros_like(
+            cls_score, device=pos_gt_bboxes.device)
+        label_weights = cls_prob**self.gamma
+
+        bbox_weights = torch.zeros_like(bbox_pred, dtype=pos_gt_bboxes.dtype)
+
+        if len(pos_inds) == 0:
+            return label_targets, label_weights, bbox_weights
+
+        pos_cls_score_inds = (pos_inds, gt_labels[pos_assigned_gt_inds])
+        iou_scores = bbox_overlaps(
+            bbox_pred[pos_inds], pos_gt_bboxes, is_aligned=True)
+
+        # t (Tensor): The weighted geometric average of the confident score
+        #   and the IoU score, to align classification and regression scores.
+        #   Shape [num_positive].
+        t = (
+            cls_prob[pos_cls_score_inds]**self.alpha *
+            iou_scores**(1 - self.alpha))
+        t = torch.clamp(t, 0.01).detach()
+
+        # Calculate rank_weights for matching queries.
+        if is_matching_queries:
+            # rank_weights (Tensor): Weights of each group of predictions
+            #   assigned to the same positive gt bbox. Shape [num_positive].
+            rank_weights = torch.zeros_like(t, dtype=self.weight_table.dtype)
+
+            assert 0 <= layer_index < len(self.weight_table), layer_index
+            rank_to_weight = self.weight_table[layer_index].to(
+                rank_weights.device)
+            unique_gt_inds = torch.unique(pos_assigned_gt_inds)
+
+            # For each positive gt bbox, get all predictions assigned to it,
+            #   then calculate rank weights for this group of predictions.
+            for gt_index in unique_gt_inds:
+                pred_group_cond = pos_assigned_gt_inds == gt_index
+                # Weights are based on their rank sorted by t in the group.
+                pred_group = t[pred_group_cond]
+                indices = pred_group.sort(descending=True)[1]
+                group_weights = torch.zeros_like(
+                    indices, dtype=self.weight_table.dtype)
+                group_weights[indices] = rank_to_weight[:len(indices)]
+                rank_weights[pred_group_cond] = group_weights
+
+            t = t * rank_weights
+            pos_bbox_weights = rank_weights.unsqueeze(-1).repeat(
+                1, bbox_pred.size(-1))
+            bbox_weights[pos_inds] = pos_bbox_weights
+        else:
+            bbox_weights[pos_inds] = 1.0
+
+        label_targets[pos_cls_score_inds] = t
+        label_weights[pos_cls_score_inds] = 1.0
+
+        return label_targets, label_weights, bbox_weights

--- a/projects/AlignDETR/align_detr/mixed_hungarian_assigner.py
+++ b/projects/AlignDETR/align_detr/mixed_hungarian_assigner.py
@@ -1,0 +1,162 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import List, Optional, Union
+
+import torch
+from mmengine import ConfigDict
+from mmengine.structures import InstanceData
+from scipy.optimize import linear_sum_assignment
+from torch import Tensor
+
+from mmdet.models.task_modules import AssignResult, BaseAssigner
+from mmdet.registry import TASK_UTILS
+
+
+@TASK_UTILS.register_module()
+class MixedHungarianAssigner(BaseAssigner):
+    """Computes 1-to-k matching between ground truth and predictions.
+
+    This class computes an assignment between the targets and the predictions
+    based on the costs. The costs are weighted sum of some components.
+    For DETR the costs are weighted sum of classification cost, regression L1
+    cost and regression iou cost. The targets don't include the no_object, so
+    generally there are more predictions than targets. After the 1-to-k
+    gt-pred matching, the un-matched are treated as backgrounds. Thus
+    each query prediction will be assigned with `0` or a positive integer
+    indicating the ground truth index:
+
+    - 0: negative sample, no assigned gt
+    - positive integer: positive sample, index (1-based) of assigned gt
+
+    Args:
+        match_costs (:obj:`ConfigDict` or dict or \
+            List[Union[:obj:`ConfigDict`, dict]]): Match cost configs.
+    """
+
+    def __init__(
+        self, match_costs: Union[List[Union[dict, ConfigDict]], dict,
+                                 ConfigDict]
+    ) -> None:
+
+        if isinstance(match_costs, dict):
+            match_costs = [match_costs]
+        elif isinstance(match_costs, list):
+            assert len(match_costs) > 0, \
+                'match_costs must not be a empty list.'
+
+        self.match_costs = [
+            TASK_UTILS.build(match_cost) for match_cost in match_costs
+        ]
+
+    def assign(self,
+               pred_instances: InstanceData,
+               gt_instances: InstanceData,
+               img_meta: Optional[dict] = None,
+               k: int = 1,
+               **kwargs) -> AssignResult:
+        """Computes 1-to-k gt-pred matching based on the weighted costs.
+
+        This method assign each query prediction to a ground truth or
+        background. The `assigned_gt_inds` with -1 means don't care,
+        0 means negative sample, and positive number is the index (1-based)
+        of assigned gt.
+        The assignment is done in the following steps, the order matters.
+
+        1. Assign every prediction to -1.
+        2. Compute the weighted costs, each cost has shape
+            (num_preds, num_gts).
+        3. Update k according to num_preds and num_gts, then repeat
+            costs k times to shape: (num_preds, k * num_gts), so that each
+            gt will match k predictions.
+        4. Do Hungarian matching on CPU based on the costs.
+        5. Assign all to 0 (background) first, then for each matched pair
+           between predictions and gts, treat this prediction as foreground
+           and assign the corresponding gt index (plus 1) to it.
+
+        Args:
+            pred_instances (:obj:`InstanceData`): Instances of model
+                predictions. It includes ``priors``, and the priors can
+                be anchors or points, or the bboxes predicted by the
+                previous stage, has shape (n, 4). The bboxes predicted by
+                the current model or stage will be named ``bboxes``,
+                ``labels``, and ``scores``, the same as the ``InstanceData``
+                in other places. It may includes ``masks``, with shape
+                (n, h, w) or (n, l).
+            gt_instances (:obj:`InstanceData`): Ground truth of instance
+                annotations. It usually includes ``bboxes``, with shape (k, 4),
+                ``labels``, with shape (k, ) and ``masks``, with shape
+                (k, h, w) or (k, l).
+            img_meta (dict): Image information for one image.
+
+        Returns:
+            :obj:`AssignResult`: The assigned result.
+        """
+        assert isinstance(gt_instances.labels, Tensor)
+        num_gts, num_preds = len(gt_instances), len(pred_instances)
+        gt_labels = gt_instances.labels
+        device = gt_labels.device
+
+        # 1. Assign -1 by default.
+        assigned_gt_inds = torch.full((num_preds, ),
+                                      -1,
+                                      dtype=torch.long,
+                                      device=device)
+        assigned_labels = torch.full((num_preds, ),
+                                     -1,
+                                     dtype=torch.long,
+                                     device=device)
+
+        if num_gts == 0 or num_preds == 0:
+            # No ground truth or boxes, return empty assignment.
+            if num_gts == 0:
+                # No ground truth, assign all to background.
+                assigned_gt_inds[:] = 0
+            return AssignResult(
+                num_gts=num_gts,
+                gt_inds=assigned_gt_inds,
+                max_overlaps=None,
+                labels=assigned_labels)
+
+        # 2. Compute weighted costs.
+        cost_list = []
+        for match_cost in self.match_costs:
+            cost = match_cost(
+                pred_instances=pred_instances,
+                gt_instances=gt_instances,
+                img_meta=img_meta)
+            cost_list.append(cost)
+        cost = torch.stack(cost_list).sum(dim=0)
+
+        # 3. Update k according to num_preds and num_gts,  then
+        #   repeat the ground truth k times to perform 1-to-k gt-pred
+        #   matching. For example, if num_preds = 900, num_gts = 3, then
+        #   there are only 3 gt-pred pairs in sum for 1-1 matching.
+        #   However, for 1-k gt-pred matching, if k = 4, then each
+        #   gt is assigned 4 unique predictions, so there would be 12
+        #   gt-pred pairs in sum.
+        k = max(1, min(k, num_preds // num_gts))
+        cost = cost.repeat(1, k)
+
+        # 4. Do Hungarian matching on CPU using linear_sum_assignment.
+        cost = cost.detach().cpu()
+        if linear_sum_assignment is None:
+            raise ImportError('Please run "pip install scipy" '
+                              'to install scipy first.')
+
+        matched_row_inds, matched_col_inds = linear_sum_assignment(cost)
+        matched_row_inds = torch.from_numpy(matched_row_inds).to(device)
+        matched_col_inds = torch.from_numpy(matched_col_inds).to(device)
+
+        matched_col_inds = matched_col_inds % num_gts
+        # 5. Assign backgrounds and foregrounds.
+        # Assign all indices to backgrounds first.
+        assigned_gt_inds[:] = 0
+        # Assign foregrounds based on matching results.
+        assigned_gt_inds[matched_row_inds] = matched_col_inds + 1
+        assigned_labels[matched_row_inds] = gt_labels[matched_col_inds]
+        assign_result = AssignResult(
+            num_gts=k * num_gts,
+            gt_inds=assigned_gt_inds,
+            max_overlaps=None,
+            labels=assigned_labels)
+
+        return assign_result

--- a/projects/AlignDETR/align_detr/utils.py
+++ b/projects/AlignDETR/align_detr/utils.py
@@ -1,0 +1,34 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Any, List, Optional
+
+
+class KeysRecorder:
+    """Wrap object to record its `__getitem__` keys in the history.
+
+    Args:
+        obj (object): Any object that supports `__getitem__`.
+        keys (List): List of keys already recorded. Default to None.
+    """
+
+    def __init__(self, obj: Any, keys: Optional[List[Any]] = None) -> None:
+        self.obj = obj
+
+        if keys is None:
+            keys = []
+        self.keys = keys
+
+    def __getitem__(self, key: Any) -> 'KeysRecorder':
+        """Wrap method `__getitem__`  to record its keys.
+
+        Args:
+            key: Key that is passed to the object.
+
+        Returns:
+            result (KeysRecorder): KeysRecorder instance that wraps sub_obj.
+        """
+        sub_obj = self.obj.__getitem__(key)
+        keys = self.keys.copy()
+        keys.append(key)
+        # Create a KeysRecorder instance from the sub_obj.
+        result = KeysRecorder(sub_obj, keys)
+        return result

--- a/projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-12e_coco.py
+++ b/projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-12e_coco.py
@@ -1,0 +1,185 @@
+_base_ = [
+    '../../../configs/_base_/datasets/coco_detection.py',
+    '../../../configs/_base_/default_runtime.py'
+]
+custom_imports = dict(
+    imports=['projects.AlignDETR.align_detr'], allow_failed_imports=False)
+
+model = dict(
+    type='DINO',
+    num_queries=900,  # num_matching_queries
+    with_box_refine=True,
+    as_two_stage=True,
+    data_preprocessor=dict(
+        type='DetDataPreprocessor',
+        mean=[123.675, 116.28, 103.53],
+        std=[58.395, 57.12, 57.375],
+        bgr_to_rgb=True,
+        pad_size_divisor=1),
+    backbone=dict(
+        type='ResNet',
+        depth=50,
+        num_stages=4,
+        out_indices=(1, 2, 3),
+        # AlignDETR: Only freeze stem.
+        frozen_stages=0,
+        norm_cfg=dict(type='FrozenBN', requires_grad=False),
+        norm_eval=True,
+        style='pytorch',
+        init_cfg=dict(type='Pretrained', checkpoint='torchvision://resnet50')),
+    neck=dict(
+        type='ChannelMapper',
+        in_channels=[512, 1024, 2048],
+        kernel_size=1,
+        out_channels=256,
+        # AlignDETR: Add conv bias.
+        bias=True,
+        act_cfg=None,
+        norm_cfg=dict(type='GN', num_groups=32),
+        num_outs=4),
+    encoder=dict(
+        num_layers=6,
+        layer_cfg=dict(
+            self_attn_cfg=dict(embed_dims=256, num_levels=4,
+                               dropout=0.0),  # 0.1 for DeformDETR
+            ffn_cfg=dict(
+                embed_dims=256,
+                feedforward_channels=2048,  # 1024 for DeformDETR
+                ffn_drop=0.0))),  # 0.1 for DeformDETR
+    decoder=dict(
+        num_layers=6,
+        return_intermediate=True,
+        layer_cfg=dict(
+            self_attn_cfg=dict(embed_dims=256, num_heads=8,
+                               dropout=0.0),  # 0.1 for DeformDETR
+            cross_attn_cfg=dict(embed_dims=256, num_levels=4,
+                                dropout=0.0),  # 0.1 for DeformDETR
+            ffn_cfg=dict(
+                embed_dims=256,
+                feedforward_channels=2048,  # 1024 for DeformDETR
+                ffn_drop=0.0)),  # 0.1 for DeformDETR
+        post_norm_cfg=None),
+    positional_encoding=dict(
+        num_feats=128,
+        normalize=True,
+        # AlignDETR: Set offset and temperature the same as DeformDETR.
+        offset=-0.5,  # -0.5 for DeformDETR
+        temperature=10000),  # 10000 for DeformDETR
+    bbox_head=dict(
+        type='AlignDETRHead',
+        # AlignDETR: First 6 elements of `all_layers_num_gt_repeat` are for
+        #   decoder layers' outputs. The last element is for encoder layer.
+        all_layers_num_gt_repeat=[2, 2, 2, 2, 2, 1, 2],
+        alpha=0.25,
+        gamma=2.0,
+        tau=1.5,
+        num_classes=80,
+        sync_cls_avg_factor=True,
+        loss_cls=dict(
+            type='CrossEntropyLoss', use_sigmoid=True,
+            loss_weight=1.0),  # 2.0 in DeformDETR
+        loss_bbox=dict(type='L1Loss', loss_weight=5.0),
+        loss_iou=dict(type='GIoULoss', loss_weight=2.0)),
+    dn_cfg=dict(  # TODO: Move to model.train_cfg ?
+        label_noise_scale=0.5,
+        box_noise_scale=1.0,  # 0.4 for DN-DETR
+        group_cfg=dict(dynamic=True, num_groups=None,
+                       num_dn_queries=100)),  # TODO: half num_dn_queries
+    # training and testing settings
+    train_cfg=dict(
+        assigner=dict(
+            type='MixedHungarianAssigner',
+            match_costs=[
+                dict(type='FocalLossCost', weight=2.0),
+                dict(type='BBoxL1Cost', weight=5.0, box_format='xywh'),
+                dict(type='IoUCost', iou_mode='giou', weight=2.0)
+            ])),
+    test_cfg=dict(max_per_img=300))  # 100 for DeformDETR
+
+# train_pipeline, NOTE the img_scale and the Pad's size_divisor is different
+# from the default setting in mmdet.
+train_pipeline = [
+    dict(type='LoadImageFromFile', backend_args=_base_.backend_args),
+    dict(type='LoadAnnotations', with_bbox=True),
+    dict(type='RandomFlip', prob=0.5),
+    dict(
+        type='RandomChoice',
+        transforms=[
+            [
+                dict(
+                    type='RandomChoiceResize',
+                    scales=[(480, 1333), (512, 1333), (544, 1333), (576, 1333),
+                            (608, 1333), (640, 1333), (672, 1333), (704, 1333),
+                            (736, 1333), (768, 1333), (800, 1333)],
+                    keep_ratio=True)
+            ],
+            [
+                dict(
+                    type='RandomChoiceResize',
+                    # The radio of all image in train dataset < 7
+                    # follow the original implement
+                    scales=[(400, 4200), (500, 4200), (600, 4200)],
+                    keep_ratio=True),
+                dict(
+                    type='RandomCrop',
+                    crop_type='absolute_range',
+                    crop_size=(384, 600),
+                    allow_negative_crop=True),
+                dict(
+                    type='RandomChoiceResize',
+                    scales=[(480, 1333), (512, 1333), (544, 1333), (576, 1333),
+                            (608, 1333), (640, 1333), (672, 1333), (704, 1333),
+                            (736, 1333), (768, 1333), (800, 1333)],
+                    keep_ratio=True)
+            ]
+        ]),
+    dict(type='PackDetInputs')
+]
+train_dataloader = dict(
+    dataset=dict(
+        # AlignDETR: Filter empty gt.
+        filter_cfg=dict(filter_empty_gt=True),
+        pipeline=train_pipeline))
+
+# optimizer
+optim_wrapper = dict(
+    type='OptimWrapper',
+    optimizer=dict(
+        type='AdamW',
+        lr=0.0001,  # 0.0002 for DeformDETR
+        weight_decay=0.0001),
+    clip_grad=dict(max_norm=0.1, norm_type=2),
+    paramwise_cfg=dict(
+        custom_keys={'backbone': dict(lr_mult=0.1)},
+        # AlignDETR: No norm decay.
+        norm_decay_mult=0.0)
+)  # custom_keys contains sampling_offsets and reference_points in DeformDETR  # noqa
+
+# learning policy
+max_epochs = 12
+train_cfg = dict(
+    type='EpochBasedTrainLoop', max_epochs=max_epochs, val_interval=1)
+
+val_cfg = dict(type='ValLoop')
+test_cfg = dict(type='TestLoop')
+
+param_scheduler = [
+    dict(
+        type='LinearLR',
+        start_factor=0.0001,
+        by_epoch=False,
+        begin=0,
+        end=2000),
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=max_epochs,
+        by_epoch=True,
+        milestones=[11],
+        gamma=0.1)
+]
+
+# NOTE: `auto_scale_lr` is for automatically scaling LR,
+# USER SHOULD NOT CHANGE ITS VALUES.
+# base_batch_size = (8 GPUs) x (2 samples per GPU)
+auto_scale_lr = dict(base_batch_size=16)

--- a/projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-24e_coco.py
+++ b/projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-24e_coco.py
@@ -1,0 +1,19 @@
+_base_ = './align_detr-4scale_r50_8xb2-12e_coco.py'
+max_epochs = 24
+train_cfg = dict(
+    type='EpochBasedTrainLoop', max_epochs=max_epochs, val_interval=1)
+param_scheduler = [
+    dict(
+        type='LinearLR',
+        start_factor=0.0001,
+        by_epoch=False,
+        begin=0,
+        end=2000),
+    dict(
+        type='MultiStepLR',
+        begin=0,
+        end=max_epochs,
+        by_epoch=True,
+        milestones=[20],
+        gamma=0.1)
+]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Support training and inference of the AlignDETR algorithm in mmdet, with reference to the open source code [AlignDETR](https://github.com/FelixCaae/AlignDETR).

Task: [OpenMMLabCamp#658](https://github.com/open-mmlab/OpenMMLabCamp/discussions/658)

## Modification
1. Add files under `projects/AlignDETR`.
2. Update `mmdet/models/detectors/deformable_detr.py` to Fix bug: RuntimeError: shape '[2, 1, 1, 2]' is invalid for input of size 2.

```
mmdet/models/detectors/deformable_detr.py
projects/AlignDETR/README.md
projects/AlignDETR/align_detr/__init__.py
projects/AlignDETR/align_detr/align_detr_head.py
projects/AlignDETR/align_detr/mixed_hungarian_assigner.py
projects/AlignDETR/align_detr/utils.py
projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-12e_coco.py
projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-24e_coco.py
```

## Use cases
### Installation
```
module load python/3.8.12-gcc-4.8.5-jbm
module load cuda/11.8
module load gcc/9.4.0-gcc-4.8.5

cd ~/align_detr
mkdir new
cd ~/align_detr/new

python -m venv  ~/align_detr/new/align_py38

source ~/align_detr/new/align_py38/bin/activate

pip install --upgrade pip setuptools wheel
pip install ipython

# Option 1: install directly.
pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
# Option 2: Download and then install.
wget -P ~/data/ https://download.pytorch.org/whl/cu118/torch-2.0.1%2Bcu118-cp38-cp38-linux_x86_64.whl
wget -P ~/data/ https://download.pytorch.org/whl/cu118/torchvision-0.15.2%2Bcu118-cp38-cp38-linux_x86_64.whl

pip install ~/data/torch-2.0.1+cu118-cp38-cp38-linux_x86_64.whl
pip install ~/data/torchvision-0.15.2+cu118-cp38-cp38-linux_x86_64.whl

pip install mmengine==0.8.4
pip install mmcv==2.0.0 -f https://download.openmmlab.com/mmcv/dist/cu118/torch2.0/index.html

cd ~/align_detr/new
git clone -b align_detr https://gitee.com/jiongjiongli/mmdetection_dev.git mmdetection
cd ~/align_detr/new/mmdetection
pip install -e .

```

### Train
```
module load python/3.8.12-gcc-4.8.5-jbm
module load cuda/11.8
module load gcc/9.4.0-gcc-4.8.5

source ~/align_detr/new/align_py38/bin/activate

cd ~/align_detr/new/mmdetection

python tools/train.py projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-12e_coco.py

```
### Test

```
module load python/3.8.12-gcc-4.8.5-jbm
module load cuda/11.8
module load gcc/9.4.0-gcc-4.8.5

source ~/align_detr/new/align_py38/bin/activate

cd ~/align_detr/new/mmdetection

python tools/test.py projects/AlignDETR/configs/align_detr-4scale_r50_8xb2-12e_coco.py $(model_weights_path)

```


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
