### PR TITLE
Fix typo in rtmdet_ins_head.py

### DIFF
--- a/mmdet/models/dense_heads/rtmdet_ins_head.py
+++ b/mmdet/models/dense_heads/rtmdet_ins_head.py
@@ -917,7 +917,7 @@ class RTMDetInsSepBNHead(RTMDetInsHead):
                         norm_cfg=self.norm_cfg,
                         act_cfg=self.act_cfg))
             self.cls_convs.append(cls_convs)
-            self.reg_convs.append(cls_convs)
+            self.reg_convs.append(reg_convs)
             self.kernel_convs.append(kernel_convs)
 
             self.rtm_cls.append(


### PR DESCRIPTION
## Motivation

rtmdet_ins_head has a typo, that leads to to a bug - reg_convs layer is initialised incorrectly

## Modification

 self.reg_convs inside rtmdet_ins_head.py now initialised correctly

## BC-breaking (Optional)

RTMDetInsSepBNHead will not be initialized correctly with previously trained weights with a bug

## Use cases (Optional)

I needed that because I initially trained a bbox-only model and wanted to start a second training with only segmentation head not freezed, but it wasn't possible because of this issue.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
