### PR TITLE
[Feature] Support OC Cost metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Apart from MMDetection, we also released [MMEngine](https://github.com/open-mmla
 (2) Based on CO-DETR, MMDet released a model with a COCO performance of 64.1 mAP.
 (3) Algorithms such as DINO support `AMP/Checkpoint/FrozenBN`, which can effectively reduce memory usage.
 
-**2. [Comprehensive Performance Comparison between CNN and Transformer](<(projects/RF100-Benchmark/README.md)>)**
+**2. [Comprehensive Performance Comparison between CNN and Transformer](projects/RF100-Benchmark/README.md)**
 RF100 consists of a dataset collection of 100 real-world datasets, including 7 domains. It can be used to assess the performance differences of Transformer models like DINO and CNN-based algorithms under different scenarios and data volumes. Users can utilize this benchmark to quickly evaluate the robustness of their algorithms in various scenarios.
 
 <div align=center>
@@ -130,7 +130,7 @@ We also provide a detailed process for training and evaluating Grounding DINO on
 | Grounding DINO-R50 |   R50    |  Scratch  | 48.9(+0.8) |       48.1        |
 
 **4. Support for the open-vocabulary detection algorithm [Detic](projects/Detic_new/README.md) and multi-dataset joint training.**
-**5. Training detection models using [FSDP and DeepSpeed](<(projects/example_largemodel/README.md)>).**
+**5. Training detection models using [FSDP and DeepSpeed](projects/example_largemodel/README.md).**
 
 | ID  | AMP | GC of Backbone | GC of Encoder | FSDP | Peak Mem (GB) | Iter Time (s) |
 | :-: | :-: | :------------: | :-----------: | :--: | :-----------: | :-----------: |

--- a/configs/solo/solo_r50_fpn_3x_coco.py
+++ b/configs/solo/solo_r50_fpn_3x_coco.py
@@ -15,7 +15,7 @@ train_dataloader = dict(dataset=dict(pipeline=train_pipeline))
 
 # training schedule for 3x
 max_epochs = 36
-train_cfg = dict(by_epoch=True, max_epochs=max_epochs)
+train_cfg = dict(max_epochs=max_epochs)
 
 # learning rate
 param_scheduler = [

--- a/docs/en/user_guides/tracking_dataset_prepare.md
+++ b/docs/en/user_guides/tracking_dataset_prepare.md
@@ -92,10 +92,10 @@ python ./tools/dataset_converters/mot2reid.py -i ./data/MOT17/ -o ./data/MOT17/r
 python ./tools/dataset_converters/crowdhuman2coco.py -i ./data/crowdhuman -o ./data/crowdhuman/annotations
 
 # YouTube-VIS 2019
-python ./tools/dataset_converters/youtubevis/youtubevis2coco.py -i ./data/youtube_vis_2019 -o ./data/youtube_vis_2019/annotations --version 2019
+python ./tools/dataset_converters/youtubevis2coco.py -i ./data/youtube_vis_2019 -o ./data/youtube_vis_2019/annotations --version 2019
 
 # YouTube-VIS 2021
-python ./tools/dataset_converters/youtubevis/youtubevis2coco.py -i ./data/youtube_vis_2021 -o ./data/youtube_vis_2021/annotations --version 2021
+python ./tools/dataset_converters/youtubevis2coco.py -i ./data/youtube_vis_2021 -o ./data/youtube_vis_2021/annotations --version 2021
 
 ```
 

--- a/docs/zh_cn/user_guides/tracking_dataset_prepare.md
+++ b/docs/zh_cn/user_guides/tracking_dataset_prepare.md
@@ -90,10 +90,10 @@ python ./tools/dataset_converters/mot2reid.py -i ./data/MOT17/ -o ./data/MOT17/r
 python ./tools/dataset_converters/crowdhuman2coco.py -i ./data/crowdhuman -o ./data/crowdhuman/annotations
 
 # YouTube-VIS 2019
-python ./tools/dataset_converters/youtubevis/youtubevis2coco.py -i ./data/youtube_vis_2019 -o ./data/youtube_vis_2019/annotations --version 2019
+python ./tools/dataset_converters/youtubevis2coco.py -i ./data/youtube_vis_2019 -o ./data/youtube_vis_2019/annotations --version 2019
 
 # YouTube-VIS 2021
-python ./tools/dataset_converters/youtubevis/youtubevis2coco.py -i ./data/youtube_vis_2021 -o ./data/youtube_vis_2021/annotations --version 2021
+python ./tools/dataset_converters/youtubevis2coco.py -i ./data/youtube_vis_2021 -o ./data/youtube_vis_2021/annotations --version 2021
 
 ```
 

--- a/mmdet/evaluation/metrics/__init__.py
+++ b/mmdet/evaluation/metrics/__init__.py
@@ -3,6 +3,7 @@ from .base_video_metric import BaseVideoMetric
 from .cityscapes_metric import CityScapesMetric
 from .coco_caption_metric import COCOCaptionMetric
 from .coco_metric import CocoMetric
+from .coco_oc_cost_metric import CocoOCCostMetric
 from .coco_occluded_metric import CocoOccludedSeparatedMetric
 from .coco_panoptic_metric import CocoPanopticMetric
 from .coco_video_metric import CocoVideoMetric
@@ -23,5 +24,5 @@ __all__ = [
     'VOCMetric', 'LVISMetric', 'CrowdHumanMetric', 'DumpProposals',
     'CocoOccludedSeparatedMetric', 'DumpDetResults', 'BaseVideoMetric',
     'MOTChallengeMetric', 'CocoVideoMetric', 'ReIDMetrics', 'YouTubeVISMetric',
-    'COCOCaptionMetric', 'SemSegMetric', 'RefSegMetric'
+    'COCOCaptionMetric', 'SemSegMetric', 'RefSegMetric', 'CocoOCCostMetric'
 ]

--- a/mmdet/evaluation/metrics/coco_oc_cost_metric.py
+++ b/mmdet/evaluation/metrics/coco_oc_cost_metric.py
@@ -1,0 +1,400 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import datetime
+import os.path as osp
+import tempfile
+from collections import OrderedDict
+from collections.abc import Sequence
+
+import numpy as np
+import pycocotools.mask as mask_utils
+import torch
+from mmengine.evaluator import BaseMetric
+from mmengine.fileio import dump, get_local_path
+from mmengine.logging import MMLogger
+from scipy.spatial.distance import cdist
+
+from mmdet.datasets.api_wrappers import COCO
+from mmdet.registry import METRICS
+from mmdet.structures.bbox import bbox_overlaps
+from mmdet.structures.mask import encode_mask_results
+
+try:
+    import ot
+except ImportError:
+    ot = None
+
+
+@METRICS.register_module()
+class CocoOCCostMetric(BaseMetric):
+    """Coco OC-Cost evaluation metric.
+
+    First, please install POT `pip install POT`.
+    Evaluate OC-Cost for detection tasks including instance segmentation.
+    Please refer to https://arxiv.org/abs/2203.14438 for more details.
+
+    Args:
+        ann_file (str, optional): Path to the coco format annotation file.
+            If not specified, ground truth annotations from the dataset will
+            be converted to coco format. Defaults to None.
+        alpha (float): Balancing localization and classification costs.
+            lambda in the paper. Defaults to 0.5.
+        beta (float): Cost of extra / missing detections. Defaults to 0.6.
+        metric (str | List[str]): Metrics to be evaluated. Valid metrics
+            include 'bbox', 'segm'. Defaults to 'bbox'.
+        outfile_prefix (str, optional): The prefix of json files. It includes
+            the file path and the prefix of filename, e.g., "a/b/prefix".
+            If not specified, a temp file will be created. Defaults to None.
+        file_client_args (dict, optional): Arguments to instantiate the
+            corresponding backend in mmdet <= 3.0.0rc6. Defaults to None.
+        backend_args (dict, optional): Arguments to instantiate the
+            corresponding backend. Defaults to None.
+        collect_device (str): Device name used for collecting results from
+            different ranks during distributed training. Must be 'cpu' or
+            'gpu'. Defaults to 'cpu'.
+        prefix (str, optional): The prefix that will be added in the metric
+            names to disambiguate homonymous metrics of different evaluators.
+            If prefix is not provided in the argument, self.default_prefix
+            will be used instead. Defaults to None.
+        sort_categories (bool): Whether sort categories in annotations. Only
+            used for `Objects365V1Dataset`. Defaults to False.
+    """
+
+    default_prefix: str | None = 'coco'
+
+    def __init__(self,
+                 ann_file: str | None = None,
+                 metric: str | list[str] = 'bbox',
+                 alpha: float = 0.5,
+                 beta: float = 0.6,
+                 outfile_prefix: str | None = None,
+                 file_client_args: dict | None = None,
+                 backend_args: dict | None = None,
+                 collect_device: str = 'cpu',
+                 prefix: str | None = None,
+                 sort_categories: bool = False) -> None:
+        super().__init__(collect_device=collect_device, prefix=prefix)
+        if ot is None:
+            raise RuntimeError('POT is not installed')
+
+        # coco evaluation metrics
+        self.metrics = metric if isinstance(metric, list) else [metric]
+        self.alpha = alpha
+        self.beta = beta
+        allowed_metrics = ['bbox', 'segm']
+        for metric in self.metrics:
+            if metric not in allowed_metrics:
+                msg = "metric should be one of 'bbox', 'segm' but "
+                f'got {metric}.'
+                raise KeyError(msg, )
+
+        self.outfile_prefix = outfile_prefix
+
+        self.backend_args = backend_args
+        if file_client_args is not None:
+            raise RuntimeError(
+                'The `file_client_args` is deprecated, '
+                'please use `backend_args` instead, please refer to'
+                'https://github.com/open-mmlab/mmdetection/blob/main/configs/_base_/datasets/coco_detection.py'  # noqa: E501
+            )
+
+        # if ann_file is not specified,
+        # initialize coco api with the converted dataset
+        if ann_file is not None:
+            with get_local_path(
+                    ann_file, backend_args=self.backend_args) as local_path:
+                self._coco_api = COCO(local_path)
+                if sort_categories:
+                    # 'categories' list in objects365_train.json and
+                    # objects365_val.json is inconsistent, need sort
+                    # list(or dict) before get cat_ids.
+                    cats = self._coco_api.cats
+                    sorted_cats = {i: cats[i] for i in sorted(cats)}
+                    self._coco_api.cats = sorted_cats
+                    categories = self._coco_api.dataset['categories']
+                    sorted_categories = sorted(
+                        categories, key=lambda i: i['id'])
+                    self._coco_api.dataset['categories'] = sorted_categories
+        else:
+            self._coco_api = None
+
+        # handle dataset lazy init
+        self.cat_ids = None
+        self.img_ids = None
+
+    def gt_to_coco_json(self, gt_dicts: Sequence[dict],
+                        outfile_prefix: str) -> str:
+        """Convert ground truth to coco format json file.
+
+        Copied from mmdetection/blob/main/mmdet/datasets/coco.py.
+
+        Args:
+            gt_dicts (Sequence[dict]): Ground truth of the dataset.
+            outfile_prefix (str): The filename prefix of the json files. If the
+                prefix is "somepath/xxx", the json file will be named
+                "somepath/xxx.gt.json".
+
+        Returns:
+            str: The filename of the json file.
+        """
+        categories = [
+            dict(id=id, name=name)
+            for id, name in enumerate(self.dataset_meta['classes'])
+        ]
+        image_infos = []
+        annotations = []
+
+        for idx, gt_dict in enumerate(gt_dicts):
+            img_id = gt_dict.get('img_id', idx)
+            image_info = dict(
+                id=img_id,
+                width=gt_dict['width'],
+                height=gt_dict['height'],
+                file_name='')
+            image_infos.append(image_info)
+            for ann in gt_dict['anns']:
+                label = ann['bbox_label']
+                bbox = ann['bbox']
+                coco_bbox = [
+                    bbox[0],
+                    bbox[1],
+                    bbox[2] - bbox[0],
+                    bbox[3] - bbox[1],
+                ]
+
+                annotation = dict(
+                    id=len(annotations) +
+                    1,  # coco api requires id starts with 1
+                    image_id=img_id,
+                    bbox=coco_bbox,
+                    iscrowd=ann.get('ignore_flag', 0),
+                    category_id=int(label),
+                    area=coco_bbox[2] * coco_bbox[3])
+                if ann.get('mask', None):
+                    mask = ann['mask']
+                    # area = mask_util.area(mask)
+                    if isinstance(mask, dict) and isinstance(
+                            mask['counts'], bytes):
+                        mask['counts'] = mask['counts'].decode()
+                    annotation['segmentation'] = mask
+                    # annotation['area'] = float(area)
+                annotations.append(annotation)
+
+        info = dict(
+            date_created=str(datetime.datetime.now()),
+            description='Coco json file converted by mmdet CocoMetric.')
+        coco_json = dict(
+            info=info,
+            images=image_infos,
+            categories=categories,
+            licenses=None,
+        )
+        if len(annotations) > 0:
+            coco_json['annotations'] = annotations
+        converted_json_path = f'{outfile_prefix}.gt.json'
+        dump(coco_json, converted_json_path)
+        return converted_json_path
+
+    def process(self, data_batch: dict, data_samples: Sequence[dict]) -> None:
+        """Process data batch.
+
+        Copied from mmdetection/blob/main/mmdet/datasets/coco.py.
+        Process one batch of data samples and predictions. The processed
+        results should be stored in ``self.results``, which will be used to
+        compute the metrics when all batches have been processed.
+
+        Args:
+            data_batch (dict): A batch of data from the dataloader.
+            data_samples (Sequence[dict]): A batch of data samples that
+                contain annotations and predictions.
+        """
+        for data_sample in data_samples:
+            result = dict()
+            pred = data_sample['pred_instances']
+            result['img_id'] = data_sample['img_id']
+            result['bboxes'] = pred['bboxes'].cpu().numpy()
+            result['scores'] = pred['scores'].cpu().numpy()
+            result['labels'] = pred['labels'].cpu().numpy()
+            # encode mask to RLE
+            if 'masks' in pred:
+                result['masks'] = encode_mask_results(
+                    pred['masks'].detach().cpu().numpy()) if isinstance(
+                        pred['masks'], torch.Tensor) else pred['masks']
+            # some detectors use different scores for bbox and mask
+            if 'mask_scores' in pred:
+                result['mask_scores'] = pred['mask_scores'].cpu().numpy()
+
+            # parse gt
+            gt = dict()
+            gt['width'] = data_sample['ori_shape'][1]
+            gt['height'] = data_sample['ori_shape'][0]
+            gt['img_id'] = data_sample['img_id']
+            if self._coco_api is None:
+                assert 'instances' in data_sample, \
+                    'ground truth is required for evaluation when ' \
+                    '`ann_file` is not provided'
+                gt['anns'] = data_sample['instances']
+            # add converted result to the results list
+            self.results.append((gt, result))
+
+    def _cls_cost_func(self, gt_label_score: np.ndarray,
+                       pred_label_score: np.ndarray) -> float:
+        """Calculate classification cost.
+
+        Args:
+            gt_label_score (np.ndarray): Ground truth label and score. [l, s].
+            pred_label_score (np.ndarray): Prediction label and score. [l, s].
+
+        Returns:
+            float: a unit cost
+        """
+        if gt_label_score[0] == pred_label_score[0]:
+            cls_cost = np.abs(gt_label_score[1] - pred_label_score[1])
+        else:
+            cls_cost = gt_label_score[1] + pred_label_score[1]
+        cls_cost *= 0.5  # normalized to [0, 1]
+
+        return cls_cost
+
+    def eval_oc_cost(self, predictions: list[dict], metric: str) -> float:
+        """Evaluate optimal transportation cost.
+
+        Args:
+            predictions (list[dict]): The processed results of each batch.
+            metric (str): Metric name, 'bbox' or 'segm'.
+
+        Returns:
+            float: Mean optimal transportation cost cost.
+        """
+        ot_costs = []
+        for img_id, prediction in zip(self.img_ids, predictions):
+            # prepare GT
+            img_info = self._coco_api.load_imgs(img_id)[0]
+            ann_ids = self._coco_api.get_ann_ids(img_ids=img_id)
+            ann_info = self._coco_api.load_anns(ann_ids)
+            gt = []
+            gt_label_score = []
+            for ann in ann_info:
+                if ann.get('ignore', False) or ann['iscrowd']:
+                    continue
+                if metric == 'bbox':
+                    x1, y1, w, h = ann['bbox']
+                    gt.append([x1, y1, x1 + w, y1 + h])
+                elif metric == 'segm':
+                    if isinstance(ann['segmentation'], Sequence):
+                        # convert Sequence to RLE
+                        rle = mask_utils.frPyObjects(ann['segmentation'],
+                                                     img_info['height'],
+                                                     img_info['width'])[0]
+                    else:
+                        rle = ann['segmentation']
+                    gt.append(rle)
+                gt_label_score.append([ann['category_id'], 1])
+
+            # prepare prediction
+            pred_label_score = np.concatenate([
+                prediction['labels'][..., None], prediction['scores'][...,
+                                                                      None]
+            ],
+                                              axis=1)
+            pred = (
+                prediction['bboxes']
+                if metric == 'bbox' else prediction['masks'])
+
+            n = len(gt)
+            m = len(pred)
+
+            if n == 0 and m == 0:
+                ot_costs.append(0)
+                continue
+
+            if n == 0 or m == 0:
+                ot_costs.append(1)
+                continue
+
+            # calculate OT cost
+            if metric == 'bbox':
+                iou_val = bbox_overlaps(
+                    torch.Tensor(gt)[None, :, :4],
+                    torch.Tensor(pred)[None, :, :4],
+                    mode='giou').numpy()
+                loc_cost = 1 - (iou_val + 1) * 0.5  # normalized to [0, 1]
+            elif metric == 'segm':
+                loc_cost = 1 - mask_utils.iou(gt, pred, [0] * len(pred))
+
+            cls_cost = cdist(gt_label_score, pred_label_score,
+                             self._cls_cost_func)
+
+            cost_matrix = np.zeros((n + 1, m + 1))
+            cost_matrix[:n, :m] = self.alpha * loc_cost + (
+                1 - self.alpha) * cls_cost
+
+            dist_a = np.ones(n + 1)
+            dist_b = np.ones(m + 1)
+
+            # cost for dummy demander / supplier
+            cost_matrix[-1, :] = self.beta
+            cost_matrix[:, -1] = self.beta
+            dist_a[-1] = m
+            dist_b[-1] = n
+
+            ot_matrix = ot.emd(dist_a, dist_b, cost_matrix)
+
+            # post process
+            ot_matrix[-1, -1] = 0
+            ot_matrix /= ot_matrix.sum()
+            ot_cost = (cost_matrix * ot_matrix).sum()
+
+            ot_costs.append(ot_cost)
+
+        return np.mean(ot_costs)
+
+    def compute_metrics(self, results: list) -> dict[str, float]:
+        """Compute the metrics from processed results.
+
+        Args:
+            results (list): The processed results of each batch.
+
+        Returns:
+            Dict[str, float]: The computed metrics. The keys are the names of
+            the metrics, and the values are corresponding results.
+        """
+        logger: MMLogger = MMLogger.get_current_instance()
+
+        # split gt and prediction list
+        gts, preds = zip(*results)
+
+        tmp_dir = None
+        if self.outfile_prefix is None:
+            tmp_dir = tempfile.TemporaryDirectory()
+            outfile_prefix = osp.join(tmp_dir.name, 'results')
+        else:
+            outfile_prefix = self.outfile_prefix
+
+        if self._coco_api is None:
+            # use converted gt json file to initialize coco api
+            logger.info('Converting ground truth to coco format...')
+            coco_json_path = self.gt_to_coco_json(
+                gt_dicts=gts, outfile_prefix=outfile_prefix)
+            self._coco_api = COCO(coco_json_path)
+
+        # handle lazy init
+        if self.cat_ids is None:
+            self.cat_ids = self._coco_api.get_cat_ids(
+                cat_names=self.dataset_meta['classes'])
+        if self.img_ids is None:
+            self.img_ids = self._coco_api.get_img_ids()
+
+        eval_results = OrderedDict()
+
+        for metric in self.metrics:
+            logger.info(f'Evaluating {metric}...')
+
+            mean_ot_costs = self.eval_oc_cost(preds, metric)
+
+            eval_results[f'{metric}_OCCost'] = float(
+                f'{round(mean_ot_costs, 3)}')
+            logger.info(f'{metric}_OCCost: {mean_ot_costs:.3f}')
+
+        if tmp_dir is not None:
+            tmp_dir.cleanup()
+        return eval_results

--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -113,7 +113,11 @@ class GroundingDINO(DINO):
         return tokenized, caption_string, tokens_positive, entities
 
     def get_positive_map(self, tokenized, tokens_positive):
-        positive_map = create_positive_map(tokenized, tokens_positive)
+        positive_map = create_positive_map(
+            tokenized,
+            tokens_positive,
+            max_num_entities=self.bbox_head.cls_branches[
+                self.decoder.num_layers].max_text_len)
         positive_map_label_to_token = create_positive_map_label_to_token(
             positive_map, plus=1)
         return positive_map_label_to_token, positive_map

--- a/mmdet/models/losses/triplet_loss.py
+++ b/mmdet/models/losses/triplet_loss.py
@@ -40,7 +40,7 @@ class TripletLoss(BaseModule):
             inputs (torch.Tensor): feature matrix with shape
                 (batch_size, feat_dim).
             targets (torch.LongTensor): ground truth labels with shape
-                (num_classes).
+                (batch_size).
 
         Returns:
             torch.Tensor: triplet loss with hard mining.

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,5 @@
 cityscapesscripts
 fairscale
 imagecorruptions
+POT
 scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ SPLIT_BEFORE_EXPRESSION_AFTER_OPENING_PAREN = true
 [codespell]
 skip = *.ipynb,configs/v3det/category_name_13204_v3det_2023_v1.txt
 quiet-level = 3
-ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,nam,DOTA,dota,conveyer,singed,comittee
+ignore-words-list = patten,nd,ty,mot,hist,formating,winn,gool,datas,wan,confids,TOOD,tood,ba,warmup,nam,DOTA,dota,conveyer,singed,comittee,OT,ot
 
 [flake8]
 per-file-ignores = mmdet/configs/*: F401,F403,F405

--- a/tests/test_evaluation/test_metrics/test_coco_oc_cost_metric.py
+++ b/tests/test_evaluation/test_metrics/test_coco_oc_cost_metric.py
@@ -1,0 +1,210 @@
+import os.path as osp
+import tempfile
+from unittest import TestCase
+
+import numpy as np
+import pycocotools.mask as mask_util
+import torch
+from mmengine.fileio import dump
+
+from mmdet.evaluation import CocoOCCostMetric
+
+
+class TestCocoOCCostMetric(TestCase):
+
+    def _create_dummy_coco_json(self, json_name):
+        dummy_mask = np.zeros((10, 10), order='F', dtype=np.uint8)
+        dummy_mask[:5, :5] = 1
+        rle_mask = mask_util.encode(dummy_mask)
+        rle_mask['counts'] = rle_mask['counts'].decode('utf-8')
+        image = {
+            'id': 0,
+            'width': 640,
+            'height': 640,
+            'file_name': 'fake_name.jpg',
+        }
+
+        annotation_1 = {
+            'id': 1,
+            'image_id': 0,
+            'category_id': 0,
+            'area': 400,
+            'bbox': [50, 60, 20, 20],
+            'iscrowd': 0,
+            'segmentation': rle_mask,
+        }
+
+        annotation_2 = {
+            'id': 2,
+            'image_id': 0,
+            'category_id': 0,
+            'area': 900,
+            'bbox': [100, 120, 30, 30],
+            'iscrowd': 0,
+            'segmentation': rle_mask,
+        }
+
+        annotation_3 = {
+            'id': 3,
+            'image_id': 0,
+            'category_id': 1,
+            'area': 1600,
+            'bbox': [150, 160, 40, 40],
+            'iscrowd': 0,
+            'segmentation': rle_mask,
+        }
+
+        annotation_4 = {
+            'id': 4,
+            'image_id': 0,
+            'category_id': 0,
+            'area': 10000,
+            'bbox': [250, 260, 100, 100],
+            'iscrowd': 0,
+            'segmentation': rle_mask,
+        }
+
+        categories = [
+            {
+                'id': 0,
+                'name': 'car',
+                'supercategory': 'car',
+            },
+            {
+                'id': 1,
+                'name': 'bicycle',
+                'supercategory': 'bicycle',
+            },
+        ]
+
+        fake_json = {
+            'images': [image],
+            'annotations':
+            [annotation_1, annotation_2, annotation_3, annotation_4],
+            'categories': categories
+        }
+
+        dump(fake_json, json_name)
+
+    def _create_dummy_results(self):
+        bboxes = np.array([[50, 60, 70, 80], [100, 120, 130, 150],
+                           [150, 160, 190, 200], [250, 260, 350, 360]])
+        scores = np.array([1.0, 0.98, 0.96, 0.95])
+        labels = np.array([0, 0, 1, 0])
+        dummy_mask = np.zeros((4, 10, 10), dtype=np.uint8)
+        dummy_mask[:, :5, :5] = 1
+        return dict(
+            bboxes=torch.from_numpy(bboxes),
+            scores=torch.from_numpy(scores),
+            labels=torch.from_numpy(labels),
+            masks=torch.from_numpy(dummy_mask))
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def test_init(self):
+        fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
+        self._create_dummy_coco_json(fake_json_file)
+        with self.assertRaisesRegex(KeyError, 'metric should be one of'):
+            CocoOCCostMetric(ann_file=fake_json_file, metric='unknown')
+
+    def test_evaluate(self):
+        # create dummy data
+        fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
+        self._create_dummy_coco_json(fake_json_file)
+        dummy_pred = self._create_dummy_results()
+
+        # test single coco dataset evaluation
+        coco_metric = CocoOCCostMetric(
+            ann_file=fake_json_file,
+            outfile_prefix=f'{self.tmp_dir.name}/test')
+        coco_metric.dataset_meta = dict(classes=['car', 'bicycle'])
+        coco_metric.process(
+            {},
+            [dict(pred_instances=dummy_pred, img_id=0, ori_shape=(640, 640))])
+        eval_results = coco_metric.evaluate(size=1)
+        target = {'coco/bbox_OCCost': 0.007}
+        self.assertDictEqual(eval_results, target)
+
+        # test box and segm coco dataset evaluation
+        coco_metric = CocoOCCostMetric(
+            ann_file=fake_json_file,
+            metric=['bbox', 'segm'],
+            outfile_prefix=f'{self.tmp_dir.name}/test')
+        coco_metric.dataset_meta = dict(classes=['car', 'bicycle'])
+        coco_metric.process(
+            {},
+            [dict(pred_instances=dummy_pred, img_id=0, ori_shape=(640, 640))])
+        eval_results = coco_metric.evaluate(size=1)
+        target = {'coco/bbox_OCCost': 0.007, 'coco/segm_OCCost': 0.007}
+        self.assertDictEqual(eval_results, target)
+
+    def test_empty_results(self):
+        # create dummy data
+        fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
+        self._create_dummy_coco_json(fake_json_file)
+        coco_metric = CocoOCCostMetric(ann_file=fake_json_file, metric='bbox')
+        coco_metric.dataset_meta = dict(classes=['car', 'bicycle'])
+        bboxes = np.zeros((0, 4))
+        labels = np.array([])
+        scores = np.array([])
+        dummy_mask = np.zeros((0, 10, 10), dtype=np.uint8)
+        empty_pred = dict(
+            bboxes=torch.from_numpy(bboxes),
+            scores=torch.from_numpy(scores),
+            labels=torch.from_numpy(labels),
+            masks=torch.from_numpy(dummy_mask))
+        coco_metric.process(
+            {},
+            [dict(pred_instances=empty_pred, img_id=0, ori_shape=(640, 640))])
+        # coco api Index error will be caught
+        coco_metric.evaluate(size=1)
+
+    def test_evaluate_without_json(self):
+        dummy_pred = self._create_dummy_results()
+
+        dummy_mask = np.zeros((10, 10), order='F', dtype=np.uint8)
+        dummy_mask[:5, :5] = 1
+        rle_mask = mask_util.encode(dummy_mask)
+        rle_mask['counts'] = rle_mask['counts'].decode('utf-8')
+        instances = [{
+            'bbox_label': 0,
+            'bbox': [50, 60, 70, 80],
+            'ignore_flag': 0,
+            'mask': rle_mask,
+        }, {
+            'bbox_label': 0,
+            'bbox': [100, 120, 130, 150],
+            'ignore_flag': 0,
+            'mask': rle_mask,
+        }, {
+            'bbox_label': 1,
+            'bbox': [150, 160, 190, 200],
+            'ignore_flag': 0,
+            'mask': rle_mask,
+        }, {
+            'bbox_label': 0,
+            'bbox': [250, 260, 350, 360],
+            'ignore_flag': 0,
+            'mask': rle_mask,
+        }]
+        coco_metric = CocoOCCostMetric(
+            ann_file=None,
+            metric=['bbox', 'segm'],
+            outfile_prefix=f'{self.tmp_dir.name}/test')
+        coco_metric.dataset_meta = dict(classes=['car', 'bicycle'])
+        coco_metric.process({}, [
+            dict(
+                pred_instances=dummy_pred,
+                img_id=0,
+                ori_shape=(640, 640),
+                instances=instances)
+        ])
+        eval_results = coco_metric.evaluate(size=1)
+        target = {'coco/bbox_OCCost': 0.007, 'coco/segm_OCCost': 0.007}
+        self.assertDictEqual(eval_results, target)
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.gt.json')))


### PR DESCRIPTION
## Motivation

github: https://github.com/mayu-ot/oc-cost
paper: https://arxiv.org/abs/2203.14438

## Use cases (Optional)

```
val_evaluator = dict(
    type="CocoOCCostMetric",
    alpha=0.5,
    beta=0.6,
    ann_file=ann_file,
    metric="bbox",
)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
