### PR TITLE
Update train.md to have runable example

### DIFF
--- a/docs/en/user_guides/train.md
+++ b/docs/en/user_guides/train.md
@@ -339,7 +339,7 @@ def convert_balloon_to_coco(ann_file, out_file, image_prefix):
     annotations = []
     images = []
     obj_count = 0
-    for idx, v in enumerate(track_iter_progress(data_infos.values())):
+    for idx, v in enumerate(track_iter_progress(list(data_infos.values()))):
         filename = v['filename']
         img_path = osp.join(image_prefix, filename)
         height, width = mmcv.imread(img_path).shape[:2]


### PR DESCRIPTION
## Motivation
I wish to fix the example to make it runable
When trying it I experienced the following error:
```
Traceback (most recent call last):
  File "convert_balloon_to_coco.py", line 55, in <module>
    convert_balloon_to_coco(ann_file='./balloon/train/via_region_data.json',
  File "convert_balloon_to_coco.py", line 15, in convert_balloon_to_coco
    for idx, v in enumerate(track_iter_progress(data_infos.values())):
  File ".../site-packages/mmengine/utils/progressbar.py", line 240, in track_iter_progress
    raise TypeError(
TypeError: "tasks" must be a tuple object or a sequence object, but got <class 'dict_values'>
```

## Modification

Convert dict_values to list before iterating on it

4. The documentation has been modified accordingly, like docstring or example tutorials.
