### PR TITLE
[bug-fix] fixed docker build error for `Hash Sum mismatch`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,10 +22,9 @@ RUN rm /etc/apt/sources.list.d/cuda.list \
 #    pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
 
 # Install the required packages
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN apt-get update \
-    && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libsm6 libxrender-dev libxext6
 
 # Install MMEngine and MMCV
 RUN pip install openmim && \


### PR DESCRIPTION
- error because of hash sum mismatch during apt-get update
- splitted `apt-get clean && rm -rf /var/lib/apt/lists/*` from `apt-get update` command

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

`docker build -t mmdetection docker/` doesn't work in `get_started.md` with current Dockerfile.
Because of `Hash sum mismatch` error during `apt-get update`, so fixed Dockerfile.

## Modification

Please briefly describe what modification is made in this PR.

splitted apt cleaning task from `apt-get update` command so that `apt-get update` can do proper job.

below is the result of running `docker build -t mmdetection docker/` at project root
- before modification
![image](https://github.com/user-attachments/assets/408b1c6e-a02e-4fab-804f-fbd5834af3a3)

- after modification
![image](https://github.com/user-attachments/assets/64c151e1-0fb4-45fb-824b-92971326fd2b)


## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
