### PR TITLE
Added documentation for configs/common (lsj, ms, ssj explanation) Issue#9581

### DIFF
--- a/configs/common/README.md
+++ b/configs/common/README.md
@@ -1,0 +1,24 @@
+# Common Configuration Files
+
+This directory contains common configuration settings used across different models and datasets in MMDetection.
+
+## Types of Configurations
+
+- **lsj (Large Scale Jittering)**  
+  Refers to a data augmentation technique where images are resized with large scale variations to improve robustness.
+
+- **ms (Multi-Scale Training)**  
+  Uses multiple image scales during training to improve model generalization.
+
+- **ssj (Standard Scale Jittering)**  
+  Applies moderate scale variations during training for balanced augmentation.
+
+## Purpose
+
+These configuration files define dataset preprocessing and augmentation strategies that are reused across different models.
+
+## Notes
+
+- These configs help standardize training pipelines.
+- They are shared across multiple model configurations.
+- Refer to specific model configs for usage examples.


### PR DESCRIPTION
## Motivation

The issue (#9581) highlighted that documentation for configuration files, especially in configs/common, is unclear and scattered. This can make it difficult for new users to understand concepts like lsj, ms, and ssj.

## Modification

- Added a README.md file in configs/common directory
- Provided clear explanations for lsj (Large Scale Jittering), ms (Multi-Scale Training), and ssj (Standard Scale Jittering)
- Improved overall clarity for configuration usage

## BC-breaking (Optional)

No breaking changes. This PR only improves documentation.

## Use cases (Optional)

This helps new users better understand configuration files and training strategies, improving usability and onboarding experience.

## Checklist

The documentation has been modified accordingly