### PR TITLE
Feat: Load datasets from huggingface hub

### DIFF
--- a/mmdet/datasets/__init__.py
+++ b/mmdet/datasets/__init__.py
@@ -15,6 +15,7 @@ from .deepfashion import DeepFashionDataset
 from .dod import DODDataset
 from .dsdl import DSDLDetDataset
 from .flickr30k import Flickr30kDataset
+from .huggingface import HuggingFaceDataset
 from .isaid import iSAIDDataset
 from .lvis import LVISDataset, LVISV1Dataset, LVISV05Dataset
 from .mdetr_style_refcoco import MDETRStyleRefCocoDataset
@@ -49,5 +50,5 @@ __all__ = [
     'BaseSegDataset', 'ADE20KSegDataset', 'CocoSegDataset',
     'ADE20KInstanceDataset', 'iSAIDDataset', 'V3DetDataset', 'ConcatDataset',
     'ODVGDataset', 'MDETRStyleRefCocoDataset', 'DODDataset',
-    'CustomSampleSizeSampler', 'Flickr30kDataset'
+    'CustomSampleSizeSampler', 'Flickr30kDataset', 'HuggingFaceDataset'
 ]

--- a/mmdet/datasets/huggingface.py
+++ b/mmdet/datasets/huggingface.py
@@ -1,0 +1,130 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Callable, List, Optional, Union
+
+from datasets import Dataset as HFDataset
+from datasets import IterableDataset as HFIterableDataset
+from datasets import load_dataset
+from mmengine.dataset import Compose
+from torch.utils.data import Dataset as TorchDataset
+
+from mmdet.registry import DATASETS
+
+
+def _decode_batched_data(batched_data):
+    data_list = []
+    for values in zip(*batched_data.values()):
+        data_list.append(dict(zip(batched_data.keys(), values)))
+    return data_list
+
+
+def _encode_batched_data(data_list):
+    batched_data = {}
+    for key in data_list[0].keys():
+        batched_data[key] = [data[key] for data in data_list]
+    return batched_data
+
+
+@DATASETS.register_module()
+class HuggingFaceDataset(TorchDataset):
+
+    def __init__(self,
+                 repo: str,
+                 split: str = 'train',
+                 pipeline: Optional[List[Union[dict, Callable]]] = None,
+                 classes: Optional[Union[List[str], str]] = None,
+                 streaming: bool = False,
+                 max_samples: Optional[int] = None,
+                 *args,
+                 lazy_init: bool = True,
+                 max_refetch: int = 20,
+                 **kwargs):
+        if pipeline is None:
+            pipeline = []
+
+        self.repo = repo
+        self.pipeline = Compose(pipeline)
+        self.streaming = streaming
+        self.max_samples = max_samples
+
+        self._lazy_init = lazy_init
+        self.max_refetch = max_refetch
+
+        self.dataset: Union[HFDataset, HFIterableDataset] = load_dataset(
+            self.repo,
+            *args,
+            split=split,
+            **kwargs,
+        )
+
+        self.metainfo = {}
+
+        if isinstance(classes, List):
+            self.metainfo['classes'] = classes
+        if isinstance(classes, str):
+            self.metainfo['classes'] = self._get_feature(classes).names
+        else:
+            self.metainfo['classes'] = self._get_feature(
+                'objects.category').names
+
+        if self._lazy_init:
+            self.dataset.set_transform(self.prepare_batched_data)
+        else:
+            self.dataset.map(self.prepare_data)
+
+        super().__init__()
+
+    def _get_feature(self, key):
+        if isinstance(key, str):
+            key = key.split('.')
+        feature = self.dataset
+        for k in key[:-1]:
+            feature = feature.features[k]
+        return feature.feature[key[-1]]
+
+    def prepare_batched_data(self, batched_data):
+        data_list = _decode_batched_data(batched_data)
+        data_list = [self.prepare_data(data) for data in data_list]
+        return _encode_batched_data(data_list)
+
+    def prepare_data(self, item):
+        result = self.pipeline(item)
+
+        # XXX: There’s a randomly occurring bug here.
+        #      after going through self.pipeline,
+        #      there’s a significant chance it returns None.
+        #      The same content can be fixed by calling self.pipeline again.
+        if result is None:
+            for _ in range(self.max_refetch):
+                result = self.pipeline(item)
+                if result is not None:
+                    break
+            else:
+                err = f'returned None from dataset at item {item}.'
+                raise RuntimeError(err)
+
+        return result
+
+    def __getitem__(self, idx):
+        if self.max_samples is not None and idx >= self.max_samples:
+            raise IndexError(
+                f'Index {idx} out of range for dataset of length {len(self)}.')
+
+        return self.dataset[idx]
+
+    def __iter__(self):
+        for idx, item in enumerate(self.dataset):
+            if self.max_samples is not None and idx >= self.max_samples:
+                break
+
+            yield self.dataset[idx]
+
+    def __len__(self):
+        if isinstance(self.dataset, HFIterableDataset):
+            if self.max_samples is None:
+                raise ValueError('Cannot get length of streaming dataset. '
+                                 'Please specify `max_samples`.')
+            return self.max_samples
+        else:
+            if self.max_samples is not None:
+                return min(len(self.dataset), self.max_samples)
+            return len(self.dataset)

