### PR TITLE
  Fix: --resume auto silently drops load_from from config

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -99,7 +99,6 @@ def main():
     # resume is determined in this priority: resume from > auto_resume
     if args.resume == 'auto':
         cfg.resume = True
-        cfg.load_from = None
     elif args.resume is not None:
         cfg.resume = True
         cfg.load_from = args.resume


### PR DESCRIPTION
  Motivation
  
  When using --resume auto, the current code overrides cfg.load_from to None. This silently drops any load_from path set in the user's config file, causing the model to start from random initialization instead of
  loading pretrained weights. Users would not notice the issue because no error or warning is raised.

  The goal is to make --resume auto compatible with load_from set in config, so users who specify both get the expected behavior: pretrained weights are loaded, and auto-resume works for subsequent restarts.

  Modification

  Deleted one line cfg.load_from = None in the --resume auto branch of tools/train.py (line 102). This line is unnecessary because MMEngine's Runner.load_or_resume() already handles all three cases correctly:

  - resume=True + load_from=None → auto resume from latest checkpoint in work_dir
  - resume=True + load_from=path → resume from the specified path
  - resume=False + load_from=path → load checkpoint without restoring optimizer state

  Without the override, --resume auto simply leaves load_from untouched, which defaults to None when not specified — matching the original behavior for users who don't set load_from.

  BC-breaking

  No. The change only affects the edge case where a user simultaneously sets load_from in config and passes --resume auto on the command line. Previously this silently ignored load_from; now it correctly loads from
  it.

  For users who do not set load_from in config (the common case), behavior is identical.
