### PR TITLE
Fix NLTK Download and add Verbose Flag for GLIP

### DIFF
--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -28,8 +28,10 @@ def find_noun_phrases(caption: str, verbose: bool = True) -> list:
     """
     try:
         import nltk
-        nltk.download('punkt', download_dir=expanduser('~/nltk_data'), quiet=not verbose)
-        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'), quiet=not verbose)
+        nltk.download('punkt', download_dir=expanduser('~/nltk_data'),
+                      quiet=not verbose)
+        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'),
+                      quiet=not verbose)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '
                            'pip install nltk.')
@@ -77,7 +79,7 @@ def run_ner(caption: str, verbose: bool = False) -> Tuple[list, list]:
             - tokens_positive (List): A list of token positions.
             - noun_phrases (List): A list of noun phrases.
     """
-    noun_phrases = find_noun_phrases(caption,verbose=verbose)
+    noun_phrases = find_noun_phrases(caption, verbose=verbose)
     noun_phrases = [remove_punctuation(phrase) for phrase in noun_phrases]
     noun_phrases = [phrase for phrase in noun_phrases if phrase != '']
     if verbose:
@@ -303,7 +305,8 @@ class GLIP(SingleStageDetector):
             original_caption = original_caption.strip(self._special_tokens)
             tokenized = self.language_model.tokenizer([original_caption],
                                                       return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption, verbose=verbose)
+            tokens_positive, noun_phrases = run_ner(original_caption,
+                                                    verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -321,7 +324,7 @@ class GLIP(SingleStageDetector):
         custom_entities: bool = False,
         enhanced_text_prompt: Optional[ConfigType] = None,
         tokens_positive: Optional[list] = None,
-        verbose:bool = False
+        verbose: bool = False
     ) -> Tuple[dict, str, Tensor, list]:
         if tokens_positive is not None:
             if tokens_positive == -1:

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -30,7 +30,8 @@ def find_noun_phrases(caption: str, verbose: bool = True) -> list:
         import nltk
         nltk.download('punkt', download_dir=expanduser('~/nltk_data'),
                       quiet=not verbose)
-        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'),
+        nltk.download('averaged_perceptron_tagger',
+                      download_dir=expanduser('~/nltk_data'),
                       quiet=not verbose)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -2,6 +2,7 @@
 import copy
 import re
 import warnings
+from os.path import expanduser
 from typing import Optional, Tuple, Union
 
 import torch
@@ -11,7 +12,6 @@ from mmdet.registry import MODELS
 from mmdet.structures import SampleList
 from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig
 from .single_stage import SingleStageDetector
-from os.path import expanduser
 
 
 def find_noun_phrases(caption: str, verbose: bool = True) -> list:
@@ -28,11 +28,12 @@ def find_noun_phrases(caption: str, verbose: bool = True) -> list:
     """
     try:
         import nltk
-        nltk.download('punkt', download_dir=expanduser('~/nltk_data'),
-                      quiet=not verbose)
-        nltk.download('averaged_perceptron_tagger',
-                      download_dir=expanduser('~/nltk_data'),
-                      quiet=not verbose)
+        nltk.download(
+            'punkt', download_dir=expanduser('~/nltk_data'), quiet=not verbose)
+        nltk.download(
+            'averaged_perceptron_tagger',
+            download_dir=expanduser('~/nltk_data'),
+            quiet=not verbose)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '
                            'pip install nltk.')
@@ -276,12 +277,11 @@ class GLIP(SingleStageDetector):
         return caption_string, tokens_positive
 
     def get_tokens_and_prompts(
-        self,
-        original_caption: Union[str, list, tuple],
-        custom_entities: bool = False,
-        enhanced_text_prompts: Optional[ConfigType] = None,
-        verbose: bool = False
-    ) -> Tuple[dict, str, list, list]:
+            self,
+            original_caption: Union[str, list, tuple],
+            custom_entities: bool = False,
+            enhanced_text_prompts: Optional[ConfigType] = None,
+            verbose: bool = False) -> Tuple[dict, str, list, list]:
         """Get the tokens positive and prompts for the caption."""
         if isinstance(original_caption, (list, tuple)) or custom_entities:
             if custom_entities and isinstance(original_caption, str):
@@ -306,8 +306,8 @@ class GLIP(SingleStageDetector):
             original_caption = original_caption.strip(self._special_tokens)
             tokenized = self.language_model.tokenizer([original_caption],
                                                       return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption,
-                                                    verbose=verbose)
+            tokens_positive, noun_phrases = run_ner(
+                original_caption, verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -320,13 +320,12 @@ class GLIP(SingleStageDetector):
         return positive_map_label_to_token, positive_map
 
     def get_tokens_positive_and_prompts(
-        self,
-        original_caption: Union[str, list, tuple],
-        custom_entities: bool = False,
-        enhanced_text_prompt: Optional[ConfigType] = None,
-        tokens_positive: Optional[list] = None,
-        verbose: bool = False
-    ) -> Tuple[dict, str, Tensor, list]:
+            self,
+            original_caption: Union[str, list, tuple],
+            custom_entities: bool = False,
+            enhanced_text_prompt: Optional[ConfigType] = None,
+            tokens_positive: Optional[list] = None,
+            verbose: bool = False) -> Tuple[dict, str, Tensor, list]:
         if tokens_positive is not None:
             if tokens_positive == -1:
                 if not original_caption.endswith('.'):
@@ -418,7 +417,8 @@ class GLIP(SingleStageDetector):
             positive_map_chunked, \
             entities_chunked
 
-    def loss(self, batch_inputs: Tensor,
+    def loss(self,
+             batch_inputs: Tensor,
              batch_data_samples: SampleList,
              verbose: bool = False) -> Union[dict, list]:
         # TODO: Only open vocabulary tasks are supported for training now.

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -28,8 +28,8 @@ def find_noun_phrases(caption: str, verbose: bool = True) -> list:
     """
     try:
         import nltk
