### PR TITLE
fix cocometric if result not exists

### DIFF
--- a/mmdet/evaluation/metrics/coco_metric.py
+++ b/mmdet/evaluation/metrics/coco_metric.py
@@ -448,23 +448,20 @@ class CocoMetric(BaseMetric):
             iou_type = 'bbox' if metric == 'proposal' else metric
             if metric not in result_files:
                 raise KeyError(f'{metric} is not in results')
-            try:
-                predictions = load(result_files[metric])
-                if iou_type == 'segm':
-                    # Refer to https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/coco.py#L331  # noqa
-                    # When evaluating mask AP, if the results contain bbox,
-                    # cocoapi will use the box area instead of the mask area
-                    # for calculating the instance area. Though the overall AP
-                    # is not affected, this leads to different
-                    # small/medium/large mask AP results.
-                    for x in predictions:
-                        x.pop('bbox')
+            predictions = load(result_files[metric])
+            if iou_type == 'segm':
+                # Refer to https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/coco.py#L331  # noqa
+                # When evaluating mask AP, if the results contain bbox,
+                # cocoapi will use the box area instead of the mask area
+                # for calculating the instance area. Though the overall AP
+                # is not affected, this leads to different
+                # small/medium/large mask AP results.
+                for x in predictions:
+                    x.pop('bbox')
+            if len(predictions) > 0:
                 coco_dt = self._coco_api.loadRes(predictions)
-
-            except IndexError:
-                logger.error(
-                    'The testing results of the whole dataset is empty.')
-                break
+            else:
+                coco_dt = COCO()
 
             if self.use_mp_eval:
                 coco_eval = COCOevalMP(self._coco_api, coco_dt, iou_type)

--- a/tests/test_evaluation/test_metrics/test_coco_metric.py
+++ b/tests/test_evaluation/test_metrics/test_coco_metric.py
@@ -305,8 +305,18 @@ class TestCocoMetric(TestCase):
         coco_metric.process(
             {},
             [dict(pred_instances=empty_pred, img_id=0, ori_shape=(640, 640))])
-        # coco api Index error will be caught
-        coco_metric.evaluate(size=1)
+        eval_results = coco_metric.evaluate(size=1)
+        target = {
+            'coco/bbox_mAP': 0.0,
+            'coco/bbox_mAP_50': 0.0,
+            'coco/bbox_mAP_75': 0.0,
+            'coco/bbox_mAP_s': 0.0,
+            'coco/bbox_mAP_m': 0.0,
+            'coco/bbox_mAP_l': 0.0,
+        }
+        self.assertDictEqual(eval_results, target)
+        self.assertTrue(
+            osp.isfile(osp.join(self.tmp_dir.name, 'test.bbox.json')))
 
     def test_evaluate_without_json(self):
         dummy_pred = self._create_dummy_results()


### PR DESCRIPTION
## Motivation

When evaluating a small number of images, inference results may not be obtained, and cocometric may not terminate normally.

## Modification

Fixed to use empty COCO class when the inference result json file is empty.

## BC-breaking (Optional)

nothing

## Use cases (Optional)

Since it is a minor case, it seems that just modifying the unit test is sufficient.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
