### PR TITLE
Add missing entry of 'isthing' for  coco panoptic in customize dataset

### DIFF
--- a/docs/en/advanced_guides/customize_dataset.md
+++ b/docs/en/advanced_guides/customize_dataset.md
@@ -395,7 +395,7 @@ The annotation json files in COCO Panoptic format has the following necessary ke
 ]
 
 'categories': [  # including both foreground categories and background categories
-    {'id': 0, 'name': 'person'},
+    {'id': 0, 'name': 'person', 'isthing': 1},
     ...
  ]
 ```


### PR DESCRIPTION
## Motivation

I created a customized dataset for coco panoptic segmentation by following mmdetection/docs/en/advanced_guides/customize_dataset.md.

In the description, we can find

```
categories': [  # including both foreground categories and background categories
    {'id': 0, 'name': 'person'},
    ...
```
 
A dataset created like this will cause errors, as the attribute 'isthing' is required. I first realized it in _browse_dataset.py_ which breaks using the panoptic coco dataset format according to customized_dataset.md.

See 

![Screenshot from 2024-02-21 12-05-00](https://github.com/open-mmlab/mmdetection/assets/11892623/426f6b21-00af-4a59-a26a-dd26102f816a)

This holds  even if _metainfo_ is defined as 

```
metainfo = dict(
        classes = ('class1','class2',... ),
        thing_classes = ('class1',... ),
        stuff_classes = ('class2',...)
        )

```
and is given to _train_dataloader_ etc.

## Modification

I would recommend changing the line 

```
categories': [  # including both foreground categories and background categories
    {'id': 0, 'name': 'person'},
```
to

```
categories': [  # including both foreground categories and background categories
    {'id': 0, 'name': 'person', 'isthing': 1},
```
so that it matches the original coco panoptic description and prevents errors in mmdetection. 

## PS
Thank you guys so much for your awesome work in mmdetection!

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
