### PR TITLE
Fix for None

### DIFF
--- a/mmdet/apis/det_inferencer.py
+++ b/mmdet/apis/det_inferencer.py
@@ -195,6 +195,8 @@ class DetInferencer(BaseInferencer):
             Visualizer or None: Visualizer initialized with config.
         """
         visualizer = super()._init_visualizer(cfg)
+        if visualizer is None:
+            return None
         visualizer.dataset_meta = self.model.dataset_meta
         return visualizer
 


### PR DESCRIPTION
## Motivation

A crash is found if there is no visualizer in the config file. Check [this line of code](https://github.com/open-mmlab/mmengine/blob/main/mmengine/infer/infer.py#L565) . This fix addresses this crash.

## Modification

To protect from the crash, more modifications might be needed in the `mmengine` repo.