### PR TITLE
Refactor label handling in cross_entropy_loss.py

### DIFF
--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -39,6 +39,11 @@ def cross_entropy(pred,
     """
     # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
+    
+    # label[0] are categorical labels of images
+    if isinstance(label, tuple) and len(label) > 1:
+        label = label[0]
+        
     # element-wise losses
     loss = F.cross_entropy(
         pred,
@@ -116,6 +121,10 @@ def binary_cross_entropy(pred,
     """
     # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
+    
+    # label[0] are categorical labels of images
+    if isinstance(label, tuple) and len(label) > 1:
+        label = label[0]
 
     if pred.dim() != label.dim():
         label, weight, valid_mask = _expand_onehot_labels(
@@ -191,6 +200,11 @@ def mask_cross_entropy(pred,
     assert ignore_index is None, 'BCE loss does not support ignore_index'
     # TODO: handle these two reserved arguments
     assert reduction == 'mean' and avg_factor is None
+
+    # label[0] are categorical labels of images
+    if isinstance(label, tuple) and len(label) > 1:
+        label = label[0]
+
     num_rois = pred.size()[0]
     inds = torch.arange(0, num_rois, dtype=torch.long, device=pred.device)
     pred_slice = pred[inds, label].squeeze(1)

--- a/mmdet/models/losses/cross_entropy_loss.py
+++ b/mmdet/models/losses/cross_entropy_loss.py
@@ -39,11 +39,11 @@ def cross_entropy(pred,
     """
     # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
-    
+
     # label[0] are categorical labels of images
     if isinstance(label, tuple) and len(label) > 1:
         label = label[0]
-        
+
     # element-wise losses
     loss = F.cross_entropy(
         pred,
@@ -121,7 +121,7 @@ def binary_cross_entropy(pred,
     """
     # The default value of ignore_index is the same as F.cross_entropy
     ignore_index = -100 if ignore_index is None else ignore_index
-    
+
     # label[0] are categorical labels of images
     if isinstance(label, tuple) and len(label) > 1:
         label = label[0]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.
- When I use RTMDet and train with cross entropy loss, it will occur an error as shown below:
```
mmdet/models/losses/cross_entropy_loss.py", line 120, in binary_cross_entropy
    if pred.dim() != label.dim():
AttributeError: 'tuple' object has no attribute 'dim'
```
- my config about loss_cls:
```
loss_cls=dict(
    _delete_=True,
    type='CrossEntropyLoss',  
    use_sigmoid=True,
    loss_weight=1.),
```
## Modification
- By default, the loss_cls label in RTMDet consists of two components: a categorical label and a quality score (quality label). This PR modifies the label handling to specifically target the categorical part.
My modifiacation is shown below:
```
# label[0] are categorical labels of images
if isinstance(label, tuple) and len(label) > 1:
    label = label[0]
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repos?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.
- No !

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
- No new feature !

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
