### PR TITLE
The input for the argument k of top k is expected to be int.

### DIFF
--- a/mmdet/models/task_modules/assigners/sim_ota_assigner.py
+++ b/mmdet/models/task_modules/assigners/sim_ota_assigner.py
@@ -202,7 +202,7 @@ class SimOTAAssigner(BaseAssigner):
         dynamic_ks = torch.clamp(topk_ious.sum(0).int(), min=1)
         for gt_idx in range(num_gt):
             _, pos_idx = torch.topk(
-                cost[:, gt_idx], k=dynamic_ks[gt_idx], largest=False)
+                cost[:, gt_idx], k=dynamic_ks[gt_idx].item(), largest=False)
             matching_matrix[:, gt_idx][pos_idx] = 1
 
         del topk_ious, dynamic_ks, pos_idx


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
dynamic_k_matching of SimOTAAsigner bug fix 


## Modification

The input for the argument k of top k is expected to be int. However, tensor is input.
so, add .item() to tensor.

## Checklist
...