### PR TITLE
Solving issue #11362. Creating nltk_data in the $HOME directory.

### DIFF
--- a/configs/mm_grounding_dino/usage.md
+++ b/configs/mm_grounding_dino/usage.md
@@ -38,9 +38,11 @@ tokenizer.save_pretrained("your path/bert-base-uncased")
 When MM Grounding DINO performs Phrase Grounding inference, it may extract noun phrases. Although it downloads specific models at runtime, considering that some users' running environments cannot connect to the internet, it is possible to download them in advance to the `~/nltk_data` path.
 
 ```python
+import os
 import nltk
-nltk.download('punkt', download_dir='~/nltk_data')
-nltk.download('averaged_perceptron_tagger', download_dir='~/nltk_data')
+download_dir = os.path.expanduser('~/nltk_data')
+nltk.download('punkt', download_dir=download_dir)
+nltk.download('averaged_perceptron_tagger', download_dir=download_dir)
 ```
 
 ### Download MM Grounding DINO-T Weight

--- a/configs/mm_grounding_dino/usage_zh-CN.md
+++ b/configs/mm_grounding_dino/usage_zh-CN.md
@@ -38,9 +38,11 @@ tokenizer.save_pretrained("your path/bert-base-uncased")
 MM Grounding DINO 在进行 Phrase Grounding 推理时候可能会进行名词短语提取，虽然会在运行时候下载特定的模型，但是考虑到有些用户运行环境无法联网，因此可以提前下载到 `~/nltk_data` 路径下
 
 ```python
+import os
 import nltk
-nltk.download('punkt', download_dir='~/nltk_data')
-nltk.download('averaged_perceptron_tagger', download_dir='~/nltk_data')
+download_dir = os.path.expanduser('~/nltk_data')
+nltk.download('punkt', download_dir=download_dir)
+nltk.download('averaged_perceptron_tagger', download_dir=download_dir)
 ```
 
 ### MM Grounding DINO-T 模型权重下载

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+import os
 import re
 import warnings
 from typing import Optional, Tuple, Union
@@ -26,7 +27,6 @@ def find_noun_phrases(caption: str) -> list:
         >>> find_noun_phrases(caption) # ['cat', 'a remote', 'the picture']
     """
     try:
-        import os
         import nltk
         download_dir = os.path.expanduser('~/nltk_data')
         nltk.download('punkt', download_dir=download_dir)

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -26,9 +26,11 @@ def find_noun_phrases(caption: str) -> list:
         >>> find_noun_phrases(caption) # ['cat', 'a remote', 'the picture']
     """
     try:
+        import os
         import nltk
-        nltk.download('punkt', download_dir='~/nltk_data')
-        nltk.download('averaged_perceptron_tagger', download_dir='~/nltk_data')
+        download_dir = os.path.expanduser('~/nltk_data')
+        nltk.download('punkt', download_dir=download_dir)
+        nltk.download('averaged_perceptron_tagger', download_dir=download_dir)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '
                            'pip install nltk.')


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The motivation is to solve issue #11362. NLTK default download creates a weird folder in the project directory level named `~/nltk_data`,  when it seems the intention is to create this at the $HOME directory.

## Modification

I solve this issue using `os` library to efectively substitute `~` by `$HOME` directory. I modify it in the code and also in the related documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
