### PR TITLE
[Fix] Fix incorrect behavior to access train pipeline from `ConcatDataset` in analyze_results.py

### DIFF
--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -369,9 +369,12 @@ def main():
     cfg.test_dataloader.pop('batch_size', 0)
     if cfg.train_dataloader.dataset.type in ('MultiImageMixDataset',
                                              'ClassBalancedDataset',
-                                             'RepeatDataset', 'ConcatDataset'):
+                                             'RepeatDataset'):
         cfg.test_dataloader.dataset.pipeline = get_loading_pipeline(
             cfg.train_dataloader.dataset.dataset.pipeline)
+    elif cfg.train_dataloader.dataset.type in ('ConcatDataset',):
+        cfg.test_dataloader.dataset.pipeline = get_loading_pipeline(
+            cfg.train_dataloader.dataset.datasets[0].pipeline)
     else:
         cfg.test_dataloader.dataset.pipeline = get_loading_pipeline(
             cfg.train_dataloader.dataset.pipeline)

--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -372,7 +372,7 @@ def main():
                                              'RepeatDataset'):
         cfg.test_dataloader.dataset.pipeline = get_loading_pipeline(
             cfg.train_dataloader.dataset.dataset.pipeline)
-    elif cfg.train_dataloader.dataset.type in ('ConcatDataset',):
+    elif cfg.train_dataloader.dataset.type in ('ConcatDataset', ):
         cfg.test_dataloader.dataset.pipeline = get_loading_pipeline(
             cfg.train_dataloader.dataset.datasets[0].pipeline)
     else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

According to the implementation of `ConcatDataset` class from [mmengine](https://github.com/open-mmlab/mmengine/blob/daacb1878b5dc01023ff9390dca6c6744ad87e92/mmengine/dataset/dataset_wrapper.py#L41), the `datasets` variable is a list.

https://github.com/open-mmlab/mmdetection/blob/f78af7785ada87f1ced75a2313746e4ba3149760/tools/analysis_tools/analyze_results.py#L374

We should use `cfg.train_dataloader.dataset.datasets[0].pipeline`, instead of `cfg.train_dataloader.dataset.dataset.pipeline`.

## Modification

* Add an if condition to check the train dataset is `ConcatDataset`
* Load and assign the train pipeline `cfg.train_dataloader.dataset.datasets[0].pipeline` to `cfg.test_dataloader.dataset.pipeline`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
