### PR TITLE
Fixed mask shape after Albu postprocess

### DIFF
--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1766,7 +1766,7 @@ class Albu(BaseTransform):
                     results['masks'] = np.array(
                         [results['masks'][i] for i in results['idx_mapper']])
                     results['masks'] = ori_masks.__class__(
-                        results['masks'], ori_masks.height, ori_masks.width)
+                        results['masks'], results['masks'][0].shape[0], results['masks'][0].shape[1])
 
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1766,8 +1766,9 @@ class Albu(BaseTransform):
                     results['masks'] = np.array(
                         [results['masks'][i] for i in results['idx_mapper']])
                     results['masks'] = ori_masks.__class__(
-                        results['masks'], results['masks'][0].shape[0], results['masks'][0].shape[1])
-
+                        results['masks'], 
+                        results['masks'][0].shape[0], 
+                        results['masks'][0].shape[1])
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):
                     return None

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1766,10 +1766,9 @@ class Albu(BaseTransform):
                     results['masks'] = np.array(
                         [results['masks'][i] for i in results['idx_mapper']])
                     results['masks'] = ori_masks.__class__(
-                        results["masks"] = ori_masks.__class__(
-                        results["masks"],
-                        results["masks"][0].shape[0],
-                        results["masks"][0].shape[1],
+                        results['masks'],
+                        results['masks'][0].shape[0],
+                        results['masks'][0].shape[1],
                     )
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1766,9 +1766,11 @@ class Albu(BaseTransform):
                     results['masks'] = np.array(
                         [results['masks'][i] for i in results['idx_mapper']])
                     results['masks'] = ori_masks.__class__(
-                        results['masks'], 
-                        results['masks'][0].shape[0], 
-                        results['masks'][0].shape[1])
+                        results["masks"] = ori_masks.__class__(
+                        results["masks"],
+                        results["masks"][0].shape[0],
+                        results["masks"][0].shape[1],
+                    )
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):
                     return None


### PR DESCRIPTION
## Motivation

If the augmented image (mask) is for example rotated by 90 or 270 deg. using "RandomRotate90" and the original image (mask) is rectangular, it could end up with height and width inverted, therefore we need to use dimensions of the augmented mask (image) to convert.

## Modification

Take the augmented mask shape instead of the original mask shape. 

## BC-breaking (Optional)

None.

## Use cases (Optional)

RandomRotate90

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
