### PR TITLE
fix spell error in deformable_detr

### DIFF
--- a/mmdet/models/detectors/deformable_detr.py
+++ b/mmdet/models/detectors/deformable_detr.py
@@ -130,7 +130,7 @@ class DeformableDETR(DetectionTransformer):
         Args:
             mlvl_feats (tuple[Tensor]): Multi-level features that may have
                 different resolutions, output from neck. Each feature has
-                shape (bs, dim, h_lvl, w_lvl), where 'lvl' means 'layer'.
+                shape (bs, dim, h_lvl, w_lvl), where 'lvl' means 'level'.
             batch_data_samples (list[:obj:`DetDataSample`], optional): The
                 batch data samples. It usually includes information such
                 as `gt_instance` or `gt_panoptic_seg` or `gt_sem_seg`.


### PR DESCRIPTION
## Motivation

It seems that `lvl` means 'level' but not 'layer'.

## Modification

change the note.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
