### PR TITLE
[Fix] rtmdet_ins_head scale_factor dimensions

### DIFF
--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -500,8 +500,8 @@ class RTMDetInsHead(RTMDetHead):
                 mask_logits = F.interpolate(
                     mask_logits,
                     size=[
-                        math.ceil(mask_logits.shape[-2] * scale_factor[0]),
-                        math.ceil(mask_logits.shape[-1] * scale_factor[1])
+                        math.ceil(mask_logits.shape[-2] * scale_factor[1]),
+                        math.ceil(mask_logits.shape[-1] * scale_factor[0])
                     ],
                     mode='bilinear',
                     align_corners=False)[..., :ori_h, :ori_w]


### PR DESCRIPTION
## Motivation

Fix mask resize error encountered when training an RTMDet instance segmentation model, which leads to inaccurate mask predictions. This manifests itself as issues such as reported in https://github.com/open-mmlab/mmdetection/issues/10179, https://github.com/open-mmlab/mmdetection/issues/10273, https://github.com/open-mmlab/mmdetection/issues/11733, https://github.com/open-mmlab/mmdetection/issues/10918, https://github.com/open-mmlab/mmdetection/issues/11314, to name a few examples.

## Modification

Switch the `scale_factor` dimensions (width and height) used when interpolating the mask. This has been done in `mmdeploy` as indicated in https://github.com/open-mmlab/mmdetection/issues/11230 and suggested in https://github.com/open-mmlab/mmdetection/issues/11840. 

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