-        nltk.download('punkt', download_dir=expanduser('~/nltk_data'), quiet=verbose)
-        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'), quiet=verbose)
+        nltk.download('punkt', download_dir=expanduser('~/nltk_data'), quiet=not verbose)
+        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'), quiet=not verbose)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '
                            'pip install nltk.')

--- a/mmdet/models/detectors/glip.py
+++ b/mmdet/models/detectors/glip.py
@@ -11,9 +11,10 @@ from mmdet.registry import MODELS
 from mmdet.structures import SampleList
 from mmdet.utils import ConfigType, OptConfigType, OptMultiConfig
 from .single_stage import SingleStageDetector
+from os.path import expanduser
 
 
-def find_noun_phrases(caption: str) -> list:
+def find_noun_phrases(caption: str, verbose: bool = True) -> list:
     """Find noun phrases in a caption using nltk.
     Args:
         caption (str): The caption to analyze.
@@ -27,8 +28,8 @@ def find_noun_phrases(caption: str) -> list:
     """
     try:
         import nltk
-        nltk.download('punkt', download_dir='~/nltk_data')
-        nltk.download('averaged_perceptron_tagger', download_dir='~/nltk_data')
+        nltk.download('punkt', download_dir=expanduser('~/nltk_data'), quiet=verbose)
+        nltk.download('averaged_perceptron_tagger', download_dir=expanduser('~/nltk_data'), quiet=verbose)
     except ImportError:
         raise RuntimeError('nltk is not installed, please install it by: '
                            'pip install nltk.')
@@ -66,7 +67,7 @@ def remove_punctuation(text: str) -> str:
     return text.strip()
 
 
-def run_ner(caption: str) -> Tuple[list, list]:
+def run_ner(caption: str, verbose: bool = False) -> Tuple[list, list]:
     """Run NER on a caption and return the tokens and noun phrases.
     Args:
         caption (str): The input caption.
@@ -76,10 +77,11 @@ def run_ner(caption: str) -> Tuple[list, list]:
             - tokens_positive (List): A list of token positions.
             - noun_phrases (List): A list of noun phrases.
     """
-    noun_phrases = find_noun_phrases(caption)
+    noun_phrases = find_noun_phrases(caption,verbose=verbose)
     noun_phrases = [remove_punctuation(phrase) for phrase in noun_phrases]
     noun_phrases = [phrase for phrase in noun_phrases if phrase != '']
-    print('noun_phrases:', noun_phrases)
+    if verbose:
+        print('noun_phrases:', noun_phrases)
     relevant_phrases = noun_phrases
     labels = noun_phrases
 
@@ -274,7 +276,8 @@ class GLIP(SingleStageDetector):
         self,
         original_caption: Union[str, list, tuple],
         custom_entities: bool = False,
-        enhanced_text_prompts: Optional[ConfigType] = None
+        enhanced_text_prompts: Optional[ConfigType] = None,
+        verbose: bool = False
     ) -> Tuple[dict, str, list, list]:
         """Get the tokens positive and prompts for the caption."""
         if isinstance(original_caption, (list, tuple)) or custom_entities:
@@ -300,7 +303,7 @@ class GLIP(SingleStageDetector):
             original_caption = original_caption.strip(self._special_tokens)
             tokenized = self.language_model.tokenizer([original_caption],
                                                       return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption)
+            tokens_positive, noun_phrases = run_ner(original_caption, verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -318,6 +321,7 @@ class GLIP(SingleStageDetector):
         custom_entities: bool = False,
         enhanced_text_prompt: Optional[ConfigType] = None,
         tokens_positive: Optional[list] = None,
+        verbose:bool = False
     ) -> Tuple[dict, str, Tensor, list]:
         if tokens_positive is not None:
             if tokens_positive == -1:
