### PR TITLE
change img.stack to img.concatenate of loadmultichannelimagefromfile

### DIFF
--- a/mmdet/datasets/transforms/loading.py
+++ b/mmdet/datasets/transforms/loading.py
@@ -133,7 +133,7 @@ class LoadMultiChannelImageFromFiles(BaseTransform):
                     img_bytes,
                     flag=self.color_type,
                     backend=self.imdecode_backend))
-        img = np.stack(img, axis=-1)
+        img = np.concatenate(img, axis=-1)
         if self.to_float32:
             img = img.astype(np.float32)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

when the read images's shape is [h, w, c], stack make the result shape is [h, w, c, n], and concatenate result is [h, w, n*c]. 
when the read images's channel is not same, stack raise an error, may concatenate is more suit for LoadMultiChannelImageFromFiles

## Modification

change np.stack(img, -1) to np.concatenate(img, -1)

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
