### PR TITLE
Convert `bboxes` to `numpy.ndarray` in InstanceData for Detection Task

### DIFF
--- a/tools/analysis_tools/analyze_results.py
+++ b/tools/analysis_tools/analyze_results.py
@@ -124,9 +124,8 @@ class ResultVisualizer:
 
             if task == 'det':
                 gt_instances = InstanceData()
-                gt_instances.bboxes = [
-                    d['bbox'] for d in data_info['gt_instances']
-                ]
+                gt_instances.bboxes = np.array(
+                    [d['bbox'] for d in data_info['gt_instances']])
                 gt_instances.labels = [
                     d['bbox_label'] for d in data_info['gt_instances']
                 ]


### PR DESCRIPTION
## Motivation

The motivation for this PR is to convert the `bboxes` attribute in the `gt_instances` object from a list format to `numpy.ndarray`. This change ensures the data is in a consistent and efficient format for further processing in deep learning models.

## Modification

The modification in this PR changes the code related to `gt_instances.bboxes` and `gt_instances.labels` assignment from list comprehensions to `numpy.ndarray`. Specifically, it uses `numpy.array` to convert the list of bounding boxes and labels into `numpy.ndarray`.

Modified code:
```python
import numpy as np
from mmdet.structures import InstanceData

if task == 'det':
    gt_instances = InstanceData()
    gt_instances.bboxes = np.array([d['bbox'] for d in data_info['gt_instances']])
```

## BC-breaking (Optional)

There are no backward-compatibility-breaking changes introduced by this modification. The modified code only affects the internal representation of `bboxes` and `labels`, but the external interface and expected behavior of the code remain unchanged.

## Use cases (Optional)

This PR does not introduce a new feature but refines the existing functionality. However, if there are any internal functions or modules relying on the old list format, ensure they are updated to handle `numpy.ndarray` appropriately.

## Checklist

1. [x] Pre-commit or other linting tools are used to fix the potential lint issues.
2. [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. [x] If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. [x] The documentation has been modified accordingly, like docstring or example tutorials.