### PR TITLE
Enable customization of kernel size in CSPLayer and DarknetBottleneck while preserving previously default kernel size

### DIFF
--- a/mmdet/models/layers/csp_layer.py
+++ b/mmdet/models/layers/csp_layer.py
@@ -201,7 +201,8 @@ class CSPLayer(BaseModule):
                  init_cfg: OptMultiConfig = None) -> None:
         super().__init__(init_cfg=init_cfg)
         block = CSPNeXtBlock if use_cspnext_block else DarknetBottleneck
-        kernel_size = (5 if use_cspnext_block else 3) if kernel_size is None else kernel_size
+        kernel_size = (5 if use_cspnext_block else 3) \
+                        if kernel_size is None else kernel_size
         mid_channels = int(out_channels * expand_ratio)
         self.channel_attention = channel_attention
         self.main_conv = ConvModule(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The default kernel size is 3 in DarknetBottleneck and in CSPLayer when using DarknetBottleneck. However, some network design requires larger kernel size (e.g. [Yolov6 Lite, where the kernel size is 5](https://github.com/meituan/YOLOv6/blob/main/configs/yolov6_lite/README.md)).

## Modification

I enable customization of kernel size in CSPLayer and DarknetBottleneck by adding input parameter `kernel_size` at the end of the formal parameter list, and set to 3 by default.

## BC-breaking (Optional)

This PR doesn't break the BC of the downstream repos.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
