### PR TITLE
Add faster-coco-eval metric

### DIFF
--- a/mmdet/evaluation/metrics/coco_metric.py
+++ b/mmdet/evaluation/metrics/coco_metric.py
@@ -8,8 +8,6 @@ from typing import Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
-from faster_coco_eval import COCO as FasterCOCO
-from faster_coco_eval import COCOeval_faster
 from mmengine.evaluator import BaseMetric
 from mmengine.fileio import dump, get_local_path, load
 from mmengine.logging import MMLogger
@@ -19,6 +17,13 @@ from mmdet.datasets.api_wrappers import COCO, COCOeval, COCOevalMP
 from mmdet.registry import METRICS
 from mmdet.structures.mask import encode_mask_results
 from ..functional import eval_recalls
+
+try:
+    from faster_coco_eval import COCO as FasterCOCO
+    from faster_coco_eval import COCOeval_faster
+except ImportError:
+    FasterCOCO = None
+    COCOeval_faster = None
 
 
 @METRICS.register_module()
@@ -102,6 +107,8 @@ class CocoMetric(BaseMetric):
         self.use_mp_eval = use_mp_eval
         # whether to use Faster Coco Eval, default False
         self.use_faster_coco_eval = use_faster_coco_eval
+        if FasterCOCO is None:
+            raise RuntimeError('faster-coco-eval is not installed')
 
         # proposal_nums used to compute recall or precision.
         self.proposal_nums = list(proposal_nums)

--- a/mmdet/evaluation/metrics/coco_metric.py
+++ b/mmdet/evaluation/metrics/coco_metric.py
@@ -107,7 +107,8 @@ class CocoMetric(BaseMetric):
         self.use_mp_eval = use_mp_eval
         # whether to use Faster Coco Eval, default False
         self.use_faster_coco_eval = use_faster_coco_eval
-        if FasterCOCO is None:
+        if self.use_faster_coco_eva:
+            assert FasterCOCO is not None, 'faster-coco-eval is not installed'
             raise RuntimeError('faster-coco-eval is not installed')
 
         # proposal_nums used to compute recall or precision.

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,5 +1,6 @@
 cityscapesscripts
 emoji
 fairscale
+faster-coco-eval
 imagecorruptions
 scikit-learn

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,4 @@
+faster-coco-eval
 matplotlib
 numpy
 pycocotools

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,3 @@
-faster-coco-eval
 matplotlib
 numpy
 pycocotools

--- a/tests/test_evaluation/test_metrics/test_coco_metric.py
+++ b/tests/test_evaluation/test_metrics/test_coco_metric.py
@@ -1,5 +1,6 @@
 import os.path as osp
 import tempfile
+import unittest
 from unittest import TestCase
 
 import numpy as np
@@ -9,6 +10,11 @@ from mmengine.fileio import dump
 from parameterized import parameterized
 
 from mmdet.evaluation import CocoMetric
+
+try:
+    from faster_coco_eval import COCO as FasterCOCO
+except ImportError:
+    FasterCOCO = None
 
 
 class TestCocoMetric(TestCase):
@@ -114,6 +120,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_evaluate(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -209,6 +218,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_classwise_evaluate(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -241,6 +253,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_manually_set_iou_thrs(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -257,6 +272,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_fast_eval_recall(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -291,6 +309,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_evaluate_proposal(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -319,6 +340,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_empty_results(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)
@@ -345,6 +369,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_evaluate_without_json(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         dummy_pred = self._create_dummy_results()
 
         dummy_mask = np.zeros((10, 10), order='F', dtype=np.uint8)
@@ -412,6 +439,9 @@ class TestCocoMetric(TestCase):
 
     @parameterized.expand([False, True])
     def test_format_only(self, use_faster_coco_eval):
+        if use_faster_coco_eval and (FasterCOCO is None):
+            return unittest.skip('faster-coco-eval is not installed')
+
         # create dummy data
         fake_json_file = osp.join(self.tmp_dir.name, 'fake_data.json')
         self._create_dummy_coco_json(fake_json_file)


### PR DESCRIPTION
## Motivation

### Faster COCO Eval

<https://github.com/MiXaiLL76/faster_coco_eval>

This package wraps a facebook C++ implementation of COCO-eval operations found in the [pycocotools](https://github.com/cocodataset/cocoapi/tree/master/PythonAPI/pycocotools) package. This implementation greatly speeds up the evaluation time for coco's AP metrics, especially when dealing with a high number of instances in an image.

## Modification

I added a variable (use_faster_coco_eval) to the CocoMetric class that allows you to select an additional type of validation, namely COCOeval_faster

## Use cases (Optional)

For our use case with a test dataset of 5000 images from the coco val dataset.
Testing was carried out using the mmdetection framework and the eval_metric.py script. The indicators are presented below.

Visualization of testing **colab_example.ipynb** available in directory [examples/comparison](https://github.com/MiXaiLL76/faster_coco_eval/blob/main/examples/comparison/mmdet/colab_example.ipynb)
[colab_example.ipynb in google collab](https://colab.research.google.com/drive/1qj392oIU8fmeyIFHCtxCrLA8PQQAMoIs)
Tested with rtmdet model bbox + segm

### Summary for 5000 imgs

| Type | faster-coco-eval | pycocotools | Profit |
| :--- | ---------------: | ----------: | -----: |
| bbox |            5.812 |       22.72 |  3.909 |
| segm |            7.413 |      24.434 |  3.296 |

## Checklist

1. [x] Pre-commit or other linting tools are used to fix the potential lint issues.

```bash
mixaill76@HOME-SERVER:~/mmdetection$ pre-commit run --all-files
flake8...................................................................Passed
isort....................................................................Passed
yapf.....................................................................Passed
trim trailing whitespace.................................................Passed
check yaml...............................................................Passed
fix end of files.........................................................Passed
fix requirements.txt.....................................................Passed
fix double quoted strings................................................Passed
check for merge conflicts................................................Passed
fix python encoding pragma...............................................Passed
mixed line ending........................................................Passed
codespell................................................................Passed
mdformat.................................................................Passed
docformatter.............................................................Passed
check algorithm readme...................................................Passed
check copyright..........................................................Passed
```

2. [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.

```bash
mixaill76@HOME-SERVER:~/mmdetection$ python3 -m coverage run --branch --source mmdet -m pytest tests/test_evaluation/test_metrics/test_coco_metric.py 
========================= test session starts ==========================
platform linux -- Python 3.10.12, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/mixaill76/mmdetection
configfile: pytest.ini
plugins: xdoctest-1.1.4, anyio-3.7.1
collected 17 items                                                                                                                                                                                                                                                             

tests/test_evaluation/test_metrics/test_coco_metric.py ................. [100%]

tests/test_evaluation/test_metrics/test_coco_metric.py::TestCocoMetric::test_evaluate_0
  /usr/lib/python3.10/tempfile.py:999: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmp606joo9e'>
    _warnings.warn(warn_message, ResourceWarning)

tests/test_evaluation/test_metrics/test_coco_metric.py::TestCocoMetric::test_evaluate_1
  /usr/lib/python3.10/tempfile.py:999: ResourceWarning: Implicitly cleaning up <TemporaryDirectory '/tmp/tmpcnbtqpk6'>
    _warnings.warn(warn_message, ResourceWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================== 17 passed, 2 warnings in 3.47s ====================
```
3. [x] The documentation has been modified accordingly, like docstring or example tutorials.
