### PR TITLE
fix incorrect kl_div_loss

### DIFF
--- a/configs/ld/ld_r18-gflv1-r101_fpn_1x_coco.py
+++ b/configs/ld/ld_r18-gflv1-r101_fpn_1x_coco.py
@@ -49,7 +49,7 @@ model = dict(
             loss_weight=1.0),
         loss_dfl=dict(type='DistributionFocalLoss', loss_weight=0.25),
         loss_ld=dict(
-            type='KnowledgeDistillationKLDivLoss', loss_weight=0.25, T=10),
+            type='KnowledgeDistillationKLDivLoss', loss_weight=0.25/(16+1), T=10),
         reg_max=16,
         loss_bbox=dict(type='GIoULoss', loss_weight=2.0)),
     # training and testing settings

--- a/mmdet/models/losses/kd_loss.py
+++ b/mmdet/models/losses/kd_loss.py
@@ -31,7 +31,7 @@ def knowledge_distillation_kl_div_loss(pred: Tensor,
         target = target.detach()
 
     kd_loss = F.kl_div(
-        F.log_softmax(pred / T, dim=1), target, reduction='none').mean(1) * (
+        F.log_softmax(pred / T, dim=1), target, reduction='none').sum(-1) * (
             T * T)
 
     return kd_loss


### PR DESCRIPTION
The original `knowledge_distillation_kl_div_loss` in LD was mistakenly implementated as mentioned in https://github.com/HikariTJU/LD/issues/74.

## Motivation

Fix the above issue. Now the kl_div is equal to the definition of KL Div.

## Modification

Change the `knowledge_distillation_kl_div_loss`. And modify the corresponding `loss_weight`, so the final behavior should be identical to the original one.

## BC-breaking (Optional)

No.
