### PR TITLE
Fix freeze_stage in swin.py

### DIFF
--- a/mmdet/models/backbones/swin.py
+++ b/mmdet/models/backbones/swin.py
@@ -641,6 +641,8 @@ class SwinTransformer(BaseModule):
             layer_name = f'norm{i}'
             self.add_module(layer_name, layer)
 
+        self._freeze_stages()
+
     def train(self, mode=True):
         """Convert the model into training mode while keep layers freezed."""
         super(SwinTransformer, self).train(mode)


### PR DESCRIPTION

## Motivation

The motivation behind this PR is to fix the error that occurs when training grounding-dino-swin-t with the argument frozen_stage set in a distributed training. The error occurs because swin.py misses adding self._freeze_stages in __init__(), leading to the optimizer adding the parameters of swin.

## Modification

In this PR, we add self._freeze_stages in __init__() in swin.py.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