@@ -354,7 +358,8 @@ class GLIP(SingleStageDetector):
         else:
             tokenized, caption_string, tokens_positive, entities = \
                 self.get_tokens_and_prompts(
-                    original_caption, custom_entities, enhanced_text_prompt)
+                    original_caption, custom_entities, enhanced_text_prompt,
+                    verbose=verbose)
             positive_map_label_to_token, positive_map = self.get_positive_map(
                 tokenized, tokens_positive)
             if tokenized.input_ids.shape[1] > self.language_model.max_tokens:
@@ -367,7 +372,8 @@ class GLIP(SingleStageDetector):
     def get_tokens_positive_and_prompts_chunked(
             self,
             original_caption: Union[list, tuple],
-            enhanced_text_prompts: Optional[ConfigType] = None):
+            enhanced_text_prompts: Optional[ConfigType] = None,
+            verbose: bool = False):
         chunked_size = self.test_cfg.get('chunked_size', -1)
         original_caption = [clean_label_name(i) for i in original_caption]
 
@@ -409,7 +415,8 @@ class GLIP(SingleStageDetector):
             entities_chunked
 
     def loss(self, batch_inputs: Tensor,
-             batch_data_samples: SampleList) -> Union[dict, list]:
+             batch_data_samples: SampleList,
+             verbose: bool = False) -> Union[dict, list]:
         # TODO: Only open vocabulary tasks are supported for training now.
         text_prompts = [
             data_samples.text for data_samples in batch_data_samples
@@ -427,7 +434,7 @@ class GLIP(SingleStageDetector):
             # so there is no need to calculate them multiple times.
             tokenized, caption_string, tokens_positive, _ = \
                 self.get_tokens_and_prompts(
-                    text_prompts[0], True)
+                    text_prompts[0], True, verbose=verbose)
             new_text_prompts = [caption_string] * len(batch_inputs)
             for gt_label in gt_labels:
                 new_tokens_positive = [
@@ -440,7 +447,7 @@ class GLIP(SingleStageDetector):
             for text_prompt, gt_label in zip(text_prompts, gt_labels):
                 tokenized, caption_string, tokens_positive, _ = \
                     self.get_tokens_and_prompts(
-                        text_prompt, True)
+                        text_prompt, True, verbose=verbose)
                 new_tokens_positive = [
                     tokens_positive[label] for label in gt_label
                 ]

--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -177,7 +177,8 @@ class GroundingDINO(DINO):
                 padding='max_length'
                 if self.language_model.pad_to_max else 'longest',
                 return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption, verbose=verbose)
+            tokens_positive, noun_phrases = run_ner(original_caption,
+                                                    verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -252,7 +253,8 @@ class GroundingDINO(DINO):
         else:
             tokenized, caption_string, tokens_positive, entities = \
                 self.get_tokens_and_prompts(
-                    original_caption, custom_entities, enhanced_text_prompt, verbose=verbose)
+                    original_caption, custom_entities, enhanced_text_prompt,
+                    verbose=verbose)
             positive_map_label_to_token, positive_map = self.get_positive_map(
                 tokenized, tokens_positive)
         return positive_map_label_to_token, caption_string, \
@@ -458,7 +460,7 @@ class GroundingDINO(DINO):
                 # so there is no need to calculate them multiple times.
                 tokenized, caption_string, tokens_positive, _ = \
                     self.get_tokens_and_prompts(
-                        text_prompts[0], True, verbose = verbose)
+                        text_prompts[0], True, verbose=verbose)
                 new_text_prompts = [caption_string] * len(batch_inputs)
                 for gt_label in gt_labels:
                     new_tokens_positive = [

--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -135,7 +135,8 @@ class GroundingDINO(DINO):
         self,
         original_caption: Union[str, list, tuple],
         custom_entities: bool = False,
-        enhanced_text_prompts: Optional[ConfigType] = None
+        enhanced_text_prompts: Optional[ConfigType] = None,
+        verbose: bool = False
     ) -> Tuple[dict, str, list]:
         """Get the tokens positive and prompts for the caption."""
         if isinstance(original_caption, (list, tuple)) or custom_entities:
@@ -176,7 +177,7 @@ class GroundingDINO(DINO):
                 padding='max_length'
                 if self.language_model.pad_to_max else 'longest',
                 return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption)
