### PR TITLE
Make MMCV and MMEngine Upper Version Bound Inclusive

### DIFF
--- a/mmdet/__init__.py
+++ b/mmdet/__init__.py
@@ -14,14 +14,14 @@ mmengine_maximum_version = '1.0.0'
 mmengine_version = digit_version(mmengine.__version__)
 
 assert (mmcv_version >= digit_version(mmcv_minimum_version)
-        and mmcv_version < digit_version(mmcv_maximum_version)), \
+        and mmcv_version <= digit_version(mmcv_maximum_version)), \
     f'MMCV=={mmcv.__version__} is used but incompatible. ' \
-    f'Please install mmcv>={mmcv_minimum_version}, <{mmcv_maximum_version}.'
+    f'Please install mmcv>={mmcv_minimum_version}, <={mmcv_maximum_version}.'
 
 assert (mmengine_version >= digit_version(mmengine_minimum_version)
-        and mmengine_version < digit_version(mmengine_maximum_version)), \
+        and mmengine_version <= digit_version(mmengine_maximum_version)), \
     f'MMEngine=={mmengine.__version__} is used but incompatible. ' \
     f'Please install mmengine>={mmengine_minimum_version}, ' \
-    f'<{mmengine_maximum_version}.'
+    f'<={mmengine_maximum_version}.'
 
 __all__ = ['__version__', 'version_info', 'digit_version']


### PR DESCRIPTION
## Motivation

When trying to build mmdetection from source, the build was unsuccessful because "`AssertionError: MMCV==2.2.0 is used but incompatible. Please install mmcv>=2.0.0rc4, <2.2.0.`" This may be intended behavior, but I suspect maximum version is supposed to be inclusive.

## Modification

I replaced < with <= for maximum version checking of mmcv and mmengine.