### PR TITLE
Fix: some bugs when text input reaches max_tokens of language_model

### DIFF
--- a/mmdet/datasets/transforms/text_transformers.py
+++ b/mmdet/datasets/transforms/text_transformers.py
@@ -60,7 +60,7 @@ def check_for_positive_overflow(gt_bboxes, gt_labels, text, tokenizer,
             keep_gt_labels.append(gt_labels[i])
 
     return gt_bboxes[keep_box_index], np.array(
-        keep_gt_labels, dtype=np.long), length
+        keep_gt_labels, dtype=np.long), length, keep_box_index
 
 
 def generate_senetence_given_labels(positive_label_list, negative_label_list,
@@ -164,7 +164,7 @@ class RandomSamplingNegPos(BaseTransform):
             if '/' in value:
                 text[key] = random.choice(value.split('/')).strip()
 
-        gt_bboxes, gt_labels, positive_caption_length = \
+        gt_bboxes, gt_labels, positive_caption_length, keep_box_index = \
             check_for_positive_overflow(gt_bboxes, gt_labels,
                                         text, self.tokenizer, self.max_tokens)
 
@@ -232,6 +232,8 @@ class RandomSamplingNegPos(BaseTransform):
 
         results['gt_bboxes'] = gt_bboxes
         results['gt_bboxes_labels'] = gt_labels
+        if results.get('gt_ignore_flags', None) is not None:
+            results['gt_ignore_flags'] = results['gt_ignore_flags'][keep_box_index]
 
         results['text'] = pheso_caption
         results['tokens_positive'] = label_to_positions

--- a/mmdet/datasets/transforms/text_transformers.py
+++ b/mmdet/datasets/transforms/text_transformers.py
@@ -217,7 +217,7 @@ class RandomSamplingNegPos(BaseTransform):
 
             negative_max_length -= len(tokenized)
 
-            if negative_max_length > 0:
+            if negative_max_length >= 0:
                 screened_negative_label_list.append(negative_label)
             else:
                 break

--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -162,7 +162,8 @@ class GroundingDINO(DINO):
                 [caption_string],
                 padding='max_length'
                 if self.language_model.pad_to_max else 'longest',
-                return_tensors='pt')
+                return_tensors='pt',
+                add_special_tokens=False)
             entities = original_caption
         else:
             if not original_caption.endswith('.'):
@@ -175,7 +176,8 @@ class GroundingDINO(DINO):
                 [original_caption],
                 padding='max_length'
                 if self.language_model.pad_to_max else 'longest',
-                return_tensors='pt')
+                return_tensors='pt',
+                add_special_tokens=False)
             tokens_positive, noun_phrases = run_ner(original_caption)
             entities = noun_phrases
             caption_string = original_caption
@@ -224,7 +226,8 @@ class GroundingDINO(DINO):
                     [original_caption],
                     padding='max_length'
                     if self.language_model.pad_to_max else 'longest',
-                    return_tensors='pt')
+                    return_tensors='pt',
+                    add_special_tokens=False)
                 positive_map_label_to_token, positive_map = \
                     self.get_positive_map(tokenized, tokens_positive)
 
@@ -281,7 +284,8 @@ class GroundingDINO(DINO):
                 caption_string, tokens_positive = self.to_plain_text_prompts(
                     original_caption_chunked[i])
             tokenized = self.language_model.tokenizer([caption_string],
-                                                      return_tensors='pt')
+                                                      return_tensors='pt',
+                                                      add_special_tokens=False)
             if tokenized.input_ids.shape[1] > self.language_model.max_tokens:
                 warnings.warn('Inputting a text that is too long will result '
                               'in poor prediction performance. '
@@ -439,7 +443,8 @@ class GroundingDINO(DINO):
                     [text_prompt],
                     padding='max_length'
                     if self.language_model.pad_to_max else 'longest',
-                    return_tensors='pt')
+                    return_tensors='pt',
+                    add_special_tokens=False)
                 new_tokens_positive = [
                     token_positive[label.item()] for label in gt_label
                 ]
@@ -477,7 +482,7 @@ class GroundingDINO(DINO):
                     positive_maps.append(positive_map)
                     new_text_prompts.append(caption_string)
 
-        text_dict = self.language_model(new_text_prompts)
+        text_dict = self.language_model(new_text_prompts, add_special_tokens=False)
         if self.text_feat_map is not None:
             text_dict['embedded'] = self.text_feat_map(text_dict['embedded'])
 
@@ -553,7 +558,7 @@ class GroundingDINO(DINO):
             for b in range(len(text_prompts[0])):
                 text_prompts_once = [text_prompts[0][b]]
                 token_positive_maps_once = token_positive_maps[0][b]
-                text_dict = self.language_model(text_prompts_once)
+                text_dict = self.language_model(text_prompts_once, add_special_tokens=False)
                 # text feature map layer
                 if self.text_feat_map is not None:
                     text_dict['embedded'] = self.text_feat_map(
@@ -577,7 +582,7 @@ class GroundingDINO(DINO):
             is_rec_tasks = [False] * len(results_list)
         else:
             # extract text feats
-            text_dict = self.language_model(list(text_prompts))
+            text_dict = self.language_model(list(text_prompts), add_special_tokens=False)
             # text feature map layer
             if self.text_feat_map is not None:
                 text_dict['embedded'] = self.text_feat_map(


### PR DESCRIPTION
Fix 1: RandomSamplingNegPos forget to remove gt_ignore_flags

在https://github.com/open-mmlab/mmdetection/blob/dev-3.x/mmdet/datasets/transforms/formatting.py#L109 中，会根据valid_idx = np.where(results['gt_ignore_flags'] == 0)[0]来获得valid_idx，并通过valid_idx从gt_bboxes中取得有效的bboxes。

在https://github.com/open-mmlab/mmdetection/blob/dev-3.x/mmdet/datasets/transforms/text_transformers.py#L62 中，如果positive labels的token数之和超过了256，会随机删掉一部分gt_bboxes和gt_labels，但是没有对gt_ignore_flags进行相应的处理，导致在PackDetInputs中，通过valid_idx从gt_bboxes中取得有效的bboxes会出现index越界error。

参考[RandomCrop](https://github.com/open-mmlab/mmdetection/blob/dev-3.x/mmdet/datasets/transforms/transforms.py#L928)中处理gt_ignore_flags的方式对RandomSamplingNegPos进行相应的修改