### PR TITLE
[Fix] Mismatch Between bboxes and scores During NMS in Confusion Matrix Calculation

### DIFF
--- a/tools/analysis_tools/confusion_matrix.py
+++ b/tools/analysis_tools/confusion_matrix.py
@@ -131,9 +131,11 @@ def analyze_per_img_dets(confusion_matrix,
         det_scores = result['scores'][mask].numpy()
 
         if nms_iou_thr:
-            det_bboxes, _ = nms(
+            dets, _ = nms(
                 det_bboxes, det_scores, nms_iou_thr, score_threshold=score_thr)
-        ious = bbox_overlaps(det_bboxes[:, :4], gt_bboxes)
+            det_bboxes = dets[:, :-1]
+            det_scores = dets[:, -1]
+        ious = bbox_overlaps(det_bboxes, gt_bboxes)
         for i, score in enumerate(det_scores):
             det_match = 0
             if score >= score_thr:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When running NMS within the `calculate_confusion_matrix` function, there is a bug where `det_scores` is not reduced even if `det_bboxes` is reduced.
The goal it to fix this bug.

## Modification

Instead of overwriting `det_bboxes` with the output (concatenation of `det_bboxes` and `det_scores`) of the function `nms`, I modified it to store the output in `dets` once and then split it into `det_bboxes` and `det_scores`.
This allows `det_scores` to match `det_bboxes`.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
