### PR TITLE
Update __init__.py

### DIFF
--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -14,7 +14,7 @@ mmengine_maximum_version = '1.0.0'
 mmengine_version = digit_version(mmengine.__version__)
 
 assert (mmcv_version >= digit_version(mmcv_minimum_version)
-        and mmcv_version < digit_version(mmcv_maximum_version)), \
+        and mmcv_version <= digit_version(mmcv_maximum_version)), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
     f'Please install mmcv>={mmcv_minimum_version}, <{mmcv_maximum_version}.'
 


### PR DESCRIPTION
Fixed a bug due to which mmdet was not installed for some Windows 10 users.

## Motivation
I was one of the users who experienced this bug. All options did not work, and the only working solution to the problem in the project issue on github is to change <2.2.0 to <=2.2.0 in the assert function. For version 2.1.0 an error occurred in all installation methods.

## Modification
<2.2.0 to <=2.2.0 in the assert function

## BC-breaking (Optional)
No