### PR TITLE
[Bugfix] analyze_results

### DIFF
--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -124,8 +124,12 @@ class ResultVisualizer:
 
             if task == 'det':
                 gt_instances = InstanceData()
-                gt_instances.bboxes = results[index]['gt_instances']['bboxes']
-                gt_instances.labels = results[index]['gt_instances']['labels']
+                gt_instances.bboxes = [
+                    d['bbox'] for d in data_info['gt_instances']
+                ]
+                gt_instances.labels = [
+                    d['bbox_label'] for d in data_info['gt_instances']
+                ]
 
                 pred_instances = InstanceData()
                 pred_instances.bboxes = results[index]['pred_instances'][
@@ -141,7 +145,9 @@ class ResultVisualizer:
 
             elif task == 'seg':
                 gt_panoptic_seg = PixelData()
-                gt_panoptic_seg.sem_seg = results[index]['gt_seg_map']
+                gt_panoptic_seg.sem_seg = [
+                    d['gt_seg_map'] for d in data_info['gt_instances']
+                ]
 
                 pred_panoptic_seg = PixelData()
                 pred_panoptic_seg.sem_seg = results[index][


### PR DESCRIPTION
## Motivation

```
  File "/usr/local/lib/python3.10/dist-packages/mmdet/.mim/tools/analysis_tools/analyze_results.py", line 398, in <module>
    main()
  File "/usr/local/lib/python3.10/dist-packages/mmdet/.mim/tools/analysis_tools/analyze_results.py", line 393, in main
    result_visualizer.evaluate_and_show(
  File "/usr/local/lib/python3.10/dist-packages/mmdet/.mim/tools/analysis_tools/analyze_results.py", line 200, in evaluate_and_show
    self._save_image_gts_results(
  File "/usr/local/lib/python3.10/dist-packages/mmdet/.mim/tools/analysis_tools/analyze_results.py", line 127, in _save_image_gts_results
    gt_instances.bboxes = results[index]['gt_instances']['bboxes']
KeyError: 'gt_instances'
```

## Modification

`results` doesn't have `gt_instances`.

https://github.com/open-mmlab/mmdetection/blob/f78af7785ada87f1ced75a2313746e4ba3149760/mmdet/evaluation/metrics/dump_det_results.py#L32

Use `data_info` insted of `results`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
