### PR TITLE
Fix Grounding DINO nan when class tokens exceeds 256

### DIFF
--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -113,7 +113,11 @@ class GroundingDINO(DINO):
         return tokenized, caption_string, tokens_positive, entities
 
     def get_positive_map(self, tokenized, tokens_positive):
-        positive_map = create_positive_map(tokenized, tokens_positive)
+        positive_map = create_positive_map(
+            tokenized,
+            tokens_positive,
+            max_num_entities=self.bbox_head.cls_branches[
+                self.decoder.num_layers].max_text_len)
         positive_map_label_to_token = create_positive_map_label_to_token(
             positive_map, plus=1)
         return positive_map_label_to_token, positive_map


### PR DESCRIPTION
## Motivation

Grounding DINO tokenizes class names using GLIP code, and associates tokens with original class names. However, "max_num_entities" is capped at 256. 
https://github.com/open-mmlab/mmdetection/blob/fe3f809a0a514189baf889aa358c498d51ee36cd/mmdet/models/detectors/glip.py#L98-L100
This causes issues when Grounding DINO is run (fine-tune or zero-shot inference) with a large number of class names whose total number of tokens exceed this amount. In my use case, 100~ classes ended up yielding 280 tokens. This causes nans in the prediction scores, because later class names are not associated with any tokens.

## Modification

Simply set the max_num_entities as `max_text_len` defined for Grounding DINO contrastive objective. This does not break original code, as `max_text_len` by default is 256.

Note that `max_tokens` for `language_model` also needs to be updated, or it can silently not detect any classes past 256 tokens. However, that can just be modified in config, unlike `max_num_entities`.