### PR TITLE
fix:Fix two of the CO-DETR config files

### DIFF
--- a/projects/CO-DETR/configs/codino/co_dino_5scale_r50_lsj_8xb2_3x_coco.py
+++ b/projects/CO-DETR/configs/codino/co_dino_5scale_r50_lsj_8xb2_3x_coco.py
@@ -1,4 +1,4 @@
 _base_ = ['co_dino_5scale_r50_lsj_8xb2_1x_coco.py']
 
-param_scheduler = [dict(milestones=[30])]
+param_scheduler = [dict(type='MultiStepLR', milestones=[30])]
 train_cfg = dict(max_epochs=36)

--- a/projects/CO-DETR/configs/codino/co_dino_5scale_swin_l_16xb1_3x_coco.py
+++ b/projects/CO-DETR/configs/codino/co_dino_5scale_swin_l_16xb1_3x_coco.py
@@ -2,5 +2,5 @@ _base_ = ['co_dino_5scale_swin_l_16xb1_1x_coco.py']
 # model settings
 model = dict(backbone=dict(drop_path_rate=0.6))
 
-param_scheduler = [dict(milestones=[30])]
+param_scheduler = [dict(type='MultiStepLR', milestones=[30])]
 train_cfg = dict(max_epochs=36)


### PR DESCRIPTION
## Motivation

The motivation of this PR is to fix one of the config files for CO-DETR project. Currently, running
```
python tools/train.py /home/baiye/mamba-test/mmdetection-main/projects/CO-DETR/configs/codino/co_dino_5scale_swin_l_16xb1_3x_coco.py
```
throws a following exception:
```
AssertionError: Each parameter scheduler should contain the key type, but got {'milestones': [30]}
```
I assume that when modifying a particular item within a list, users are required to add a type key to distinguish it from other possible items in that particular list.

## Modification

This PR resolves the error by adding the type key that is inherited from some of the base configs:
co_dino_5scale_swin_l_16xb1_3x_coco.py
co_dino_5scale_r50_lsj_8xb2_3x_coco.py

## BC-breaking (Optional)
N/A
## Use cases (Optional)
Anyone extending the modified config can now do so without running into this error.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
