### PR TITLE
CopyPaste bugfix - result['img'] not in src image dtype

### DIFF
--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -3132,6 +3132,9 @@ class CopyPaste(BaseTransform):
 
         # update masks and generate bboxes from updated masks
         composed_mask = np.where(np.any(src_masks.masks, axis=0), 1, 0)
+        # Min and max values are inside the uint8 range, so cast it
+        # accordingly to the source image type
+        composed_mask = composed_mask.astype(src_img.dtype)
         updated_dst_masks = self._get_updated_masks(dst_masks, composed_mask)
         updated_dst_bboxes = updated_dst_masks.get_bboxes(type(dst_bboxes))
         assert len(updated_dst_bboxes) == len(updated_dst_masks)


### PR DESCRIPTION
## Motivation

Bugfixing CopyPaste: indices multiplication was creating a `results['img']` `int64` dtype, now it's casted to the `src_img` dtype.


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
