### PR TITLE
loosen version constraint with mmcv

### DIFF
--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -14,7 +14,7 @@ mmengine_maximum_version = '1.0.0'
 mmengine_version = digit_version(mmengine.__version__)
 
 assert (mmcv_version >= digit_version(mmcv_minimum_version)
-        and mmcv_version < digit_version(mmcv_maximum_version)), \
+        and mmcv_version <= digit_version(mmcv_maximum_version)), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv>={mmcv_minimum_version}, <{mmcv_maximum_version}.'
 


### PR DESCRIPTION
## Motivation
To resolve version compatibility issue with `mmcv`
( `mmcv` cannot be used with `mmdet` on `torch` above 2.2.x ) 
- #11763 

## Modification
Enabled `mmcv==2.2.0`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
