### PR TITLE
replace '.jpg' instead of 'jpg' to guarantee replacing file ending

### DIFF
--- a/mmdet/datasets/api_wrappers/coco_api.py
+++ b/mmdet/datasets/api_wrappers/coco_api.py
@@ -92,7 +92,7 @@ class COCOPanoptic(COCO):
         if 'images' in self.dataset:
             for img_info in self.dataset['images']:
                 img_info['segm_file'] = img_info['file_name'].replace(
-                    'jpg', 'png')
+                    '.jpg', '.png')
                 imgs[img_info['id']] = img_info
 
         if 'categories' in self.dataset:

--- a/mmdet/datasets/coco_panoptic.py
+++ b/mmdet/datasets/coco_panoptic.py
@@ -208,7 +208,7 @@ class CocoPanopticDataset(CocoDataset):
         if self.data_prefix.get('seg', None):
             seg_map_path = osp.join(
                 self.data_prefix['seg'],
-                img_info['file_name'].replace('jpg', 'png'))
+                img_info['file_name'].replace('.jpg', '.png'))
         else:
             seg_map_path = None
         data_info['img_path'] = img_path

--- a/mmdet/evaluation/metrics/coco_panoptic_metric.py
+++ b/mmdet/evaluation/metrics/coco_panoptic_metric.py
@@ -190,7 +190,7 @@ class CocoPanopticMetric(BaseMetric):
                 }
                 segments_info.append(new_segment_info)
 
-            segm_file = image_info['file_name'].replace('jpg', 'png')
+            segm_file = image_info['file_name'].replace('.jpg', '.png')
             annotation = dict(
                 image_id=img_id,
                 segments_info=segments_info,

--- a/mmdet/evaluation/metrics/coco_panoptic_metric.py
+++ b/mmdet/evaluation/metrics/coco_panoptic_metric.py
@@ -330,7 +330,7 @@ class CocoPanopticMetric(BaseMetric):
             # parse pred
             img_id = data_sample['img_id']
             segm_file = osp.basename(data_sample['img_path']).replace(
-                'jpg', 'png')
+                '.jpg', '.png')
             result = self._parse_predictions(
                 pred=data_sample,
                 img_id=img_id,
@@ -397,7 +397,7 @@ class CocoPanopticMetric(BaseMetric):
             # parse pred
             img_id = data_sample['img_id']
             segm_file = osp.basename(data_sample['img_path']).replace(
-                'jpg', 'png')
+                '.jpg', '.png')
             result = self._parse_predictions(
                 pred=data_sample, img_id=img_id, segm_file=segm_file)
 


### PR DESCRIPTION
The Mapillary Vistas Dataset validation split contains random strings as filenames, one of which has 'jpg' as part of the random filename. 

this results in a file not found error during validation when training with mapillary vistas dataset as a panoptic dataset

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The Mapillary Vistas Dataset validation split contains random strings as filenames, one of which has 'jpg' as part of the random filename. 

this results in a file not found error during validation when training with mapillary vistas dataset as a panoptic dataset

## Modification

replace '.jpg' instead of 'jpg' with '.png'

## BC-breaking (Optional)

no braking changes.

## Use cases (Optional)

bug fix for widespread panoptic dataset: Mapillary Vistas Dataset.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
