### PR TITLE
Add the functionality to plot the PR curve in the COCO metric indicators of mmdet

### DIFF
--- a/mmdet/evaluation/functional/__init__.py
+++ b/mmdet/evaluation/functional/__init__.py
@@ -9,6 +9,7 @@ from .class_names import (cityscapes_classes, coco_classes,
 from .mean_ap import average_precision, eval_map, print_map_summary
 from .panoptic_utils import (INSTANCE_OFFSET, pq_compute_multi_core,
                              pq_compute_single_core)
+from .plot import prplot
 from .recall import (eval_recalls, plot_iou_recall, plot_num_recall,
                      print_recall_summary)
 from .ytvis import YTVIS
@@ -22,5 +23,5 @@ __all__ = [
     'oid_v6_classes', 'oid_challenge_classes', 'INSTANCE_OFFSET',
     'pq_compute_single_core', 'pq_compute_multi_core', 'bbox_overlaps',
     'objects365v1_classes', 'objects365v2_classes', 'coco_panoptic_classes',
-    'evaluateImgLists', 'YTVIS', 'YTVISeval'
+    'evaluateImgLists', 'YTVIS', 'YTVISeval', 'prplot'
 ]

--- a/mmdet/evaluation/functional/plot.py
+++ b/mmdet/evaluation/functional/plot.py
@@ -1,0 +1,46 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import matplotlib.pyplot as plt
+import numpy as np
+from mmengine.visualization import Visualizer
+
+
+def prplot(rs, ps, class_name, iou_type, types):
+
+    def fig2im(fig):
+        fig.canvas.draw()
+        w, h = fig.canvas.get_width_height()
+        buf_ndarray = np.frombuffer(fig.canvas.tostring_rgb(), dtype='u1')
+        im = buf_ndarray.reshape(h, w, 3)
+        return im
+
+    vis = Visualizer.get_current_instance()
+    cs = np.vstack([
+        np.array([0.31, 0.51, 0.74]),
+        np.array([0.75, 0.31, 0.30]),
+        np.array([0.36, 0.90, 0.38]),
+        np.array([0.50, 0.39, 0.64]),
+        np.array([1, 0.6, 0]),
+    ])
+
+    figure_title = iou_type + '-' + class_name
+    ps_curve = [ps_.mean(axis=1) if ps_.ndim > 1 else ps_ for ps_ in ps]
+    fig = plt.figure()
+    ax = plt.subplot(111)
+    for k in range(len(types)):
+        ap = np.mean(ps_curve[k])
+        ax.plot(
+            rs,
+            ps_curve[k],
+            color=cs[k],
+            label=str(f'[{ap:.3f}]' + types[k]),
+            linewidth=0.5)
+    plt.xlabel('recall')
+    plt.ylabel('precision')
+    plt.xlim(0, 1.0)
+    plt.ylim(0, 1.0)
+    plt.title(figure_title)
+    plt.legend()
+    # plt.show()
+    img = fig2im(fig)
+    vis.add_image(f'{figure_title}.png', img)
+    plt.close(fig)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Add the functionality to plot the PR curve in the COCO metric indicators of mmdet.

## Modification

1. A new file plot.py was created in mmdet/evaluation/functional. The plot function in it is a modified version of makeplot()  in coco_error_analysis.py and applys Visualizer to save curve images.
2. The function compute_metrics() in coco_metric.py was modified. The code now uses the intermediate results from coco api and calls the above function to plot the curve.


## Use cases

Modify the config file like this:
`val_evaluator = dict(
    type='CocoMetric',
    ann_file=data_root + 'annotations/instances_val2017.json',
    metric='bbox',
    format_only=False,
    **plot_pr=True,**
    backend_args=backend_args)`
Then PR curve will be saved In the folder specified by Visualizer.
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
4. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
5. The documentation has been modified accordingly, like docstring or example tutorials.
