### PR TITLE
copy to cpu without oom

### DIFF
--- a/mmdet/utils/memory.py
+++ b/mmdet/utils/memory.py
@@ -160,15 +160,15 @@ class AvoidOOM:
                                  'cannot get dtype and device.')
 
             # Convert to FP16
-            fp16_args = cast_tensor_type(args, dst_type=torch.half)
-            fp16_kwargs = cast_tensor_type(kwargs, dst_type=torch.half)
             logger = MMLogger.get_current_instance()
-            logger.warning(f'Attempting to copy inputs of {str(func)} '
-                           'to FP16 due to CUDA OOM')
-
-            # get input tensor type, the output type will same as
-            # the first parameter type.
             with _ignore_torch_cuda_oom():
+                fp16_args = cast_tensor_type(args, dst_type=torch.half)
+                fp16_kwargs = cast_tensor_type(kwargs, dst_type=torch.half)
+                logger.warning(f'Attempting to copy inputs of {str(func)} '
+                            'to FP16 due to CUDA OOM')
+
+                # get input tensor type, the output type will same as
+                # the first parameter type.
                 output = func(*fp16_args, **fp16_kwargs)
                 output = cast_tensor_type(
                     output, src_type=torch.half, dst_type=dtype)


### PR DESCRIPTION
## Motivation
![image](https://github.com/open-mmlab/mmdetection/assets/46431181/8efec0c0-7b93-4bc7-94e2-cf02b89c95e1)
The "function AvoidCUDAOOM.retry_if_cuda_oom" couldnot ensure successful copy of input to cpu or  convert to FP16, since the copy function may cause cuda oom in the process without ignoring the error and skip other attempt.

## Modification

The inputs is casted to FP16 while ignore cuda_oom