### PR TITLE
[Bug fix] attention_mask dtype in BiMultiHeadAttention

### DIFF
--- a/mmdet/models/utils/vlfuse_helper.py
+++ b/mmdet/models/utils/vlfuse_helper.py
@@ -197,8 +197,9 @@ class BiMultiHeadAttention(nn.Module):
             assert (attention_mask_l.dim() == 2)
             attention_mask = attention_mask_l.unsqueeze(1).unsqueeze(1)
             attention_mask = attention_mask.expand(bsz, 1, tgt_len, src_len)
-            attention_mask = attention_mask.masked_fill(
-                attention_mask == 0, -9e15)
+            if attention_mask.dtype == torch.bool:
+                attention_mask = torch.zeros_like(attention_mask, dtype=query_states.dtype).masked_fill_(
+                                                  attention_mask == True, -9e15)
 
             if attention_mask.size() != (bsz, 1, tgt_len, src_len):
                 raise ValueError('Attention mask should be of '

--- a/mmdet/models/utils/vlfuse_helper.py
+++ b/mmdet/models/utils/vlfuse_helper.py
@@ -198,8 +198,9 @@ class BiMultiHeadAttention(nn.Module):
             attention_mask = attention_mask_l.unsqueeze(1).unsqueeze(1)
             attention_mask = attention_mask.expand(bsz, 1, tgt_len, src_len)
             if attention_mask.dtype == torch.bool:
-                attention_mask = torch.zeros_like(attention_mask, dtype=query_states.dtype).masked_fill_(
-                                                  attention_mask == True, -9e15)
+                attention_mask = torch.zeros_like(
+                    attention_mask, dtype=query_states.dtype).masked_fill_(
+                        attention_mask, -9e15)
 
             if attention_mask.size() != (bsz, 1, tgt_len, src_len):
                 raise ValueError('Attention mask should be of '


### PR DESCRIPTION
This PR fix the data type of attention_mask in `BiMultiHeadAttention`, see https://github.com/open-mmlab/mmdetection/issues/12351
