### PR TITLE
fix(depreciation): np >= 1.20 dtype long is int_

### DIFF
--- a/mmdet/datasets/transforms/text_transformers.py
+++ b/mmdet/datasets/transforms/text_transformers.py
@@ -60,7 +60,7 @@ def check_for_positive_overflow(gt_bboxes, gt_labels, text, tokenizer,
             keep_gt_labels.append(gt_labels[i])
 
     return gt_bboxes[keep_box_index], np.array(
-        keep_gt_labels, dtype=np.long), length
+        keep_gt_labels, dtype=np.int_), length
 
 
 def generate_senetence_given_labels(positive_label_list, negative_label_list,

--- a/tests/test_models/test_dense_heads/test_lad_head.py
+++ b/tests/test_models/test_dense_heads/test_lad_head.py
@@ -25,7 +25,7 @@ class TestLADHead(TestCase):
                 pass
 
             def predict(self, loss):
-                components = np.zeros_like(loss, dtype=np.long)
+                components = np.zeros_like(loss, dtype=np.int_)
                 return components.reshape(-1)
 
             def score_samples(self, loss):

--- a/tests/test_models/test_dense_heads/test_paa_head.py
+++ b/tests/test_models/test_dense_heads/test_paa_head.py
@@ -25,7 +25,7 @@ class TestPAAHead(TestCase):
                 pass
 
             def predict(self, loss):
-                components = np.zeros_like(loss, dtype=np.long)
+                components = np.zeros_like(loss, dtype=np.int_)
                 return components.reshape(-1)
 
             def score_samples(self, loss):


### PR DESCRIPTION
## Motivation

When I was trying to run a small notebook to explore the Obj365 dataset I get an error of a numpy depreciation. Since numpy 1.20, the use of `np.long` is deprecated. https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations

So I run the following command to get the occurrence of the use of `np.long` in the repo.

```bash
$ fgrep -r -n np.long mmdet tools tests configs
mmdet/datasets/transforms/text_transformers.py:63:        keep_gt_labels, dtype=np.long), length
tests/test_models/test_dense_heads/test_lad_head.py:28:                components = np.zeros_like(loss, dtype=np.long)
tests/test_models/test_dense_heads/test_paa_head.py:28:                components = np.zeros_like(loss, dtype=np.long)
```

## Modification

This minor commit just rename the `np.long` to `np.int_`. 

## BC-breaking (Optional)

I do not know what is the impact on this change on numpy versions before. My dev env is based on Python 3.10 so it is not compatible with numpy version <= 1.21.1. Although, only concerning this change, I tested on another dev env of mine and there is no problem to use `np.int_`, it is a correct data type for Numpy.

Maybe pin the version of numpy prior 1.20.0 in the requirements/build.txt if you do not want to use this commit? So there would not be any depreciation.