### PR TITLE
fix BUG of SSDHead when predict

### DIFF
--- a/mmdet/models/dense_heads/base_dense_head.py
+++ b/mmdet/models/dense_heads/base_dense_head.py
@@ -373,7 +373,8 @@ class BaseDenseHead(BaseModule, metaclass=ABCMeta):
             # the `custom_cls_channels` parameter is derived from
             # CrossEntropyCustomLoss and FocalCustomLoss, and is currently used
             # in v3det.
-            if getattr(self.loss_cls, 'custom_cls_channels', False):
+            if hasattr(self, 'loss_cls') and getattr(
+                    self.loss_cls, 'custom_cls_channels', False):
                 scores = self.loss_cls.get_activation(cls_score)
             elif self.use_sigmoid_cls:
                 scores = cls_score.sigmoid()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I meet a bug when predict with ssd 
**'SSDHead' object has no attribute 'loss_cls'**
on mmdet/models/dense_heads/base_dense_head.py L376:
```
if getattr(self.loss_cls, 'custom_cls_channels', False):
```


## Modification
I fix it by change this line to:
```
if hasattr(self, 'loss_cls') and getattr(self.loss_cls, 'custom_cls_channels', False):
```


## Use cases (Optional)
```
from mmdet.apis import DetInferencer

inferencer = DetInferencer('ssd512_coco')

inferencer('demo/demo.jpg', show=False, out_dir='demo/result')
```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
