### PR TITLE
Fixed channel order RGB bug in the inference Code

### DIFF
--- a/demo/MMDet_InstanceSeg_Tutorial.ipynb
+++ b/demo/MMDet_InstanceSeg_Tutorial.ipynb
@@ -2068,9 +2068,10 @@
     "import mmcv\n",
     "from mmdet.apis import init_detector, inference_detector\n",
     "img = mmcv.imread('./ballondatasets/balloon/train/7178882742_f090f3ce56_k.jpg',channel_order='rgb')\n",
+    "img_bgr = mmcv.imread('./ballondatasets/balloon/train/7178882742_f090f3ce56_k.jpg',channel_order='bgr')\n",
     "checkpoint_file = 'tutorial_exps/epoch_12.pth'\n",
     "model = init_detector(cfg, checkpoint_file, device='cpu')\n",
-    "new_result = inference_detector(model, img)\n",
+    "new_result = inference_detector(model, img_bgr)\n",
     "print(new_result)"
    ]
   },


### PR DESCRIPTION
## Motivation

The inference section of the tutorial jupyter notebook takes the input image as RGB. This affects the performance of the detector as the detector is trained with BGR format. This effect is not apparent in the provided ballon dataset but can have a huge impact depending on the dataset.

## Modification

RGB bug in the inference Code is fixed by creating another variable for image. The model is then sent the image in BGR format and the visualizer is sent the image in RGB format.
`import mmcv
from mmdet.apis import init_detector, inference_detector
img = mmcv.imread('./ballondatasets/balloon/train/7178882742_f090f3ce56_k.jpg',channel_order='rgb')
img_bgr = mmcv.imread('./ballondatasets/balloon/train/7178882742_f090f3ce56_k.jpg',channel_order='bgr')
checkpoint_file = 'tutorial_exps/epoch_12.pth'
model = init_detector(cfg, checkpoint_file, device='cpu')
new_result = inference_detector(model, img_bgr)
print(new_result)`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
No sure


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
