### PR TITLE
[fix]fix torch version comparison

### DIFF
--- a/.dev_scripts/gather_models.py
+++ b/.dev_scripts/gather_models.py
@@ -12,7 +12,7 @@ import torch
 import yaml
 from mmengine.config import Config
 from mmengine.fileio import dump
-from mmengine.utils import mkdir_or_exist, scandir
+from mmengine.utils import digit_version, mkdir_or_exist, scandir
 
 
 def ordered_yaml_dump(data, stream=None, Dumper=yaml.SafeDumper, **kwds):
@@ -45,7 +45,7 @@ def process_checkpoint(in_file, out_file):
 
     # if it is necessary to remove some sensitive data in checkpoint['meta'],
     # add the code here.
-    if torch.__version__ >= '1.6':
+    if digit_version(torch.__version__) >= digit_version('1.6'):
         torch.save(checkpoint, out_file, _use_new_zipfile_serialization=False)
     else:
         torch.save(checkpoint, out_file)

--- a/mmdet/models/layers/normed_predictor.py
+++ b/mmdet/models/layers/normed_predictor.py
@@ -2,6 +2,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from mmengine.utils import digit_version
 from torch import Tensor
 
 from mmdet.registry import MODELS
@@ -91,7 +92,7 @@ class NormedConv2d(nn.Conv2d):
         if hasattr(self, 'conv2d_forward'):
             x_ = self.conv2d_forward(x_, weight_)
         else:
-            if torch.__version__ >= '1.8':
+            if digit_version(torch.__version__) >= digit_version('1.8'):
                 x_ = self._conv_forward(x_, weight_, self.bias)
             else:
                 x_ = self._conv_forward(x_, weight_)

--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -11,6 +11,7 @@ from mmengine.logging import MMLogger
 from mmengine.model import revert_sync_batchnorm
 from mmengine.registry import init_default_scope
 from mmengine.runner import Runner
+from mmengine.utils import digit_version
 
 from mmdet.registry import MODELS
 
@@ -44,7 +45,7 @@ def parse_args():
 
 
 def inference(args, logger):
-    if str(torch.__version__) < '1.12':
+    if digit_version(torch.__version__) < digit_version('1.12'):
         logger.warning(
             'Some config files, such as configs/yolact and configs/detectors,'
             'may have compatibility issues with torch.jit when torch<1.12. '

--- a/tools/model_converters/publish_model.py
+++ b/tools/model_converters/publish_model.py
@@ -4,6 +4,7 @@ import subprocess
 
 import torch
 from mmengine.logging import print_log
+from mmengine.utils import digit_version
 
 
 def parse_args():
@@ -37,7 +38,7 @@ def process_checkpoint(in_file, out_file, save_keys=['meta', 'state_dict']):
 
     # if it is necessary to remove some sensitive data in checkpoint['meta'],
     # add the code here.
-    if torch.__version__ >= '1.6':
+    if digit_version(torch.__version__) >= digit_version('1.6'):
         torch.save(checkpoint, out_file, _use_new_zipfile_serialization=False)
     else:
         torch.save(checkpoint, out_file)

--- a/tools/model_converters/upgrade_ssd_version.py
+++ b/tools/model_converters/upgrade_ssd_version.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 import torch
 from mmengine import Config
+from mmengine.utils import digit_version
 
 
 def parse_config(config_strings):
@@ -39,7 +40,7 @@ def convert(in_file, out_file):
         out_state_dict[new_key] = value
     checkpoint['state_dict'] = out_state_dict
 
-    if torch.__version__ >= '1.6':
+    if digit_version(torch.__version__) >= digit_version('1.6'):
         torch.save(checkpoint, out_file, _use_new_zipfile_serialization=False)
     else:
         torch.save(checkpoint, out_file)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I notice that there's
1. inconsistency in version comparison since some file use `mmengine.utils.digit_version` while some just compare string
2. misuse of string comparison, for example: `'1.9.0' < '1.12'` and you get `False` with python

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
5. The documentation has been modified accordingly, like docstring or example tutorials.
