### PR TITLE
 Fix albumentations versions >= 1.4.11

### DIFF
--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -35,7 +35,7 @@ try:
 
     # This assumes albumentations' versions are just ints separated by
     # periods, e.g. 1.4.11, allowing us to avoid a new dependency.
-    ALBU_VERSION = tuple(map(int, albumentations.__version__.split('.')))[:3]
+    ALBU_VERSION = tuple(map(int, albumentations.__version__.split('.')))
 except ImportError:
     albumentations = None
     Compose = None

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -34,7 +34,7 @@ try:
     from albumentations import Compose
     # This assumes albumentations' versions are just ints separated by
     # periods, e.g. 1.4.11, allowing us to avoid a new dependency.
-    ALBU_VERSION = list(map(int, albumentations.__version__.split(".")))[:3]
+    ALBU_VERSION = list(map(int, albumentations.__version__.split('.')))[:3]
 except ImportError:
     albumentations = None
     Compose = None

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1635,7 +1635,8 @@ class Albu(BaseTransform):
             self.aug = Compose([self.albu_builder(t) for t in self.transforms],
                                bbox_params=self.bbox_params, strict=False)
         else:
-            self.aug = Compose([self.albu_builder(t) for t in self.transforms])
+            self.aug = Compose([self.albu_builder(t) for t in self.transforms],
+                               bbox_params=self.bbox_params)
 
         if not keymap:
             self.keymap_to_albu = {

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -35,7 +35,7 @@ try:
 
     # This assumes albumentations' versions are just ints separated by
     # periods, e.g. 1.4.11, allowing us to avoid a new dependency.
-    ALBU_VERSION = list(map(int, albumentations.__version__.split('.')))[:3]
+    ALBU_VERSION = tuple(map(int, albumentations.__version__.split('.')))[:3]
 except ImportError:
     albumentations = None
     Compose = None

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -32,6 +32,7 @@ except ImportError:
 try:
     import albumentations
     from albumentations import Compose
+
     # This assumes albumentations' versions are just ints separated by
     # periods, e.g. 1.4.11, allowing us to avoid a new dependency.
     ALBU_VERSION = list(map(int, albumentations.__version__.split('.')))[:3]

--- a/mmdet/datasets/transforms/transforms.py
+++ b/mmdet/datasets/transforms/transforms.py
@@ -1634,7 +1634,8 @@ class Albu(BaseTransform):
             self.albu_builder(bbox_params) if bbox_params else None)
         if ALBU_VERSION is not None and ALBU_VERSION >= (1, 4, 11):
             self.aug = Compose([self.albu_builder(t) for t in self.transforms],
-                               bbox_params=self.bbox_params, strict=False)
+                               bbox_params=self.bbox_params,
+                               strict=False)
         else:
             self.aug = Compose([self.albu_builder(t) for t in self.transforms],
                                bbox_params=self.bbox_params)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I want to fix #11770 and allow more up-to-date versions of the albumentations library to be used in my transform pipeline.

## Modification

This PR introduces very basic version parsing for albumentations in order to know whether the strict parameter for albu.Compose is supported, and passes strict=False if it is. If it isn't supported, fall back to not passing the strict parameter, which only works on albu <= 1.4.6.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
