### PR TITLE
PipelineSwitchHook now compatible with MultiImageMixDataset

### DIFF
--- a/mmdet/engine/hooks/pipeline_switch_hook.py
+++ b/mmdet/engine/hooks/pipeline_switch_hook.py
@@ -32,7 +32,7 @@ class PipelineSwitchHook(Hook):
             # Make it compatible with MultiImageMixDataset
             if hasattr(train_loader.dataset, 'dataset'):
                 # Set the loading pipeline to the identity function
-                # Keep it compatible with "scale_factor" key, which 
+                # Keep it compatible with "scale_factor" key, which
                 # is not available otherwise.
                 train_loader.dataset.pipeline = Compose([lambda x: x])
                 # Rewrite the inner pipeline with the one given

--- a/mmdet/engine/hooks/pipeline_switch_hook.py
+++ b/mmdet/engine/hooks/pipeline_switch_hook.py
@@ -29,6 +29,17 @@ class PipelineSwitchHook(Hook):
             # The dataset pipeline cannot be updated when persistent_workers
             # is True, so we need to force the dataloader's multi-process
             # restart. This is a very hacky approach.
+            # Make it compatible with MultiImageMixDataset
+            if hasattr(train_loader.dataset, "dataset"):
+                # Set the loading pipeline to the identity function
+                # Keep it compatible with "scale_factor" key, which 
+                # is not available otherwise.
+                train_loader.dataset.pipeline = Compose([lambda x: x])
+                # Rewrite the inner pipeline with the one given
+                train_loader.dataset.dataset.pipeline = Compose(self.switch_pipeline)
+            else:
+                train_loader.dataset.pipeline = \
+                    Compose(self.switch_pipeline)
             train_loader.dataset.pipeline = Compose(self.switch_pipeline)
             if hasattr(train_loader, 'persistent_workers'
                        ) and train_loader.persistent_workers is True:

--- a/mmdet/engine/hooks/pipeline_switch_hook.py
+++ b/mmdet/engine/hooks/pipeline_switch_hook.py
@@ -36,7 +36,8 @@ class PipelineSwitchHook(Hook):
                 # is not available otherwise.
                 train_loader.dataset.pipeline = Compose([lambda x: x])
                 # Rewrite the inner pipeline with the one given
-                train_loader.dataset.dataset.pipeline = Compose(self.switch_pipeline)
+                train_loader.dataset.dataset.pipeline = \
+                    Compose(self.switch_pipeline)
             else:
                 train_loader.dataset.pipeline = \
                     Compose(self.switch_pipeline)

--- a/mmdet/engine/hooks/pipeline_switch_hook.py
+++ b/mmdet/engine/hooks/pipeline_switch_hook.py
@@ -30,7 +30,7 @@ class PipelineSwitchHook(Hook):
             # is True, so we need to force the dataloader's multi-process
             # restart. This is a very hacky approach.
             # Make it compatible with MultiImageMixDataset
-            if hasattr(train_loader.dataset, "dataset"):
+            if hasattr(train_loader.dataset, 'dataset'):
                 # Set the loading pipeline to the identity function
                 # Keep it compatible with "scale_factor" key, which 
                 # is not available otherwise.


### PR DESCRIPTION
## Motivation
The switch pipeline was not compatible with MultImageMixDataset: it only replaced the `loading_pipeline` of the outer (`MultiImageMixDataset`) dataset. With this modification, the loading pipeline is set to the identity function, and the inner (train_pipeline) is rewritten with the one provided to the hook.
