### PR TITLE
[fix] use image instead of ori_mask to get shape

### DIFF
--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1767,8 +1767,8 @@ class Albu(BaseTransform):
                         [results['masks'][i] for i in results['idx_mapper']])
                     results['masks'] = ori_masks.__class__(
                         results['masks'],
-                        results['masks'][0].shape[0],
-                        results['masks'][0].shape[1],
+                        results['image'].shape[0],
+                        results['image'].shape[1],
                     )
                 if (not len(results['idx_mapper'])
                         and self.skip_img_without_anno):


### PR DESCRIPTION
## Motivation

Fix https://github.com/open-mmlab/mmdetection/issues/11422

## Modification

Use augmented image shape instead of first mask shape.