+            tokens_positive, noun_phrases = run_ner(original_caption, verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -198,6 +199,7 @@ class GroundingDINO(DINO):
         custom_entities: bool = False,
         enhanced_text_prompt: Optional[ConfigType] = None,
         tokens_positive: Optional[list] = None,
+        verbose: bool = False
     ) -> Tuple[dict, str, Tensor, list]:
         """Get the tokens positive and prompts for the caption.
 
@@ -250,7 +252,7 @@ class GroundingDINO(DINO):
         else:
             tokenized, caption_string, tokens_positive, entities = \
                 self.get_tokens_and_prompts(
-                    original_caption, custom_entities, enhanced_text_prompt)
+                    original_caption, custom_entities, enhanced_text_prompt, verbose=verbose)
             positive_map_label_to_token, positive_map = self.get_positive_map(
                 tokenized, tokens_positive)
         return positive_map_label_to_token, caption_string, \
@@ -417,7 +419,8 @@ class GroundingDINO(DINO):
         return decoder_inputs_dict, head_inputs_dict
 
     def loss(self, batch_inputs: Tensor,
-             batch_data_samples: SampleList) -> Union[dict, list]:
+             batch_data_samples: SampleList,
+             verbose: bool = False) -> Union[dict, list]:
         text_prompts = [
             data_samples.text for data_samples in batch_data_samples
         ]
@@ -455,7 +458,7 @@ class GroundingDINO(DINO):
                 # so there is no need to calculate them multiple times.
                 tokenized, caption_string, tokens_positive, _ = \
                     self.get_tokens_and_prompts(
-                        text_prompts[0], True)
+                        text_prompts[0], True, verbose = verbose)
                 new_text_prompts = [caption_string] * len(batch_inputs)
                 for gt_label in gt_labels:
                     new_tokens_positive = [
@@ -468,7 +471,7 @@ class GroundingDINO(DINO):
                 for text_prompt, gt_label in zip(text_prompts, gt_labels):
                     tokenized, caption_string, tokens_positive, _ = \
                         self.get_tokens_and_prompts(
-                            text_prompt, True)
+                            text_prompt, True,  verbose=verbose)
                     new_tokens_positive = [
                         tokens_positive[label] for label in gt_label
                     ]

--- a/mmdet/models/detectors/grounding_dino.py
+++ b/mmdet/models/detectors/grounding_dino.py
@@ -132,12 +132,11 @@ class GroundingDINO(DINO):
         return caption_string, tokens_positive
 
     def get_tokens_and_prompts(
-        self,
-        original_caption: Union[str, list, tuple],
-        custom_entities: bool = False,
-        enhanced_text_prompts: Optional[ConfigType] = None,
-        verbose: bool = False
-    ) -> Tuple[dict, str, list]:
+            self,
+            original_caption: Union[str, list, tuple],
+            custom_entities: bool = False,
+            enhanced_text_prompts: Optional[ConfigType] = None,
+            verbose: bool = False) -> Tuple[dict, str, list]:
         """Get the tokens positive and prompts for the caption."""
         if isinstance(original_caption, (list, tuple)) or custom_entities:
             if custom_entities and isinstance(original_caption, str):
@@ -177,8 +176,8 @@ class GroundingDINO(DINO):
                 padding='max_length'
                 if self.language_model.pad_to_max else 'longest',
                 return_tensors='pt')
-            tokens_positive, noun_phrases = run_ner(original_caption,
-                                                    verbose=verbose)
+            tokens_positive, noun_phrases = run_ner(
+                original_caption, verbose=verbose)
             entities = noun_phrases
             caption_string = original_caption
 
@@ -195,13 +194,12 @@ class GroundingDINO(DINO):
         return positive_map_label_to_token, positive_map
 
     def get_tokens_positive_and_prompts(
-        self,
-        original_caption: Union[str, list, tuple],
-        custom_entities: bool = False,
-        enhanced_text_prompt: Optional[ConfigType] = None,
-        tokens_positive: Optional[list] = None,
-        verbose: bool = False
-    ) -> Tuple[dict, str, Tensor, list]:
+            self,
+            original_caption: Union[str, list, tuple],
+            custom_entities: bool = False,
+            enhanced_text_prompt: Optional[ConfigType] = None,
+            tokens_positive: Optional[list] = None,
+            verbose: bool = False) -> Tuple[dict, str, Tensor, list]:
         """Get the tokens positive and prompts for the caption.
 
         Args:
@@ -420,7 +418,8 @@ class GroundingDINO(DINO):
         head_inputs_dict['text_token_mask'] = text_token_mask
         return decoder_inputs_dict, head_inputs_dict
 
-    def loss(self, batch_inputs: Tensor,
+    def loss(self,
+             batch_inputs: Tensor,
              batch_data_samples: SampleList,
              verbose: bool = False) -> Union[dict, list]:
         text_prompts = [


### PR DESCRIPTION

## Motivation

Current NLTK download is 1) set in an unexpected directory, and 2) can't be set to quiet with a flag.

## Modification

This PR adds both those changes by 1) changing `download_dir='~/nltk_data'` to `download_dir=expanduser('~/nltk_data')`, and 2) adding in a verbosity flag to allow to set `quiet=True`.

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