--- a/mmdet/datasets/transforms/__init__.py
+++ b/mmdet/datasets/transforms/__init__.py
@@ -8,6 +8,8 @@ from .formatting import (ImageToTensor, PackDetInputs, PackReIDInputs,
 from .frame_sampling import BaseFrameSample, UniformRefFrameSample
 from .geometric import (GeomTransform, Rotate, ShearX, ShearY, TranslateX,
                         TranslateY)
+from .huggingface import (LoadAnnotationsFromHuggingface,
+                          LoadImageFromHuggingface)
 from .instaboost import InstaBoost
 from .loading import (FilterAnnotations, InferencerLoader, LoadAnnotations,
                       LoadEmptyAnnotations, LoadImageFromNDArray,
@@ -41,5 +43,6 @@ __all__ = [
     'LoadTrackAnnotations', 'BaseFrameSample', 'UniformRefFrameSample',
     'PackTrackInputs', 'PackReIDInputs', 'FixScaleResize',
     'ResizeShortestEdge', 'GTBoxSubOne_GLIP', 'RandomFlip_GLIP',
-    'RandomSamplingNegPos', 'LoadTextAnnotations'
+    'RandomSamplingNegPos', 'LoadTextAnnotations', 'LoadImageFromHuggingface',
+    'LoadAnnotationsFromHuggingface'
 ]

--- a/mmdet/datasets/transforms/huggingface.py
+++ b/mmdet/datasets/transforms/huggingface.py
@@ -1,0 +1,191 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+from mmcv.transforms import BaseTransform
+from PIL import Image, ImageOps
+
+from mmdet.datasets.transforms import LoadAnnotations, LoadImageFromNDArray
+from mmdet.registry import TRANSFORMS
+
+
+def _get_dict_value(data: Dict[str, Any], key: Union[str, List[str]]):
+    if isinstance(key, str):
+        key = key.split('.')
+    for k in key:
+        data = data[k]
+    return data
+
+
+# Copy from mmcv
+# https://github.com/open-mmlab/mmcv/blob/c7c02a7c5ba25d37c7f7928013ffb3016e254eb9/mmcv/image/io.py#L87-L141
+def _pillow2array(img, flag='color', channel_order='bgr'):
+    """Convert a pillow image to numpy array.
+
+    Args:
+        img (:obj:`PIL.Image.Image`): The image loaded using PIL
+        flag (str): Flags specifying the color type of a loaded image,
+            candidates are 'color', 'grayscale' and 'unchanged'.
+            Default to 'color'.
+        channel_order (str): The channel order of the output image array,
+            candidates are 'bgr' and 'rgb'. Default to 'bgr'.
+
+    Returns:
+        np.ndarray: The converted numpy array
+    """
+    channel_order = channel_order.lower()
+    if channel_order not in ['rgb', 'bgr']:
+        raise ValueError('channel order must be either "rgb" or "bgr"')
+
+    if flag == 'unchanged':
+        array = np.array(img)
+        if array.ndim >= 3 and array.shape[2] >= 3:  # color image
+            array[:, :, :3] = array[:, :, (2, 1, 0)]  # RGB to BGR
+    else:
+        # Handle exif orientation tag
+        if flag in ['color', 'grayscale']:
+            img = ImageOps.exif_transpose(img)
+        # If the image mode is not 'RGB', convert it to 'RGB' first.
+        if img.mode != 'RGB':
+            if img.mode != 'LA':
+                # Most formats except 'LA' can be directly converted to RGB
+                img = img.convert('RGB')
+            else:
+                # When the mode is 'LA', the default conversion will fill in
+                #  the canvas with black, which sometimes shadows black objects
+                #  in the foreground.
+                #
+                # Therefore, a random color (124, 117, 104) is used for canvas
+                img_rgba = img.convert('RGBA')
+                img = Image.new('RGB', img_rgba.size, (124, 117, 104))
+                img.paste(img_rgba, mask=img_rgba.split()[3])  # 3 is alpha
+        if flag in ['color', 'color_ignore_orientation']:
+            array = np.array(img)
+            if channel_order != 'rgb':
+                array = array[:, :, ::-1]  # RGB to BGR
+        elif flag in ['grayscale', 'grayscale_ignore_orientation']:
+            img = img.convert('L')
+            array = np.array(img)
+        else:
+            raise ValueError(
+                'flag must be "color", "grayscale", "unchanged", '
+                f'"color_ignore_orientation" or "grayscale_ignore_orientation"'
+                f' but got {flag}')
+    return array
+
+
+@TRANSFORMS.register_module()
+class LoadImageFromHuggingface(BaseTransform):
+
+    def __init__(self,
+                 img_prefix='image',
+                 color_mode='color',
+                 to_float32=False):
+        super().__init__()
+
+        self.img_prefix = img_prefix
+
+        self.color_mode = color_mode
+        self.to_float32 = to_float32
+
+        self._loader = LoadImageFromNDArray(to_float32=to_float32, )
+
+    def transform(self,
+                  results: Dict) -> Optional[Union[Dict, Tuple[List, List]]]:
+        img = _get_dict_value(results, self.img_prefix)
+        img = _pillow2array(img, flag=self.color_mode)
+
+        results['img'] = img
+        results['width'] = img.shape[1]
+        results['height'] = img.shape[0]
+
+        return self._loader.transform(results)
+
+
+@TRANSFORMS.register_module()
+class LoadAnnotationsFromHuggingface(BaseTransform):
+
+    def __init__(self,
+                 bbox_label_prefix='objects.category',
+                 bbox_prefix=None,
+                 mask_prefix=None,
+                 ignore_flag_prefix=None,
+                 seg_map_prefix=None,
+                 with_mask: bool = False,
+                 poly2mask: bool = True,
+                 box_type: str = 'hbox',
+                 reduce_zero_label: bool = False,
+                 ignore_index: int = 255,
+                 **kwargs):
+        super().__init__()
+        self.bbox_prefix = bbox_prefix
+        self.bbox_label_prefix = bbox_label_prefix
+        self.mask_prefix = mask_prefix
+        self.ignore_flag_prefix = ignore_flag_prefix
+        self.seg_map_prefix = seg_map_prefix
+
+        self._load_annotations = LoadAnnotations(
+            with_mask=with_mask,
+            poly2mask=poly2mask,
+            box_type=box_type,
+            reduce_zero_label=reduce_zero_label,
+            ignore_index=ignore_index,
+            **kwargs)
+
+    def transform(self,
+                  results: Dict) -> Optional[Union[Dict, Tuple[List, List]]]:
+        instances = []
+
+        weight = results['width']
+        height = results['height']
+
+        try:
+            label_list = _get_dict_value(results, self.bbox_label_prefix)
+        except KeyError:
+            raise ValueError(
+                f'No key {self.bbox_label_prefix} found in results')
+
+        if self.bbox_prefix is not None:
+            bbox_list = _get_dict_value(results, self.bbox_prefix)
+        else:
+            bbox_list = None
+
+        if self.mask_prefix is not None:
+            mask_list = _get_dict_value(results, self.mask_prefix)
+        else:
+            mask_list = None
+
+        if self.ignore_flag_prefix is not None:
+            ignore_flag_list = _get_dict_value(results,
+                                               self.ignore_flag_prefix)
+        else:
+            ignore_flag_list = None
+
+        for i, label in enumerate(label_list):
+            instance = {'bbox_label': label}
+
+            if bbox_list is not None:
+                bbox = bbox_list[i]
+                x1, y1, w, h = bbox
+                inter_w = max(0, min(x1 + w, weight) - max(x1, 0))
+                inter_h = max(0, min(y1 + h, height) - max(y1, 0))
+                if inter_w * inter_h == 0:
+                    continue
+                bbox = [x1, y1, x1 + w, y1 + h]
+                instance['bbox'] = bbox
+
+            if mask_list is not None:
+                mask = mask_list[i]
+                instance['mask'] = mask
+
+            if ignore_flag_list is not None:
+                ignore_flag = ignore_flag_list[i]
+                instance['ignore_flag'] = ignore_flag
+            else:
+                instance['ignore_flag'] = 0
+
+            instances.append(instance)
+
+        results['instances'] = instances
+
+        return self._load_annotations.transform(results)


### PR DESCRIPTION
Add a loader to the mmdet.datasets module to download and load datasets from the huggingface hub.
#11378 

## Motivation

In our use case, this will help leverage datasets to manage dataset caching, which is faster than downloading from the original server.
It will also help in achieving streaming (e.g., using the WebDatasets module in [datasets](https://huggingface.co/docs/hub/datasets-webdataset#webdataset)), which is crucial for large datasets like ImageNet.

## Modification

`HuggingFaceDataset` has been added to the `mmdet.datasets` module.
`LoadImageFromHuggingface` and `LoadAnnotationsFromHuggingface` have been added to the `mmdet.datasets.transforms` module.

## About Unit Test

I have confirmed that the modified content can run on the cppe-5 dataset and the loss function is changing normally, as well as other metrics such as mAP, by running a complete rtmdet training loop. 
I also wrote a simple unit test, but downloading dataset takes some time, and I am not sure if this will break the CI Pipeline, so I have not submitted it for now.

**Can someone tell me how to handle unit tests in case that may slow down the CI pipeline?**