### PR TITLE
Avoid assigning dataset_meta when visualizer is None

### DIFF
--- a/mmdet/apis/det_inferencer.py
+++ b/mmdet/apis/det_inferencer.py
@@ -195,7 +195,8 @@ class DetInferencer(BaseInferencer):
             Visualizer or None: Visualizer initialized with config.
         """
         visualizer = super()._init_visualizer(cfg)
-        visualizer.dataset_meta = self.model.dataset_meta
+        if visualizer is not None:
+            visualizer.dataset_meta = self.model.dataset_meta
         return visualizer
 
     def _inputs_to_list(self, inputs: InputsType) -> list:


### PR DESCRIPTION
## Motivation

Avoid assigning dataset_meta when visualizer is None

## Modification

Add an if None safeguard.

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
3. If the modification has potential influence on downstream projects, this PR should be tested with downstream projects, like MMDet or MMPreTrain.
4. The documentation has been modified accordingly, like docstring or example tutorials.
