### PR TITLE
add support for custom input & output channels in mobileNetV2

### DIFF
--- a/mmdet/models/backbones/mobilenet_v2.py
+++ b/mmdet/models/backbones/mobilenet_v2.py
@@ -49,6 +49,7 @@ class MobileNetV2(BaseModule):
                  out_indices=(1, 2, 4, 7),
                  frozen_stages=-1,
                  input_channels=3,
+                 output_channels=1280,
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),
                  act_cfg=dict(type='ReLU6'),
@@ -121,9 +122,9 @@ class MobileNetV2(BaseModule):
             self.layers.append(layer_name)
 
         if widen_factor > 1.0:
-            self.out_channel = int(1280 * widen_factor)
+            self.out_channel = int(output_channels * widen_factor)
         else:
-            self.out_channel = 1280
+            self.out_channel = output_channels
 
         layer = ConvModule(
             in_channels=self.in_channels,

--- a/mmdet/models/backbones/mobilenet_v2.py
+++ b/mmdet/models/backbones/mobilenet_v2.py
@@ -48,6 +48,7 @@ class MobileNetV2(BaseModule):
                  widen_factor=1.,
                  out_indices=(1, 2, 4, 7),
                  frozen_stages=-1,
+                 input_channels=3,
                  conv_cfg=None,
                  norm_cfg=dict(type='BN'),
                  act_cfg=dict(type='ReLU6'),
@@ -96,7 +97,7 @@ class MobileNetV2(BaseModule):
         self.in_channels = make_divisible(32 * widen_factor, 8)
 
         self.conv1 = ConvModule(
-            in_channels=3,
+            in_channels=input_channels,
             out_channels=self.in_channels,
             kernel_size=3,
             stride=2,


### PR DESCRIPTION
Changes : 

1. Added custom number of input_channels, so that anyone can use mobileNetV2 for single channel as well as 3 channel images.
2.  Added custom number of output_channels for mobileNetV2.