### PR TITLE
Update grounding_dino_swin-t_pretrain_obj365.py, adding GIOU loss.

### DIFF
--- a/configs/mm_grounding_dino/grounding_dino_swin-t_pretrain_obj365.py
+++ b/configs/mm_grounding_dino/grounding_dino_swin-t_pretrain_obj365.py
@@ -100,7 +100,8 @@ model = dict(
             gamma=2.0,
             alpha=0.25,
             loss_weight=1.0),  # 2.0 in DeformDETR
-        loss_bbox=dict(type='L1Loss', loss_weight=5.0)),
+        loss_bbox=dict(type='L1Loss', loss_weight=5.0),
+        loss_iou=dict(type='GIoULoss', loss_weight=2.0)),
     dn_cfg=dict(  # TODO: Move to model.train_cfg ?
         label_noise_scale=0.5,
         box_noise_scale=1.0,  # 0.4 for DN-DETR


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

GIOU loss was missed in MM grounding dino pretraining configs.

## Modification

Now GIOU loss is added.
