### PR TITLE
Fix wrong size of mask in RTMDet-Ins post-processing.

### DIFF
--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -500,8 +500,8 @@ class RTMDetInsHead(RTMDetHead):
                 mask_logits = F.interpolate(
                     mask_logits,
                     size=[
-                        math.ceil(mask_logits.shape[-2] * scale_factor[0]),
-                        math.ceil(mask_logits.shape[-1] * scale_factor[1])
+                        math.ceil(mask_logits.shape[-2] * scale_factor[1]),
+                        math.ceil(mask_logits.shape[-1] * scale_factor[0])
                     ],
                     mode='bilinear',
                     align_corners=False)[..., :ori_h, :ori_w]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

Fix wrong size of mask in rtmdet-ins post-processing. #11230 

## Modification

Please briefly describe what modification is made in this PR.

```python
            if rescale:
                ori_h, ori_w = img_meta['ori_shape'][:2]
                mask_logits = F.interpolate(
                    mask_logits,
                    size=[
                        math.ceil(mask_logits.shape[-2] * scale_factor[1]),  # modified scale_factor[0] to scale_factor[1]
                        math.ceil(mask_logits.shape[-1] * scale_factor[0])  # modified scale_factor[1] to scale_factor[0]
                    ],
                    mode='bilinear',
                    align_corners=False)[..., :ori_h, :ori_w]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
