### PR TITLE
Remove unused kwarray

### DIFF
--- a/mmdet/models/roi_heads/bbox_heads/bbox_head.py
+++ b/mmdet/models/roi_heads/bbox_heads/bbox_head.py
@@ -597,7 +597,6 @@ class BBoxHead(BaseModule):
             list[:obj:`InstanceData`]: Refined bboxes of each image.
 
         Example:
-            >>> # xdoctest: +REQUIRES(module:kwarray)
             >>> import numpy as np
             >>> from mmdet.models.task_modules.samplers.
             ... sampling_result import random_boxes

--- a/projects/Detic_new/detic/detic_bbox_head.py
+++ b/projects/Detic_new/detic/detic_bbox_head.py
@@ -337,7 +337,6 @@ class DeticBBoxHead(Shared2FCBBoxHead):
             list[:obj:`InstanceData`]: Refined bboxes of each image.
 
         Example:
-            >>> # xdoctest: +REQUIRES(module:kwarray)
             >>> import numpy as np
             >>> from mmdet.models.task_modules.samplers.
             ... sampling_result import random_boxes

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,8 +6,6 @@ imagecorruptions
 instaboostfast
 interrogate
 isort==4.3.21
-# Note: used for kwarray.group_items, this may be ported to mmcv in the future.
-kwarray
 memory_profiler
 -e git+https://github.com/open-mmlab/mmtracking@dev-1.x#egg=mmtrack
 nltk


### PR DESCRIPTION
I introduced the test dependency kwarray in https://github.com/open-mmlab/mmdetection/pull/1962 and it appears it is no longer used. This PR finishes removing it as a dependency. 