### PR TITLE
Large Image utilities need a local implementation of shift_bbox

### DIFF
--- a/mmdet/utils/large_image.py
+++ b/mmdet/utils/large_image.py
@@ -23,6 +23,22 @@ def shift_rbboxes(bboxes: torch.Tensor, offset: Sequence[int]):
     shifted_bboxes[:, 0:2] = shifted_bboxes[:, 0:2] + offset_tensor
     return shifted_bboxes
 
+def shift_bboxes(bboxes: torch.Tensor, offset: Sequence[int]):
+    """Shift bboxes with offset.
+
+    Args:
+        bboxes (Tensor): The bboxes need to be translated.
+            With shape (n, 4), which means (x, y, x, y).
+        offset (Sequence[int]): The translation offsets with shape of (2, ).
+    Returns:
+        Tensor: Shifted rotated bboxes.
+    """
+    offset_tensor = bboxes.new_tensor(offset)
+    shifted_bboxes = bboxes.clone()
+    shifted_bboxes[:, 0:2] = shifted_bboxes[:, 0:2] + offset_tensor
+    shifted_bboxes[:, 2:4] = shifted_bboxes[:, 2:4] + offset_tensor
+    return shifted_bboxes
+
 
 def shift_predictions(det_data_samples: SampleList,
                       offsets: Sequence[Tuple[int, int]],
@@ -39,7 +55,7 @@ def shift_predictions(det_data_samples: SampleList,
         (List[:obj:`DetDataSample`]): shifted results.
     """
     try:
-        from sahi.slicing import shift_bboxes, shift_masks
+        from sahi.slicing import shift_masks
     except ImportError:
         raise ImportError('Please run "pip install -U sahi" '
                           'to install sahi first for large image inference.')


### PR DESCRIPTION
## Motivation
MMdetection is adding support for large image inference including a demo.
As of today this implementation is heavily dependant on Sahi codebase and maintenance.
I observed an inconsistency between Sahi postprocesing implementation and MMDetection codebase. 
And I am proposing a adding a local function to extend the support alongside stability. 

## Bug
MMDetection models are able to output boxes with negative coordinate values. While this is the case Sahi Bbox class does not support negative values for coordinates.(That's a shame right :) )

Because of the aforementioned problem when using MMDet models(in my case YoloX) the occasional bbox with negative coordinates(this is negative coordinates in the patch not frame) will throw an exception.

## Modification

I am proposing an easy solution by implementing a local version of `shift_bboxes` function instead of importing it from Sahi.

The modifications include writing a new function for `shift_bboxes` and removing the import from Sahi part in `shift_predictions`.

NOTE: shifting masks are still done by Sahi functions

## BC-breaking (Optional)
Modification is seamless and will not break any downstream tasks due to python dynamic linking.

## Use cases (Optional)
This functionality is use in the large image demo.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
